### PR TITLE
refactor(section): generic section.Model[T RowData] (collapse duplicate pull/issue sections)

### DIFF
--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -25,7 +25,7 @@ func fetchedMsg(prs []data.PullRequest) context.TaskFinishedMsg {
 		SectionType: pullsection.SectionType,
 		TaskId:      "t1",
 		Msg: pullsection.SectionPullRequestsFetchedMsg{
-			Prs: prs, TotalCount: len(prs), TaskId: "t1",
+			Rows: prs, TotalCount: len(prs), TaskId: "t1",
 		},
 	}
 }
@@ -226,7 +226,7 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "t1",
 		Msg: pullsection.SectionPullRequestsFetchedMsg{
-			Prs: []data.PullRequest{{
+			Rows: []data.PullRequest{{
 				Number: 5, Title: "Late PR", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
 			}},
 			TotalCount: 1, TaskId: "t1",
@@ -277,7 +277,7 @@ func TestShowingCountAndSingular(t *testing.T) {
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "t1",
 		Msg: pullsection.SectionPullRequestsFetchedMsg{
-			Prs: []data.PullRequest{{
+			Rows: []data.PullRequest{{
 				Number: 1, Title: "One", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
 			}},
 			TotalCount: 5, TaskId: "t1",

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
 	"github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -293,6 +294,52 @@ func TestShowingCountAndSingular(t *testing.T) {
 	view := m.View().Content
 	if !strings.Contains(view, "1 pull request") || strings.Contains(view, "1 pull requests") {
 		t.Fatalf("status line should read singular \"1 pull request\":\n%s", view)
+	}
+}
+
+// TestModelRendersLoadedIssues mirrors TestShowingCountAndSingular but for the
+// ISSUES view, guarding the issue-specific status-line wording: a copy-pasted
+// "pull request" phrasing in issuesection.NewModel would fail here. It routes an
+// issues fetch through the real Update path and asserts the rendered View().
+func TestModelRendersLoadedIssues(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	if m.ctx.View != context.IssuesView {
+		t.Fatalf("View = %v, want IssuesView", m.ctx.View)
+	}
+
+	// One row shown, server total 5 -> "showing 1 of 5 issues" (plural wording).
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 0, SectionType: issuesection.SectionType, TaskId: "t1",
+		Msg: issuesection.SectionIssuesFetchedMsg{
+			Rows: []data.Issue{{
+				Number: 7, Title: "Fix flaky test", RepoNameWithOwner: "gitea/tea",
+				Author: "me", State: "open", UpdatedAt: time.Now().Add(-time.Hour),
+			}},
+			TotalCount: 5, TaskId: "t1",
+		},
+	})
+	view := m.View().Content
+	for _, want := range []string{"#7", "Fix flaky test", "gitea/tea", "@me", "showing 1 of 5 issues"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("issues view is missing %q\n---\n%s", want, view)
+		}
+	}
+
+	// total == shown == 1 -> singular "1 issue" (never "1 issues").
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 0, SectionType: issuesection.SectionType, TaskId: "t2",
+		Msg: issuesection.SectionIssuesFetchedMsg{
+			Rows: []data.Issue{{
+				Number: 8, Title: "Only one", RepoNameWithOwner: "gitea/tea",
+				Author: "me", State: "open", UpdatedAt: time.Now().Add(-time.Hour),
+			}},
+			TotalCount: 1, TaskId: "t2",
+		},
+	})
+	view = m.View().Content
+	if !strings.Contains(view, "1 issue") || strings.Contains(view, "1 issues") {
+		t.Fatalf("status line should read singular \"1 issue\":\n%s", view)
 	}
 }
 

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -45,7 +45,7 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 	})
 }
 
