### PR TITLE
feat(auth): instance.tokenCommand + tokenEnv (1Password / pass / keychain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,15 @@ Optional. Create `~/.config/tea-dash/config.yml`
 view, and define your own sections:
 
 ```yaml
-# tea login profile to use (optional; empty = your default tea login)
 instance:
-  login: ""
+  login: ""          # tea login profile to use (empty = your default tea login)
+  # url:   ""        # override the instance URL (else taken from the tea login)
+  # Token source (first non-empty wins): token > tokenCommand > tokenEnv > TEA_DASH_TOKEN > tea login.
+  # tea-dash reads the token from tea's config file. If tea stored yours in the OS
+  # keychain (so the config's token is empty), give tea-dash one of these instead:
+  # token:        ""                                   # a literal token (not recommended in plaintext)
+  # tokenCommand: op read "op://Private/tea-dash/credential"   # e.g. 1Password, pass, gopass
+  # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
 
 defaults:
   view: prs        # startup view: "prs" or "issues"

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,10 +3,13 @@
 package auth
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -21,11 +24,13 @@ type Config struct {
 
 // Overrides come from tea-dash's own config (its `instance:` block).
 type Overrides struct {
-	Login      string // pick a named tea login
-	URL        string
-	Token      string
-	Insecure   bool
-	CACertPath string
+	Login        string // pick a named tea login
+	URL          string
+	Token        string // literal token (instance.token)
+	TokenCommand string // shell command whose stdout is the token (e.g. `op read op://...`)
+	TokenEnv     string // name of an env var to read the token from
+	Insecure     bool
+	CACertPath   string
 }
 
 // teaLogin mirrors one entry in tea's config.yml `logins:` list.
@@ -75,13 +80,16 @@ func ResolveFromFile(path string, ov Overrides) (Config, error) {
 	}
 
 	url := firstNonEmpty(ov.URL, os.Getenv("TEA_DASH_URL"), loginField(login, func(l teaLogin) string { return l.URL }))
-	token := firstNonEmpty(ov.Token, os.Getenv("TEA_DASH_TOKEN"), loginField(login, func(l teaLogin) string { return l.Token }))
-
 	if url == "" {
 		return Config{}, errors.New("no Gitea instance URL: run `tea login add`, or set instance.url / TEA_DASH_URL")
 	}
+
+	token, err := resolveToken(ov, login)
+	if err != nil {
+		return Config{}, err
+	}
 	if token == "" {
-		return Config{}, errors.New("no Gitea token: run `tea login add`, or set instance.token / TEA_DASH_TOKEN")
+		return Config{}, tokenError(login)
 	}
 
 	insecure := ov.Insecure
