### PR TITLE
build: Homebrew distribution (goreleaser homebrew_casks + tap token)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with `repo` scope on gbarany/homebrew-tap so goreleaser can push
+          # the formula there (the default GITHUB_TOKEN can't write another repo).
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,3 +49,26 @@ changelog:
 
 release:
   draft: false
+
+homebrew_casks:
+  - name: tea-dash
+    repository:
+      owner: gbarany
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/gbarany/tea-dash"
+    description: "Terminal dashboard for Gitea/Forgejo, in the spirit of gh-dash"
+    license: "MIT"
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    # The binaries aren't code-signed/notarized, so strip the macOS quarantine
+    # bit on install (else Gatekeeper blocks "tea-dash is damaged").
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/tea-dash"]
+          end


### PR DESCRIPTION
Sets up `brew install` distribution via a personal tap.

- **`homebrew_casks`** (not `brews`): goreleaser deprecated the formula path in v2.16 ("hackyish" formulas for pre-compiled binaries); casks are the right tool and, since Homebrew added Linux cask support (brew#19121), work on **macOS + Linux**. Publishes to `gbarany/homebrew-tap` (`Casks/tea-dash.rb`).
- **macOS quarantine hook**: the binaries aren't code-signed/notarized, so a post-install hook strips `com.apple.quarantine` (else Gatekeeper blocks "tea-dash is damaged").
- **`release.yml`** passes `HOMEBREW_TAP_GITHUB_TOKEN` so goreleaser can push the cask into the *separate* tap repo (the default `GITHUB_TOKEN` can only write the current repo).

Validated locally with `goreleaser check` (passes).

**Blocked on (owner action) before tagging v0.1.0:**
1. Make `gbarany/tea-dash` **public** (or releases stay private and `brew install` can't fetch them).
2. Create the empty `gbarany/homebrew-tap` repo.
3. Add a `HOMEBREW_TAP_GITHUB_TOKEN` secret (PAT with write access to the tap).

Then `git tag v0.1.0 && git push --tags` → `brew install gbarany/tap/tea-dash`.

https://claude.ai/code/session_01G2CWgm2mEqTJ6L6VwL85oB