-// issueBuildRow maps an issue into the table's 6-cell row (unchanged formatting).
+// issueBuildRow maps an issue into the table's 6-cell row.
 func issueBuildRow(issue data.Issue) table.Row {
 	author := ""
 	if issue.Author != "" {

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -1,17 +1,16 @@
-// Package issuesection is the issues dashboard section.
+// Package issuesection is the issues dashboard section: thin wiring over the
+// generic section.Model parameterized for data.Issue.
 package issuesection
 
 import (
 	stdctx "context"
 	"fmt"
-	"time"
 
-	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/table"
-	tea "charm.land/bubbletea/v2"
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/section"
 	appctx "github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -19,199 +18,45 @@ import (
 // SectionType is the routing type tag for issue sections.
 const SectionType = "issue"
 
-const fetchTimeout = 30 * time.Second
-
-// Model is the issues section.
-type Model struct {
-	section.BaseModel
-	issues []data.Issue
-}
-
-// compile-time interface assertion
-var _ section.Section = (*Model)(nil)
+// Model is the issues section (the generic section specialized for issues).
+type Model = section.Model[data.Issue]
 
 // SectionIssuesFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
-type SectionIssuesFetchedMsg struct {
-	Issues     []data.Issue
-	TotalCount int
-	TaskId     string
-	Err        error
-}
+type SectionIssuesFetchedMsg = section.RowsFetchedMsg[data.Issue]
 
 // NewModel builds an issues section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
-	m := &Model{}
-	m.BaseModel = section.NewBaseModel(section.NewOptions{
+	return section.New(section.Options[data.Issue]{
 		Id:           id,
-		Type:         SectionType,
 		Ctx:          ctx,
 		Config:       cfg,
-		Columns:      columns(ctx.MainContentWidth),
+		Type:         SectionType,
+		FilterKind:   "issues",
 		LoadingText:  "Loading issues…",
 		EmptyText:    "No open issues authored by you.",
 		EmptyHint:    "This board shows issues you created across all repos on your Gitea instance.",
 		SingularForm: "issue",
 		PluralForm:   "issues",
+		Limit:        func(c *config.Config) int { return c.Defaults.IssuesLimit },
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.Issue, int, error) {
+			return c.SearchIssues(ctx, f, limit)
+		},
+		BuildRow: issueBuildRow,
 	})
-	return m
 }
 
-// FetchRows fetches the current user's open issues across all repos.
-func (m *Model) FetchRows() tea.Cmd {
-	taskId := fmt.Sprintf("fetch-issues-%d-%d", m.GetId(), time.Now().UnixNano())
-	m.SetLastFetchID(taskId)
-	m.SetIsLoading(true)
-	client := m.Ctx.Client
-	id, sType := m.GetId(), m.GetType()
-	start := m.Ctx.StartTask(appctx.Task{Id: taskId, StartText: "Loading issues…", State: appctx.TaskStart})
-	f := m.Config.Filter.WithDefaults("issues")
-	limit := m.Config.Limit
-	if limit == 0 && m.Ctx.Config != nil {
-		limit = m.Ctx.Config.Defaults.IssuesLimit
+// issueBuildRow maps an issue into the table's 6-cell row (unchanged formatting).
+func issueBuildRow(issue data.Issue) table.Row {
+	author := ""
+	if issue.Author != "" {
+		author = "@" + issue.Author
 	}
-	fetch := func() tea.Msg {
-		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), fetchTimeout)
-		defer cancel()
-		issues, total, err := client.SearchIssues(ctx, f, limit)
-		return appctx.TaskFinishedMsg{
-			SectionId: id, SectionType: sType, TaskId: taskId,
-			Msg: SectionIssuesFetchedMsg{Issues: issues, TotalCount: total, TaskId: taskId, Err: err},
-		}
-	}
-	return tea.Batch(start, m.Spinner.Tick, fetch)
-}
-
-// Update applies fetched rows (behind a stale-fetch guard), advances the
-// spinner while loading, and otherwise delegates to the table (row nav).
-func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
-	// Only divert key presses to the search bar while it is focused. Other
-	// messages (fetch payloads, spinner ticks, etc.) must fall through to the
-	// normal switch so they are applied even during an active search.
-	if key, ok := msg.(tea.KeyPressMsg); ok && m.IsSearchFocused() {
-		switch key.String() {
-		case "enter":
-			m.Config.Filter.Q = m.SearchBar.Value()
-			m.SetIsSearching(false)
-			return m, m.FetchRows()
-		case "esc", "ctrl+c":
-			m.SearchBar.SetValue(m.Config.Filter.Q) // revert to the applied keyword
-			m.SetIsSearching(false)
-			return m, nil
-		}
-		var cmd tea.Cmd
-		m.SearchBar, cmd = m.SearchBar.Update(msg)
-		return m, cmd
-	}
-	switch msg := msg.(type) {
-	case SectionIssuesFetchedMsg:
-		if m.LastFetchID() != "" && m.LastFetchID() != msg.TaskId {
-			return m, nil // stale/superseded fetch
-		}
-		m.SetIsLoading(false)
-		if msg.Err != nil {
-			m.SetError(msg.Err)
-			return m, nil
-		}
-		m.issues = msg.Issues
-		m.SetTotalCount(msg.TotalCount)
-		m.SetError(nil)
-		// SetRows clamps but does not reset the cursor, so a refresh keeps the
-		// selected row (intentional; better UX than the pre-refactor reset-to-top).
-		m.SetRows(m.BuildRows())
-		return m, nil
-	case spinner.TickMsg:
-		if m.GetIsLoading() {
-			var cmd tea.Cmd
-			m.Spinner, cmd = m.Spinner.Update(msg)
-			return m, cmd
-		}
-		return m, nil
-	}
-	// Only forward navigation/other messages to the table when ready — matches the
-	// pre-refactor gating, which ignored keys while loading or in the error state.
-	if m.GetIsLoading() || m.GetError() != nil {
-		return m, nil
-	}
-	var cmd tea.Cmd
-	m.Table, cmd = m.Table.Update(msg)
-	return m, cmd
-}
-
-// UpdateProgramContext resizes the table and refreshes columns for the new width.
-func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
-	m.BaseModel.UpdateProgramContext(ctx)
-	m.Columns = columns(ctx.MainContentWidth)
-	m.Table.SetColumns(m.Columns)
-}
-
-// GetCurrRow returns the selected issue, or nil when there are no rows.
-func (m *Model) GetCurrRow() data.RowData {
-	if len(m.issues) == 0 {
-		return nil
-	}
-	i := m.CurrRow()
-	if i < 0 || i >= len(m.issues) {
-		return nil
-	}
-	return m.issues[i]
-}
-
-// BuildRows maps the issues into the table's 6-cell rows.
-func (m *Model) BuildRows() []table.Row {
-	rows := make([]table.Row, len(m.issues))
-	for i, issue := range m.issues {
-		author := ""
-		if issue.Author != "" {
-			author = "@" + issue.Author
-		}
-		rows[i] = table.Row{
-			fmt.Sprintf("#%d", issue.Number),
-			issue.Title,
-			issue.RepoNameWithOwner,
-			author,
-			issue.State,
-			humanizeTime(issue.UpdatedAt),
-		}
-	}
-	return rows
-}
-
-// columns reproduces the pull-requests column widths and title-grow formula.
-func columns(mainWidth int) []table.Column {
-	const (
-		numW     = 6
-		repoW    = 22
-		authorW  = 16
-		stateW   = 8
-		updatedW = 10
-	)
-	titleW := mainWidth - (numW + repoW + authorW + stateW + updatedW) - 6
-	if titleW < 20 {
-		titleW = 20
-	}
-	return []table.Column{
-		{Title: "#", Width: numW},
-		{Title: "Title", Width: titleW},
-		{Title: "Repo", Width: repoW},
-		{Title: "Author", Width: authorW},
-		{Title: "State", Width: stateW},
-		{Title: "Updated", Width: updatedW},
-	}
-}
-
-func humanizeTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return fmt.Sprintf("%dm ago", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh ago", int(d.Hours()))
-	default:
-		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	return table.Row{
+		fmt.Sprintf("#%d", issue.Number),
+		issue.Title,
+		issue.RepoNameWithOwner,
+		author,
+		issue.State,
+		section.HumanizeTime(issue.UpdatedAt),
 	}
 }

--- a/internal/ui/components/issuesection/issuesection_test.go
+++ b/internal/ui/components/issuesection/issuesection_test.go
@@ -83,7 +83,7 @@ func TestFetchedMsgBuildsRows(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t1")
 	next, _ := m.Update(SectionIssuesFetchedMsg{
-		Issues: []data.Issue{{
+		Rows: []data.Issue{{
 			Number: 77, Title: "Bug X", RepoNameWithOwner: "acme/widgets",
 			Author: "octo", State: "open", UpdatedAt: time.Now().Add(-2 * time.Hour),
 		}},
@@ -110,7 +110,7 @@ func TestStaleFetchIgnored(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t2") // an in-flight fetch t2 is expected
 	next, _ := m.Update(SectionIssuesFetchedMsg{
-		Issues: []data.Issue{{Number: 1}}, TotalCount: 1, TaskId: "t1", // stale
+		Rows: []data.Issue{{Number: 1}}, TotalCount: 1, TaskId: "t1", // stale
 	})
 	m = next.(*Model)
 	if m.NumRows() != 0 {

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -53,7 +53,7 @@ func prState(pr data.PullRequest) string {
 	return pr.State
 }
 
-// prBuildRow maps a PR into the table's 6-cell row (unchanged formatting).
+// prBuildRow maps a PR into the table's 6-cell row.
 func prBuildRow(pr data.PullRequest) table.Row {
 	author := ""
 	if pr.Author != "" {

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -1,17 +1,16 @@
-// Package pullsection is the pull-requests dashboard section.
+// Package pullsection is the pull-requests dashboard section: thin wiring over
+// the generic section.Model parameterized for data.PullRequest.
 package pullsection
 
 import (
 	stdctx "context"
 	"fmt"
-	"time"
 
-	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/table"
-	tea "charm.land/bubbletea/v2"
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/section"
 	appctx "github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -19,186 +18,34 @@ import (
 // SectionType is the routing type tag for pull-request sections.
 const SectionType = "pr"
 
-const fetchTimeout = 30 * time.Second
-
-// Model is the pull-requests section.
-type Model struct {
-	section.BaseModel
-	prs []data.PullRequest
-}
-
-// compile-time interface assertion
-var _ section.Section = (*Model)(nil)
+// Model is the pull-requests section (the generic section specialized for PRs).
+type Model = section.Model[data.PullRequest]
 
 // SectionPullRequestsFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
-type SectionPullRequestsFetchedMsg struct {
-	Prs        []data.PullRequest
-	TotalCount int
-	TaskId     string
-	Err        error
-}
+type SectionPullRequestsFetchedMsg = section.RowsFetchedMsg[data.PullRequest]
 
 // NewModel builds a pull-requests section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
-	m := &Model{}
-	m.BaseModel = section.NewBaseModel(section.NewOptions{
+	return section.New(section.Options[data.PullRequest]{
 		Id:           id,
-		Type:         SectionType,
 		Ctx:          ctx,
 		Config:       cfg,
-		Columns:      columns(ctx.MainContentWidth),
+		Type:         SectionType,
+		FilterKind:   "pulls",
 		LoadingText:  "Loading pull requests…",
 		EmptyText:    "No open pull requests authored by you.",
 		EmptyHint:    "This board shows PRs you created across all repos on your Gitea instance.",
 		SingularForm: "pull request",
 		PluralForm:   "pull requests",
+		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.PullRequest, int, error) {
+			return c.SearchPulls(ctx, f, limit)
+		},
+		BuildRow: prBuildRow,
 	})
-	return m
 }
 
-// FetchRows fetches the current user's open PRs across all repos.
-func (m *Model) FetchRows() tea.Cmd {
-	taskId := fmt.Sprintf("fetch-pulls-%d-%d", m.GetId(), time.Now().UnixNano())
-	m.SetLastFetchID(taskId)
-	m.SetIsLoading(true)
-	client := m.Ctx.Client
-	id, sType := m.GetId(), m.GetType()
-	start := m.Ctx.StartTask(appctx.Task{Id: taskId, StartText: "Loading pull requests…", State: appctx.TaskStart})
-	f := m.Config.Filter.WithDefaults("pulls")
-	limit := m.Config.Limit
-	if limit == 0 && m.Ctx.Config != nil {
-		limit = m.Ctx.Config.Defaults.PRsLimit
-	}
-	fetch := func() tea.Msg {
-		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), fetchTimeout)
-		defer cancel()
-		prs, total, err := client.SearchPulls(ctx, f, limit)
-		return appctx.TaskFinishedMsg{
-			SectionId: id, SectionType: sType, TaskId: taskId,
-			Msg: SectionPullRequestsFetchedMsg{Prs: prs, TotalCount: total, TaskId: taskId, Err: err},
-		}
-	}
-	return tea.Batch(start, m.Spinner.Tick, fetch)
-}
-
-// Update applies fetched rows (behind a stale-fetch guard), advances the
-// spinner while loading, and otherwise delegates to the table (row nav).
-func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
-	// Only divert key presses to the search bar while it is focused. Other
-	// messages (fetch payloads, spinner ticks, etc.) must fall through to the
-	// normal switch so they are applied even during an active search.
-	if key, ok := msg.(tea.KeyPressMsg); ok && m.IsSearchFocused() {
-		switch key.String() {
-		case "enter":
-			m.Config.Filter.Q = m.SearchBar.Value()
-			m.SetIsSearching(false)
-			return m, m.FetchRows()
-		case "esc", "ctrl+c":
-			m.SearchBar.SetValue(m.Config.Filter.Q) // revert to the applied keyword
-			m.SetIsSearching(false)
-			return m, nil
-		}
-		var cmd tea.Cmd
-		m.SearchBar, cmd = m.SearchBar.Update(msg)
-		return m, cmd
-	}
-	switch msg := msg.(type) {
-	case SectionPullRequestsFetchedMsg:
-		if m.LastFetchID() != "" && m.LastFetchID() != msg.TaskId {
-			return m, nil // stale/superseded fetch
-		}
-		m.SetIsLoading(false)
-		if msg.Err != nil {
-			m.SetError(msg.Err)
-			return m, nil
-		}
-		m.prs = msg.Prs
-		m.SetTotalCount(msg.TotalCount)
-		m.SetError(nil)
-		// SetRows clamps but does not reset the cursor, so a refresh keeps the
-		// selected row (intentional; better UX than the pre-refactor reset-to-top).
-		m.SetRows(m.BuildRows())
-		return m, nil
-	case spinner.TickMsg:
-		if m.GetIsLoading() {
-			var cmd tea.Cmd
-			m.Spinner, cmd = m.Spinner.Update(msg)
-			return m, cmd
-		}
-		return m, nil
-	}
-	// Only forward navigation/other messages to the table when ready — matches the
-	// pre-refactor gating, which ignored keys while loading or in the error state.
-	if m.GetIsLoading() || m.GetError() != nil {
-		return m, nil
-	}
-	var cmd tea.Cmd
-	m.Table, cmd = m.Table.Update(msg)
-	return m, cmd
-}
-
-// UpdateProgramContext resizes the table and refreshes columns for the new width.
-func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
-	m.BaseModel.UpdateProgramContext(ctx)
-	m.Columns = columns(ctx.MainContentWidth)
-	m.Table.SetColumns(m.Columns)
-}
-
-// GetCurrRow returns the selected PR, or nil when there are no rows.
-func (m *Model) GetCurrRow() data.RowData {
-	if len(m.prs) == 0 {
-		return nil
-	}
-	i := m.CurrRow()
-	if i < 0 || i >= len(m.prs) {
-		return nil
-	}
-	return m.prs[i]
-}
-
-// BuildRows maps the PRs into the table's 6-cell rows (unchanged formatting).
-func (m *Model) BuildRows() []table.Row {
-	rows := make([]table.Row, len(m.prs))
-	for i, pr := range m.prs {
-		author := ""
-		if pr.Author != "" {
-			author = "@" + pr.Author
-		}
-		rows[i] = table.Row{
-			fmt.Sprintf("#%d", pr.Number),
-			pr.Title,
-			pr.RepoNameWithOwner,
-			author,
-			prState(pr),
-			humanizeTime(pr.UpdatedAt),
-		}
-	}
-	return rows
-}
-
-// columns reproduces the pre-refactor column widths and title-grow formula.
-func columns(mainWidth int) []table.Column {
-	const (
-		numW     = 6
-		repoW    = 22
-		authorW  = 16
-		stateW   = 8
-		updatedW = 10
-	)
-	titleW := mainWidth - (numW + repoW + authorW + stateW + updatedW) - 6
-	if titleW < 20 {
-		titleW = 20
-	}
-	return []table.Column{
-		{Title: "#", Width: numW},
-		{Title: "Title", Width: titleW},
-		{Title: "Repo", Width: repoW},
-		{Title: "Author", Width: authorW},
-		{Title: "State", Width: stateW},
-		{Title: "Updated", Width: updatedW},
-	}
-}
-
+// prState renders a draft PR's state as "draft" and otherwise the raw state.
 func prState(pr data.PullRequest) string {
 	if pr.Draft {
 		return "draft"
@@ -206,19 +53,18 @@ func prState(pr data.PullRequest) string {
 	return pr.State
 }
 
-func humanizeTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
+// prBuildRow maps a PR into the table's 6-cell row (unchanged formatting).
+func prBuildRow(pr data.PullRequest) table.Row {
+	author := ""
+	if pr.Author != "" {
+		author = "@" + pr.Author
 	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return fmt.Sprintf("%dm ago", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh ago", int(d.Hours()))
-	default:
-		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	return table.Row{
+		fmt.Sprintf("#%d", pr.Number),
+		pr.Title,
+		pr.RepoNameWithOwner,
+		author,
+		prState(pr),
+		section.HumanizeTime(pr.UpdatedAt),
 	}
 }

--- a/internal/ui/components/pullsection/pullsection_test.go
+++ b/internal/ui/components/pullsection/pullsection_test.go
@@ -115,7 +115,7 @@ func TestFetchedMsgBuildsRows(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t1")
 	next, _ := m.Update(SectionPullRequestsFetchedMsg{
-		Prs: []data.PullRequest{{
+		Rows: []data.PullRequest{{
 			Number: 128, Title: "Add wiki CLI", RepoNameWithOwner: "gitea/tea",
 			Author: "lunny", State: "open", UpdatedAt: time.Now().Add(-2 * time.Hour),
 		}},
@@ -149,7 +149,7 @@ func TestDraftPRRowShowsDraft(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t1")
 	next, _ := m.Update(SectionPullRequestsFetchedMsg{
-		Prs: []data.PullRequest{{
+		Rows: []data.PullRequest{{
 			Number: 9, Title: "WIP", RepoNameWithOwner: "gitea/tea",
 			Author: "me", State: "open", Draft: true,
 		}},
@@ -166,7 +166,7 @@ func TestStaleFetchIgnored(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t2") // an in-flight fetch t2 is expected
 	next, _ := m.Update(SectionPullRequestsFetchedMsg{
-		Prs: []data.PullRequest{{Number: 1}}, TotalCount: 1, TaskId: "t1", // stale
+		Rows: []data.PullRequest{{Number: 1}}, TotalCount: 1, TaskId: "t1", // stale
 	})
 	m = next.(*Model)
 	if m.NumRows() != 0 {

--- a/internal/ui/components/section/model.go
+++ b/internal/ui/components/section/model.go
@@ -1,0 +1,194 @@
+package section
+
+import (
+	stdctx "context"
+	"fmt"
+	"time"
+
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+const fetchTimeout = 30 * time.Second
+
+// RowsFetchedMsg is the generic fetch payload carried in TaskFinishedMsg.Msg.
+type RowsFetchedMsg[T data.RowData] struct {
+	Rows       []T
+	TotalCount int
+	TaskId     string
+	Err        error
+}
+
+// Options parameterizes New, carrying the three per-type seams (fetch, row
+// build, limit) plus the section metadata forwarded to NewBaseModel.
+type Options[T data.RowData] struct {
+	Id         int
+	Ctx        *appctx.ProgramContext
+	Config     config.SectionConfig
+	Type       string
+	FilterKind string
+
+	LoadingText  string
+	EmptyText    string
+	EmptyHint    string
+	SingularForm string
+	PluralForm   string
+
+	Fetch    func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int) ([]T, int, error)
+	BuildRow func(T) table.Row
+	Limit    func(*config.Config) int
+}
+
+// Model is the generic dashboard section shared by the pull-request and issue
+// views. It embeds BaseModel and holds the per-type seams.
+type Model[T data.RowData] struct {
+	BaseModel
+	rows       []T
+	fetch      func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int) ([]T, int, error)
+	buildRow   func(T) table.Row
+	limitFn    func(*config.Config) int
+	filterKind string
+}
+
+// compile-time interface assertions
+var (
+	_ Section = (*Model[data.PullRequest])(nil)
+	_ Section = (*Model[data.Issue])(nil)
+)
+
+// New builds a generic section from Options.
+func New[T data.RowData](o Options[T]) *Model[T] {
+	m := &Model[T]{}
+	m.BaseModel = NewBaseModel(NewOptions{
+		Id:           o.Id,
+		Type:         o.Type,
+		Ctx:          o.Ctx,
+		Config:       o.Config,
+		Columns:      DefaultColumns(o.Ctx.MainContentWidth),
+		LoadingText:  o.LoadingText,
+		EmptyText:    o.EmptyText,
+		EmptyHint:    o.EmptyHint,
+		SingularForm: o.SingularForm,
+		PluralForm:   o.PluralForm,
+	})
+	m.fetch = o.Fetch
+	m.buildRow = o.BuildRow
+	m.limitFn = o.Limit
+	m.filterKind = o.FilterKind
+	return m
+}
+
+// FetchRows fetches the current user's rows across all repos.
+func (m *Model[T]) FetchRows() tea.Cmd {
+	taskId := fmt.Sprintf("fetch-%s-%d-%d", m.GetType(), m.GetId(), time.Now().UnixNano())
+	m.SetLastFetchID(taskId)
+	m.SetIsLoading(true)
+	client := m.Ctx.Client
+	id, sType := m.GetId(), m.GetType()
+	start := m.Ctx.StartTask(appctx.Task{Id: taskId, StartText: m.loadingText, State: appctx.TaskStart})
+	f := m.Config.Filter.WithDefaults(m.filterKind)
+	limit := m.Config.Limit
+	if limit == 0 && m.Ctx.Config != nil {
+		limit = m.limitFn(m.Ctx.Config)
+	}
+	fetch := func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), fetchTimeout)
+		defer cancel()
+		rows, total, err := m.fetch(ctx, client, f, limit)
+		return appctx.TaskFinishedMsg{
+			SectionId: id, SectionType: sType, TaskId: taskId,
+			Msg: RowsFetchedMsg[T]{Rows: rows, TotalCount: total, TaskId: taskId, Err: err},
+		}
+	}
+	return tea.Batch(start, m.Spinner.Tick, fetch)
+}
+
+// Update applies fetched rows (behind a stale-fetch guard), advances the
+// spinner while loading, and otherwise delegates to the table (row nav).
+func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
+	// Only divert key presses to the search bar while it is focused. Other
+	// messages (fetch payloads, spinner ticks, etc.) must fall through to the
+	// normal switch so they are applied even during an active search.
+	if key, ok := msg.(tea.KeyPressMsg); ok && m.IsSearchFocused() {
+		switch key.String() {
+		case "enter":
+			m.Config.Filter.Q = m.SearchBar.Value()
+			m.SetIsSearching(false)
+			return m, m.FetchRows()
+		case "esc", "ctrl+c":
+			m.SearchBar.SetValue(m.Config.Filter.Q) // revert to the applied keyword
+			m.SetIsSearching(false)
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.SearchBar, cmd = m.SearchBar.Update(msg)
+		return m, cmd
+	}
+	switch msg := msg.(type) {
+	case RowsFetchedMsg[T]:
+		if m.LastFetchID() != "" && m.LastFetchID() != msg.TaskId {
+			return m, nil // stale/superseded fetch
+		}
+		m.SetIsLoading(false)
+		if msg.Err != nil {
+			m.SetError(msg.Err)
+			return m, nil
+		}
+		m.rows = msg.Rows
+		m.SetTotalCount(msg.TotalCount)
+		m.SetError(nil)
+		// SetRows clamps but does not reset the cursor, so a refresh keeps the
+		// selected row (intentional; better UX than the pre-refactor reset-to-top).
+		m.SetRows(m.BuildRows())
+		return m, nil
+	case spinner.TickMsg:
+		if m.GetIsLoading() {
+			var cmd tea.Cmd
+			m.Spinner, cmd = m.Spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+	// Only forward navigation/other messages to the table when ready — matches the
+	// pre-refactor gating, which ignored keys while loading or in the error state.
+	if m.GetIsLoading() || m.GetError() != nil {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.Table, cmd = m.Table.Update(msg)
+	return m, cmd
+}
+
+// UpdateProgramContext resizes the table and refreshes columns for the new width.
+func (m *Model[T]) UpdateProgramContext(ctx *appctx.ProgramContext) {
+	m.BaseModel.UpdateProgramContext(ctx)
+	m.Columns = DefaultColumns(ctx.MainContentWidth)
+	m.Table.SetColumns(m.Columns)
+}
+
+// GetCurrRow returns the selected row, or nil when there are no rows.
+func (m *Model[T]) GetCurrRow() data.RowData {
+	if len(m.rows) == 0 {
+		return nil
+	}
+	i := m.CurrRow()
+	if i < 0 || i >= len(m.rows) {
+		return nil
+	}
+	return m.rows[i]
+}
+
+// BuildRows maps the fetched rows into the table's rows via the per-type BuildRow.
+func (m *Model[T]) BuildRows() []table.Row {
+	rows := make([]table.Row, len(m.rows))
+	for i, r := range m.rows {
+		rows[i] = m.buildRow(r)
+	}
+	return rows
+}

--- a/internal/ui/components/section/model.go
+++ b/internal/ui/components/section/model.go
@@ -25,12 +25,15 @@ type RowsFetchedMsg[T data.RowData] struct {
 	Err        error
 }
 
-// Options parameterizes New, carrying the three per-type seams (fetch, row
-// build, limit) plus the section metadata forwarded to NewBaseModel.
+// Options parameterizes New, carrying the four per-type seams (fetch, row
+// build, limit, filter kind) plus the section metadata forwarded to
+// NewBaseModel.
 type Options[T data.RowData] struct {
-	Id         int
-	Ctx        *appctx.ProgramContext
-	Config     config.SectionConfig
+	Id     int
+	Ctx    *appctx.ProgramContext
+	Config config.SectionConfig
+	// Type MUST correspond to the type parameter T: it drives app-level fetch
+	// routing, so a Type/T mismatch would silently misroute fetch results.
 	Type       string
 	FilterKind string
 
@@ -64,6 +67,15 @@ var (
 
 // New builds a generic section from Options.
 func New[T data.RowData](o Options[T]) *Model[T] {
+	if o.Fetch == nil {
+		panic("section.New: Options.Fetch is required")
+	}
+	if o.BuildRow == nil {
+		panic("section.New: Options.BuildRow is required")
+	}
+	if o.Limit == nil {
+		panic("section.New: Options.Limit is required")
+	}
 	m := &Model[T]{}
 	m.BaseModel = NewBaseModel(NewOptions{
 		Id:           o.Id,
@@ -144,7 +156,8 @@ func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
 		m.SetTotalCount(msg.TotalCount)
 		m.SetError(nil)
 		// SetRows clamps but does not reset the cursor, so a refresh keeps the
-		// selected row (intentional; better UX than the pre-refactor reset-to-top).
+		// selected row (intentional: preserves the user's position rather than
+		// jumping to the top).
 		m.SetRows(m.BuildRows())
 		return m, nil
 	case spinner.TickMsg:
@@ -155,8 +168,8 @@ func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
 		}
 		return m, nil
 	}
-	// Only forward navigation/other messages to the table when ready — matches the
-	// pre-refactor gating, which ignored keys while loading or in the error state.
+	// Only forward navigation/other messages to the table when ready: keys are
+	// ignored while loading or in the error state.
 	if m.GetIsLoading() || m.GetError() != nil {
 		return m, nil
 	}

--- a/internal/ui/components/section/section.go
+++ b/internal/ui/components/section/section.go
@@ -4,6 +4,9 @@
 package section
 
 import (
+	"fmt"
+	"time"
+
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -191,4 +194,48 @@ func (m *BaseModel) View() string {
 		return m.SearchBar.View() + "\n" + body
 	}
 	return body
+}
+
+// DefaultColumns reproduces the shared column widths and title-grow formula used
+// by the pull-request and issue sections (# / Title / Repo / Author / State /
+// Updated).
+func DefaultColumns(mainWidth int) []table.Column {
+	const (
+		numW     = 6
+		repoW    = 22
+		authorW  = 16
+		stateW   = 8
+		updatedW = 10
+	)
+	titleW := mainWidth - (numW + repoW + authorW + stateW + updatedW) - 6
+	if titleW < 20 {
+		titleW = 20
+	}
+	return []table.Column{
+		{Title: "#", Width: numW},
+		{Title: "Title", Width: titleW},
+		{Title: "Repo", Width: repoW},
+		{Title: "Author", Width: authorW},
+		{Title: "State", Width: stateW},
+		{Title: "Updated", Width: updatedW},
+	}
+}
+
+// HumanizeTime renders a coarse "just now / Xm / Xh / Xd ago" relative time,
+// returning "" for the zero time.
+func HumanizeTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
 }

--- a/internal/ui/components/section/section.go
+++ b/internal/ui/components/section/section.go
@@ -1,6 +1,8 @@
 // Package section defines the Section contract every dashboard section
 // satisfies, plus an embeddable BaseModel that owns the table/spinner and
-// renders the loading/error/empty/table body.
+// renders the loading/error/empty/table body. It also provides a generic
+// Model[T RowData] that implements Section for any row type, which the
+// pullsection/issuesection packages specialize.
 package section
 
 import (
@@ -196,9 +198,8 @@ func (m *BaseModel) View() string {
 	return body
 }
 
-// DefaultColumns reproduces the shared column widths and title-grow formula used
-// by the pull-request and issue sections (# / Title / Repo / Author / State /
-// Updated).
+// DefaultColumns defines the shared column widths and title-grow formula for
+// every section (# / Title / Repo / Author / State / Updated).
 func DefaultColumns(mainWidth int) []table.Column {
 	const (
 		numW     = 6


### PR DESCRIPTION
**M1c-0** — the foundation for the rest of M1c (preview, comments, actions), so those features get written once, not per-section.

The pull and issue sections were ~95% identical. This introduces a generic **`section.Model[T data.RowData]`** carrying the three genuine per-type seams (`fetch` / `buildRow` / `limit`), and hoists the shared helpers (`HumanizeTime`, `DefaultColumns`) into the `section` package.

- `pullsection` / `issuesection` shrink to ~20-line wirings + `type Model = section.Model[data.PullRequest]` aliases that keep every existing test surface (`.(*pullsection.Model)`, `pullsection.NewModel`, the fetched-msg types) compiling.
- **Behavior-preserving**: the `/` search-focus branch, stale-fetch guard, spinner, and loading/error-gated table delegate are all intact. Only change is the field rename `Prs`/`Issues` → `Rows` on the fetched msg (aliased) and an opaque internal taskId prefix.
- **Net −309 lines** across the two section files (441 → 132); dedup moves into `section/model.go`.

Gated + reviewed (build/vet/`go test -race` green; review found only a cosmetic note). No user-visible change.

https://claude.ai/code/session_01G2CWgm2mEqTJ6L6VwL85oB