@@ -145,4 +153,68 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// resolveToken resolves the API token, in precedence order:
+//
+//	instance.token > instance.tokenCommand > instance.tokenEnv > TEA_DASH_TOKEN >
+//	the selected tea login's token
+//
+// A configured tokenCommand that fails (or yields nothing) is a hard error
+// rather than a silent fall-through, so a misconfigured secret manager surfaces.
+func resolveToken(ov Overrides, login *teaLogin) (string, error) {
+	if ov.Token != "" {
+		return ov.Token, nil
+	}
+	if ov.TokenCommand != "" {
+		out, err := runTokenCommand(ov.TokenCommand)
+		if err != nil {
+			return "", fmt.Errorf("instance.tokenCommand failed: %w", err)
+		}
+		if out == "" {
+			return "", fmt.Errorf("instance.tokenCommand %q produced no output", ov.TokenCommand)
+		}
+		return out, nil
+	}
+	if ov.TokenEnv != "" {
+		if v := os.Getenv(ov.TokenEnv); v != "" {
+			return v, nil
+		}
+	}
+	if v := os.Getenv("TEA_DASH_TOKEN"); v != "" {
+		return v, nil
+	}
+	return loginField(login, func(l teaLogin) string { return l.Token }), nil
+}
+
+// runTokenCommand runs command through the user's $SHELL and returns its
+// trimmed stdout. On failure it includes stderr so the cause is actionable.
+func runTokenCommand(command string) (string, error) {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+	cmd := exec.Command(shell, "-c", command)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%w: %s", err, msg)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// tokenError builds an actionable error for the no-token case, calling out the
+// common situation where a tea login exists but its token lives in the OS
+// keychain (which tea-dash cannot read) rather than tea's config file.
+func tokenError(login *teaLogin) error {
+	if login != nil {
+		return fmt.Errorf("found tea login %q but no usable token: its token is not in tea's config "+
+			"file (tea may keep it in your OS keychain, which tea-dash cannot read). Set instance.token, "+
+			"instance.tokenCommand (e.g. `op read \"op://vault/item/credential\"`), or TEA_DASH_TOKEN", login.Name)
+	}
+	return errors.New("no Gitea token: run `tea login add`, or set instance.token / instance.tokenCommand / TEA_DASH_TOKEN")
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -145,3 +145,58 @@ func TestResolveMalformedConfigErrors(t *testing.T) {
 		t.Fatal("expected a parse error for malformed tea config YAML")
 	}
 }
+
+func TestResolveTokenCommand(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	got, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", TokenCommand: "echo tokfromcmd"})
+	if err != nil {
+		t.Fatalf("ResolveFromFile: %v", err)
+	}
+	if got.Token != "tokfromcmd" {
+		t.Fatalf("token = %q, want %q (trimmed stdout of tokenCommand)", got.Token, "tokfromcmd")
+	}
+}
+
+func TestResolveTokenCommandFailureErrors(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	_, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", TokenCommand: "exit 3"})
+	if err == nil || !strings.Contains(err.Error(), "tokenCommand") {
+		t.Fatalf("expected a tokenCommand failure error, got %v", err)
+	}
+}
+
+func TestResolveTokenCommandEmptyErrors(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	_, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", TokenCommand: "true"})
+	if err == nil || !strings.Contains(err.Error(), "no output") {
+		t.Fatalf("expected an empty-output error, got %v", err)
+	}
+}
+
+func TestResolveTokenEnv(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	t.Setenv("MY_TEADASH_TOK", "envtok2")
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	got, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", TokenEnv: "MY_TEADASH_TOK"})
+	if err != nil {
+		t.Fatalf("ResolveFromFile: %v", err)
+	}
+	if got.Token != "envtok2" {
+		t.Fatalf("token = %q, want the value of the named env var", got.Token)
+	}
+}
+
+func TestResolveLiteralTokenBeatsCommand(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	got, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", Token: "literal", TokenCommand: "echo fromcmd"})
+	if err != nil {
+		t.Fatalf("ResolveFromFile: %v", err)
+	}
+	if got.Token != "literal" {
+		t.Fatalf("token = %q, want the literal token to win over tokenCommand", got.Token)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,11 +39,13 @@ type Defaults struct {
 
 // Instance selects and overrides the Gitea connection.
 type Instance struct {
-	Login    string `yaml:"login"`              // pick a named tea login
-	URL      string `yaml:"url"`                // override instance URL
-	Token    string `yaml:"token"`              // override token
-	Insecure bool   `yaml:"insecureSkipVerify"` // disable TLS verification
-	CACert   string `yaml:"caCert"`             // path to a private CA bundle
+	Login        string `yaml:"login"`              // pick a named tea login
+	URL          string `yaml:"url"`                // override instance URL
+	Token        string `yaml:"token"`              // literal token
+	TokenCommand string `yaml:"tokenCommand"`       // command whose stdout is the token (e.g. `op read ...`)
+	TokenEnv     string `yaml:"tokenEnv"`           // name of an env var holding the token
+	Insecure     bool   `yaml:"insecureSkipVerify"` // disable TLS verification
+	CACert       string `yaml:"caCert"`             // path to a private CA bundle
 }
 
 // SectionConfig describes one dashboard section (a tab).

--- a/main.go
+++ b/main.go
@@ -44,11 +44,13 @@ func run() error {
 	}
 
 	ov := auth.Overrides{
-		Login:      firstNonEmpty(cfg.Instance.Login, cfg.Login),
-		URL:        cfg.Instance.URL,
-		Token:      cfg.Instance.Token,
-		Insecure:   cfg.Instance.Insecure,
-		CACertPath: expandHome(cfg.Instance.CACert),
+		Login:        firstNonEmpty(cfg.Instance.Login, cfg.Login),
+		URL:          cfg.Instance.URL,
+		Token:        cfg.Instance.Token,
+		TokenCommand: cfg.Instance.TokenCommand,
+		TokenEnv:     cfg.Instance.TokenEnv,
+		Insecure:     cfg.Instance.Insecure,
+		CACertPath:   expandHome(cfg.Instance.CACert),
 	}
 	authCfg, err := auth.Resolve(ov)
 	if err != nil {


### PR DESCRIPTION
## Summary

tea-dash reuses your `tea` login for auth — but only the token stored in tea's **config file**. Modern `tea` often keeps the token in the **OS keychain** (empty in the config), so tea-dash couldn't see it. This adds a general escape hatch.

New `instance:` config options (in `~/.config/tea-dash/config.yml`):
- **`tokenCommand`** — a shell command whose stdout is the token, e.g. `op read "op://Private/tea-dash/credential"` (1Password), `pass gitea`, `gopass ...`, or even `security find-generic-password -s <svc> -w`.
- **`tokenEnv`** — the name of an env var to read the token from.

Token precedence: `token` > `tokenCommand` > `tokenEnv` > `TEA_DASH_TOKEN` > tea login token.

A configured `tokenCommand` that fails (or yields nothing) is a **hard error** (surfaces a broken secret-manager setup instead of silently falling through). The no-token error now explains the keychain case and points at `tokenCommand`.

## Why not implement OAuth2 instead

OAuth2 would need a browser authorization-code flow + local callback server + token refresh, just to end up with an expiring bearer token; Forgejo has no machine/client-credentials grant for user-API access. A scoped (read-only) PAT pulled from a secret manager via `tokenCommand` is simpler, stable, and headless — the right fit for a dashboard.

## Testing

- `internal/auth`: tokenCommand success (trimmed stdout), failure → error, empty output → error, tokenEnv, and precedence (literal token beats command). `make check` / `go test -race ./...` green.
- README documents the options.

https://claude.ai/code/session_01G2CWgm2mEqTJ6L6VwL85oB