### PR TITLE
M1c-2: show comments, reviews, and CI in preview

### DIFF
--- a/internal/data/detail.go
+++ b/internal/data/detail.go
@@ -2,6 +2,36 @@ package data
 
 import "time"
 
+// ReviewState is a submitted pull-request review state.
+type ReviewState string
+
+const (
+	ReviewStateApproved       ReviewState = "APPROVED"
+	ReviewStateRequestChanges ReviewState = "REQUEST_CHANGES"
+	ReviewStateComment        ReviewState = "COMMENT"
+)
+
+// CheckState is one CI/check status state attached to a commit.
+type CheckState string
+
+const (
+	CheckStateSuccess CheckState = "success"
+	CheckStatePending CheckState = "pending"
+	CheckStateFailure CheckState = "failure"
+	CheckStateError   CheckState = "error"
+	CheckStateWarning CheckState = "warning"
+)
+
+// CIState is the rolled-up combined status state for a commit.
+type CIState string
+
+const (
+	CIStateSuccess CIState = "success"
+	CIStatePending CIState = "pending"
+	CIStateFailure CIState = "failure"
+	CIStateError   CIState = "error"
+)
+
 // Comment is one issue/PR comment. Populated by a later sub-plan; the field
 // set is defined now so downstream code can compile against it.
 type Comment struct {
@@ -13,7 +43,7 @@ type Comment struct {
 // Review is one pull-request review (approve/request-changes/comment).
 type Review struct {
 	Author      string
-	State       string // "APPROVED" | "REQUEST_CHANGES" | "COMMENT" | ...
+	State       ReviewState
 	Body        string
 	SubmittedAt time.Time
 }
@@ -21,17 +51,23 @@ type Review struct {
 // Check is one CI status entry attached to a commit SHA.
 type Check struct {
 	Context     string
-	State       string // "success" | "pending" | "failure" | "error" | ...
+	State       CheckState
 	Description string
 	TargetURL   string
 }
 
-// CIStatus is the combined CI state for a pull request's head commit.
+// CIStatus is the combined CI state for a pull request's head commit. The zero
+// value means CI was not fetched or was unavailable.
 type CIStatus struct {
-	State  string // rolled-up state
+	State  CIState
 	SHA    string
 	Total  int
 	Checks []Check
+}
+
+// HasCI reports whether a combined status was populated.
+func (c CIStatus) HasCI() bool {
+	return c.State != "" || c.SHA != "" || c.Total != 0 || len(c.Checks) > 0
 }
 
 // PullDetail is the read-only detail view of a pull request, kept separate

--- a/internal/data/detail_test.go
+++ b/internal/data/detail_test.go
@@ -41,13 +41,13 @@ func TestPullDetailConstruction(t *testing.T) {
 		Deletions:    3,
 		ChangedFiles: 2,
 		Comments:     []Comment{{Author: "a", Body: "b", CreatedAt: now}},
-		Reviews:      []Review{{Author: "r", State: "APPROVED", Body: "lgtm", SubmittedAt: now}},
+		Reviews:      []Review{{Author: "r", State: ReviewStateApproved, Body: "lgtm", SubmittedAt: now}},
 		CI: CIStatus{
-			State: "success",
+			State: CIStateSuccess,
 			SHA:   "deadbeef",
 			Total: 1,
 			Checks: []Check{
-				{Context: "build", State: "success", Description: "ok", TargetURL: "http://x"},
+				{Context: "build", State: CheckStateSuccess, Description: "ok", TargetURL: "http://x"},
 			},
 		},
 	}
@@ -57,11 +57,14 @@ func TestPullDetailConstruction(t *testing.T) {
 	if len(d.Comments) != 1 || d.Comments[0].Author != "a" {
 		t.Errorf("comments did not round-trip: %+v", d.Comments)
 	}
-	if len(d.Reviews) != 1 || d.Reviews[0].State != "APPROVED" {
+	if len(d.Reviews) != 1 || d.Reviews[0].State != ReviewStateApproved {
 		t.Errorf("reviews did not round-trip: %+v", d.Reviews)
 	}
 	if d.CI.Total != 1 || len(d.CI.Checks) != 1 || d.CI.Checks[0].Context != "build" {
 		t.Errorf("CI did not round-trip: %+v", d.CI)
+	}
+	if !d.CI.HasCI() {
+		t.Error("CI with a state/checks should report HasCI")
 	}
 }
 

--- a/internal/gitea/detail.go
+++ b/internal/gitea/detail.go
@@ -9,8 +9,15 @@ import (
 )
 
 // GetPullDetail fetches the read-only detail view of a single pull request.
-// The typed SDK call runs through c.call, the wrapper point for SDK calls.
-// Comments/Reviews/CI are populated by a later sub-plan.
+//
+// The primary payload is the PR itself (body/base/head/stats); its fetch error
+// is fatal. Comments, reviews, and CI are secondary decorations fetched
+// best-effort: each runs as its own c.call, and a failure on any one of them
+// leaves the corresponding slice/struct empty rather than failing the whole
+// detail. Sub-fetch errors are intentionally swallowed here — the detail view
+// must still render when, e.g., the combined-status endpoint is disabled on the
+// server or a review list momentarily 500s. Every typed SDK call goes through
+// c.call, the wrapper point for SDK calls.
 func (c *Client) GetPullDetail(owner, repo string, index int64) (data.PullDetail, error) {
 	var pr *sdk.PullRequest
 	err := c.call(func() error {
@@ -21,11 +28,47 @@ func (c *Client) GetPullDetail(owner, repo string, index int64) (data.PullDetail
 	if err != nil {
 		return data.PullDetail{}, fmt.Errorf("get pull %s/%s#%d: %w", owner, repo, index, err)
 	}
-	return mapPullDetail(pr), nil
+	d := mapPullDetail(pr)
+
+	// Best-effort comments.
+	var comments []*sdk.Comment
+	if e := c.call(func() error {
+		var ce error
+		comments, _, ce = c.sdk.ListIssueComments(owner, repo, index, sdk.ListIssueCommentOptions{})
+		return ce
+	}); e == nil {
+		d.Comments = mapComments(comments)
+	}
+
+	// Best-effort reviews.
+	var reviews []*sdk.PullReview
+	if e := c.call(func() error {
+		var re error
+		reviews, _, re = c.sdk.ListPullReviews(owner, repo, index, sdk.ListPullReviewsOptions{})
+		return re
+	}); e == nil {
+		d.Reviews = mapReviews(reviews)
+	}
+
+	// Best-effort CI: only meaningful when we actually have a head SHA to query.
+	if pr != nil && pr.Head != nil && pr.Head.Sha != "" {
+		var cs *sdk.CombinedStatus
+		if e := c.call(func() error {
+			var se error
+			cs, _, se = c.sdk.GetCombinedStatus(owner, repo, pr.Head.Sha)
+			return se
+		}); e == nil {
+			d.CI = mapCombinedStatus(cs)
+		}
+	}
+
+	return d, nil
 }
 
-// GetIssueDetail fetches the read-only detail view of a single issue. The SDK
-// call runs through c.call. Comments are populated by a later sub-plan.
+// GetIssueDetail fetches the read-only detail view of a single issue. The issue
+// fetch is primary and fatal on error; comments are fetched best-effort with
+// the same rationale as GetPullDetail — a failed comment fetch leaves Comments
+// empty rather than failing the issue detail. Both SDK calls run through c.call.
 func (c *Client) GetIssueDetail(owner, repo string, index int64) (data.IssueDetail, error) {
 	var iss *sdk.Issue
 	err := c.call(func() error {
@@ -36,7 +79,19 @@ func (c *Client) GetIssueDetail(owner, repo string, index int64) (data.IssueDeta
 	if err != nil {
 		return data.IssueDetail{}, fmt.Errorf("get issue %s/%s#%d: %w", owner, repo, index, err)
 	}
-	return mapIssueDetail(iss), nil
+	d := mapIssueDetail(iss)
+
+	// Best-effort comments.
+	var comments []*sdk.Comment
+	if e := c.call(func() error {
+		var ce error
+		comments, _, ce = c.sdk.ListIssueComments(owner, repo, index, sdk.ListIssueCommentOptions{})
+		return ce
+	}); e == nil {
+		d.Comments = mapComments(comments)
+	}
+
+	return d, nil
 }
 
 // mapPullDetail is the pure mapping from the SDK pull request onto the domain
@@ -79,4 +134,92 @@ func mapIssueDetail(iss *sdk.Issue) data.IssueDetail {
 		return data.IssueDetail{}
 	}
 	return data.IssueDetail{Body: iss.Body}
+}
+
+// mapComments maps SDK issue/PR comments onto the domain Comment type. Pure and
+// nil-safe: nil slice entries are skipped, and a nil Poster maps to an empty
+// author. Note the SDK's User.UserName field carries the login (json:"login").
+func mapComments(cs []*sdk.Comment) []data.Comment {
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]data.Comment, 0, len(cs))
+	for _, c := range cs {
+		if c == nil {
+			continue
+		}
+		cm := data.Comment{
+			Body:      c.Body,
+			CreatedAt: c.Created,
+		}
+		if c.Poster != nil {
+			cm.Author = c.Poster.UserName
+		}
+		out = append(out, cm)
+	}
+	return out
+}
+
+// mapReviews maps SDK pull reviews onto the domain Review type, dropping draft
+// reviews whose state is empty (ReviewStateUnknown) or PENDING — those are not
+// yet submitted and would otherwise render as blank entries. APPROVED /
+// REQUEST_CHANGES / COMMENT and any other concrete state are kept. Pure and
+// nil-safe: nil entries are skipped and a nil Reviewer maps to an empty author.
+func mapReviews(rs []*sdk.PullReview) []data.Review {
+	if len(rs) == 0 {
+		return nil
+	}
+	out := make([]data.Review, 0, len(rs))
+	for _, r := range rs {
+		if r == nil {
+			continue
+		}
+		if r.State == sdk.ReviewStateUnknown || r.State == sdk.ReviewStatePending {
+			continue
+		}
+		rv := data.Review{
+			State:       data.ReviewState(r.State),
+			Body:        r.Body,
+			SubmittedAt: r.Submitted,
+		}
+		if r.Reviewer != nil {
+			rv.Author = r.Reviewer.UserName
+		}
+		out = append(out, rv)
+	}
+	return out
+}
+
+// mapCombinedStatus maps the SDK combined commit status onto the domain
+// CIStatus. Pure and nil-safe: a nil status maps to the zero CIStatus, and nil
+// per-status entries are skipped. Each check's TargetURL prefers the status's
+// TargetURL and falls back to its API URL when TargetURL is empty.
+func mapCombinedStatus(cs *sdk.CombinedStatus) data.CIStatus {
+	if cs == nil {
+		return data.CIStatus{}
+	}
+	ci := data.CIStatus{
+		State: data.CIState(cs.State),
+		SHA:   cs.SHA,
+		Total: cs.TotalCount,
+	}
+	if len(cs.Statuses) > 0 {
+		ci.Checks = make([]data.Check, 0, len(cs.Statuses))
+		for _, s := range cs.Statuses {
+			if s == nil {
+				continue
+			}
+			targetURL := s.TargetURL
+			if targetURL == "" {
+				targetURL = s.URL
+			}
+			ci.Checks = append(ci.Checks, data.Check{
+				Context:     s.Context,
+				State:       data.CheckState(s.State),
+				Description: s.Description,
+				TargetURL:   targetURL,
+			})
+		}
+	}
+	return ci
 }

--- a/internal/gitea/detail_test.go
+++ b/internal/gitea/detail_test.go
@@ -2,8 +2,11 @@ package gitea
 
 import (
 	"testing"
+	"time"
 
 	sdk "code.gitea.io/sdk/gitea"
+
+	"github.com/gbarany/tea-dash/internal/data"
 )
 
 func intp(n int) *int { return &n }
@@ -64,4 +67,116 @@ func TestMapIssueDetail(t *testing.T) {
 	if got := mapIssueDetail(iss); got.Body != "issue body" {
 		t.Errorf("Body = %q, want %q", got.Body, "issue body")
 	}
+}
+
+// TestMapComments drives the pure comment mapper: author from Poster.UserName
+// (json:"login"), nil Poster -> empty author, nil entries skipped, and an
+// empty input mapping to a nil slice.
+func TestMapComments(t *testing.T) {
+	t.Run("empty and nil", func(t *testing.T) {
+		if got := mapComments(nil); got != nil {
+			t.Errorf("nil input should map to nil slice, got %v", got)
+		}
+		if got := mapComments([]*sdk.Comment{}); got != nil {
+			t.Errorf("empty input should map to nil slice, got %v", got)
+		}
+	})
+
+	t.Run("mapping and guards", func(t *testing.T) {
+		created := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		in := []*sdk.Comment{
+			{Poster: &sdk.User{UserName: "alice"}, Body: "first", Created: created},
+			nil,                              // skipped
+			{Poster: nil, Body: "no poster"}, // empty author, kept
+		}
+		got := mapComments(in)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 comments (nil skipped), got %d: %+v", len(got), got)
+		}
+		if got[0].Author != "alice" || got[0].Body != "first" || !got[0].CreatedAt.Equal(created) {
+			t.Errorf("comment[0] mismatch: %+v", got[0])
+		}
+		if got[1].Author != "" || got[1].Body != "no poster" {
+			t.Errorf("comment[1] should have empty author, got %+v", got[1])
+		}
+	})
+}
+
+// TestMapReviews drives the pure review mapper: author from Reviewer.UserName,
+// state stringified, PENDING and empty (draft) states filtered out, nil
+// Reviewer -> empty author, nil entries skipped.
+func TestMapReviews(t *testing.T) {
+	t.Run("empty and nil", func(t *testing.T) {
+		if got := mapReviews(nil); got != nil {
+			t.Errorf("nil input should map to nil slice, got %v", got)
+		}
+	})
+
+	t.Run("state filtering and mapping", func(t *testing.T) {
+		submitted := time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC)
+		in := []*sdk.PullReview{
+			{Reviewer: &sdk.User{UserName: "bob"}, State: sdk.ReviewStateApproved, Body: "lgtm", Submitted: submitted},
+			{Reviewer: &sdk.User{UserName: "carol"}, State: sdk.ReviewStateRequestChanges, Body: "nope"},
+			{Reviewer: &sdk.User{UserName: "dave"}, State: sdk.ReviewStateComment, Body: "nit"},
+			{Reviewer: &sdk.User{UserName: "eve"}, State: sdk.ReviewStatePending, Body: "draft"},   // filtered
+			{Reviewer: &sdk.User{UserName: "frank"}, State: sdk.ReviewStateUnknown, Body: "empty"}, // filtered
+			nil, // skipped
+			{Reviewer: nil, State: sdk.ReviewStateApproved, Body: "ghost"}, // empty author, kept
+		}
+		got := mapReviews(in)
+		if len(got) != 4 {
+			t.Fatalf("expected 4 reviews (PENDING/empty/nil dropped), got %d: %+v", len(got), got)
+		}
+		if got[0].Author != "bob" || got[0].State != data.ReviewStateApproved || got[0].Body != "lgtm" || !got[0].SubmittedAt.Equal(submitted) {
+			t.Errorf("review[0] mismatch: %+v", got[0])
+		}
+		if got[1].State != data.ReviewStateRequestChanges || got[2].State != data.ReviewStateComment {
+			t.Errorf("review states mismatch: %+v", got)
+		}
+		if got[3].Author != "" || got[3].State != data.ReviewStateApproved {
+			t.Errorf("review[3] (nil reviewer) should have empty author, got %+v", got[3])
+		}
+	})
+}
+
+// TestMapCombinedStatus drives the pure CI mapper: state/SHA/total plus each
+// check's fields, the TargetURL->URL fallback, nil-status guard, and skipping
+// of nil per-status entries.
+func TestMapCombinedStatus(t *testing.T) {
+	t.Run("nil guard", func(t *testing.T) {
+		got := mapCombinedStatus(nil)
+		if got.State != "" || got.SHA != "" || got.Total != 0 || got.Checks != nil || got.HasCI() {
+			t.Errorf("nil should map to zero CIStatus, got %+v", got)
+		}
+	})
+
+	t.Run("full mapping with URL fallback", func(t *testing.T) {
+		cs := &sdk.CombinedStatus{
+			State:      sdk.StatusSuccess,
+			SHA:        "abc123",
+			TotalCount: 2,
+			Statuses: []*sdk.Status{
+				{Context: "build", State: sdk.StatusSuccess, Description: "ok", TargetURL: "http://ci/build"},
+				nil, // skipped
+				{Context: "lint", State: sdk.StatusFailure, Description: "bad", TargetURL: "", URL: "http://api/lint"},
+			},
+		}
+		got := mapCombinedStatus(cs)
+		if got.State != data.CIStateSuccess || got.SHA != "abc123" || got.Total != 2 {
+			t.Errorf("combined status header mismatch: %+v", got)
+		}
+		if !got.HasCI() {
+			t.Errorf("non-empty combined status should report HasCI: %+v", got)
+		}
+		if len(got.Checks) != 2 {
+			t.Fatalf("expected 2 checks (nil skipped), got %d: %+v", len(got.Checks), got.Checks)
+		}
+		if got.Checks[0].Context != "build" || got.Checks[0].State != data.CheckStateSuccess ||
+			got.Checks[0].Description != "ok" || got.Checks[0].TargetURL != "http://ci/build" {
+			t.Errorf("check[0] mismatch: %+v", got.Checks[0])
+		}
+		if got.Checks[1].State != data.CheckStateFailure || got.Checks[1].TargetURL != "http://api/lint" {
+			t.Errorf("check[1] should fall back to URL, got %+v", got.Checks[1])
+		}
+	})
 }

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/markdown"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
 )
 
 // foldLines is the folded-body cap: a non-expanded preview shows at most this
@@ -26,10 +27,21 @@ const (
 	colDraft  = "#6e7681" // gray
 )
 
+// maxChecks / maxComments cap how many per-check and per-comment lines render
+// before a "…and N more" summary line.
+const (
+	maxChecks   = 8
+	maxComments = 10
+)
+
 var (
 	dimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	titleStyle = lipgloss.NewStyle().Bold(true)
 	subtleRef  = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
+	greenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(colOpen))
+	redStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color(colClosed))
+	yellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#d29922"))
 )
 
 // RenderPull renders a pull-request row and optional detail into the preview
@@ -57,12 +69,16 @@ func RenderPull(row data.PullRequest, detail *data.PullDetail, width int, expand
 	}
 
 	var body string
-	if detail == nil {
-		body = ""
-	} else {
+	var extras []string
+	if detail != nil {
 		body = detail.Body
+		extras = []string{
+			renderCI(detail.CI, width),
+			renderReviews(detail.Reviews),
+			renderComments(detail.Comments, width),
+		}
 	}
-	return compose(header, body, detail == nil, width, expanded)
+	return compose(header, body, detail == nil, width, expanded, extras)
 }
 
 // RenderIssue renders an issue row and optional detail into the preview string,
@@ -75,27 +91,37 @@ func RenderIssue(row data.Issue, detail *data.IssueDetail, width int, expanded b
 	}
 
 	var body string
+	var extras []string
 	if detail != nil {
 		body = detail.Body
+		extras = []string{renderComments(detail.Comments, width)}
 	}
-	return compose(header, body, detail == nil, width, expanded)
+	return compose(header, body, detail == nil, width, expanded, extras)
 }
 
-// compose joins the header block with the rendered body. When loading is true
-// the body is a dim placeholder; otherwise rawBody is Markdown-rendered and
-// folded unless expanded.
-func compose(header []string, rawBody string, loading bool, width int, expanded bool) string {
+// compose joins the header block with the rendered body, then appends any
+// non-empty extra sections (CI / reviews / comments) below the fold, each
+// separated by a blank line so the viewport scrolls through them. When loading
+// is true the body is a dim placeholder and extras are ignored.
+func compose(header []string, rawBody string, loading bool, width int, expanded bool, extras []string) string {
 	var body string
 	if loading {
 		body = dimStyle.Render("Loading…")
 	} else {
 		body = foldBody(markdown.Render(rawBody, width), expanded)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left,
+	parts := []string{
 		lipgloss.JoinVertical(lipgloss.Left, header...),
 		"",
 		body,
-	)
+	}
+	for _, e := range extras {
+		if e == "" {
+			continue
+		}
+		parts = append(parts, "", e)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
 // foldBody truncates a rendered body to foldLines (plus a hint) unless expanded
@@ -152,4 +178,157 @@ func stateColor(state string) string {
 	default:
 		return colOpen
 	}
+}
+
+// renderCI renders the CI block: a colored "Checks: ✓N ✗M •K" summary line
+// followed by up to maxChecks per-check lines (with a "…and N more" overflow
+// line). It returns "" when no CI state was populated.
+func renderCI(ci data.CIStatus, width int) string {
+	if !ci.HasCI() {
+		return ""
+	}
+	var success, failure, pending int
+	for _, c := range ci.Checks {
+		switch c.State {
+		case data.CheckStateSuccess:
+			success++
+		case data.CheckStateFailure, data.CheckStateError:
+			failure++
+		default:
+			pending++
+		}
+	}
+	summary := "Checks: " +
+		greenStyle.Render(fmt.Sprintf("✓%d", success)) + " " +
+		redStyle.Render(fmt.Sprintf("✗%d", failure)) + " " +
+		yellowStyle.Render(fmt.Sprintf("•%d", pending))
+
+	lines := []string{summary}
+	shown := ci.Checks
+	extra := 0
+	if len(shown) > maxChecks {
+		extra = len(shown) - maxChecks
+		shown = shown[:maxChecks]
+	}
+	for _, c := range shown {
+		lines = append(lines, checkLine(c, width))
+	}
+	if extra > 0 {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("…and %d more", extra)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// checkLine renders one CI check as "icon Context — Description", truncated to
+// width so it stays on a single line.
+func checkLine(c data.Check, width int) string {
+	icon, st := checkIcon(c.State)
+	text := c.Context
+	if c.Description != "" {
+		text += " — " + c.Description
+	}
+	return st.Render(icon) + " " + truncateText(text, width-2)
+}
+
+// checkIcon maps a check state to its icon and color style.
+func checkIcon(state data.CheckState) (string, lipgloss.Style) {
+	switch state {
+	case data.CheckStateSuccess:
+		return "✓", greenStyle
+	case data.CheckStateFailure, data.CheckStateError:
+		return "✗", redStyle
+	case data.CheckStateWarning:
+		return "!", yellowStyle
+	default:
+		return "•", yellowStyle
+	}
+}
+
+// renderReviews renders the "Reviews:" block: one line per review with a
+// colored state badge and @author. Returns "" when there are no reviews.
+func renderReviews(reviews []data.Review) string {
+	if len(reviews) == 0 {
+		return ""
+	}
+	lines := []string{titleStyle.Render("Reviews:")}
+	for _, r := range reviews {
+		lines = append(lines, reviewBadge(r.State)+" @"+r.Author)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// reviewBadge renders a review's state as a colored, uppercased badge:
+// APPROVED green, REQUEST_CHANGES red, anything else dim.
+func reviewBadge(state data.ReviewState) string {
+	label := strings.ToUpper(string(state))
+	switch state {
+	case data.ReviewStateApproved:
+		return greenStyle.Render(label)
+	case data.ReviewStateRequestChanges, "CHANGES_REQUESTED":
+		return redStyle.Render(label)
+	default:
+		return dimStyle.Render(label)
+	}
+}
+
+// renderComments renders the comments block for a PR or issue: a "N comments"
+// header (singular "1 comment") followed by each comment's dim meta line and
+// wrapped body, capped at maxComments with a "…and N more" overflow line.
+// Returns "" when there are no comments.
+func renderComments(comments []data.Comment, width int) string {
+	if len(comments) == 0 {
+		return ""
+	}
+	header := fmt.Sprintf("%d comments", len(comments))
+	if len(comments) == 1 {
+		header = "1 comment"
+	}
+	lines := []string{titleStyle.Render(header)}
+
+	shown := comments
+	extra := 0
+	if len(shown) > maxComments {
+		extra = len(shown) - maxComments
+		shown = shown[:maxComments]
+	}
+	for _, c := range shown {
+		meta := "@" + c.Author
+		if rel := section.HumanizeTime(c.CreatedAt); rel != "" {
+			meta += " · " + rel
+		}
+		lines = append(lines, "", dimStyle.Render(meta), commentBody(c.Body, width))
+	}
+	if extra > 0 {
+		lines = append(lines, "", dimStyle.Render(fmt.Sprintf("…and %d more", extra)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// commentBody trims and wraps a comment body to width for readable display.
+func commentBody(body string, width int) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	s := lipgloss.NewStyle()
+	if width > 0 {
+		s = s.Width(width)
+	}
+	return s.Render(body)
+}
+
+// truncateText shortens s to at most max runes, appending an ellipsis when it
+// cuts. A non-positive max returns s unchanged.
+func truncateText(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(r[:max-1]) + "…"
 }

--- a/internal/ui/components/prview/prview_test.go
+++ b/internal/ui/components/prview/prview_test.go
@@ -3,6 +3,7 @@ package prview
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gbarany/tea-dash/internal/data"
 )
@@ -110,5 +111,89 @@ func TestRenderIssue(t *testing.T) {
 	}
 	if !strings.Contains(loaded, "token-abc") {
 		t.Fatalf("loaded issue preview missing body token:\n%s", loaded)
+	}
+}
+
+// TestRenderPullCommentsCIReviews verifies the appended CI, reviews, and
+// comments sections all render with their contexts, badges, headers, authors,
+// and bodies.
+func TestRenderPullCommentsCIReviews(t *testing.T) {
+	now := time.Now()
+	detail := &data.PullDetail{
+		Body: "pr body",
+		CI: data.CIStatus{
+			State: data.CIStateFailure,
+			Checks: []data.Check{
+				{Context: "build-linux", State: data.CheckStateSuccess, Description: "passed"},
+				{Context: "test-race", State: data.CheckStateFailure, Description: "1 test failed"},
+			},
+		},
+		Reviews: []data.Review{
+			{Author: "octocat", State: data.ReviewStateApproved, SubmittedAt: now},
+		},
+		Comments: []data.Comment{
+			{Author: "alice", Body: "first comment body zeta", CreatedAt: now.Add(-2 * time.Hour)},
+			{Author: "bob", Body: "second comment body omega", CreatedAt: now.Add(-30 * time.Minute)},
+		},
+	}
+	out := RenderPull(samplePull(), detail, 60, false)
+
+	wants := []string{
+		// CI block
+		"Checks:", "build-linux", "test-race",
+		// Reviews block
+		"Reviews:", "APPROVED", "octocat",
+		// Comments block
+		"2 comments", "alice", "first comment body zeta", "bob", "second comment body omega",
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Fatalf("PR preview missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderIssueSingleComment verifies the issue comments block uses the
+// singular "1 comment" header and shows the comment body.
+func TestRenderIssueSingleComment(t *testing.T) {
+	row := data.Issue{
+		Number:            7,
+		Title:             "Something broke",
+		RepoNameWithOwner: "gbarany/tea-dash",
+		State:             "open",
+	}
+	detail := &data.IssueDetail{
+		Body: "issue body",
+		Comments: []data.Comment{
+			{Author: "carol", Body: "only comment here delta", CreatedAt: time.Now()},
+		},
+	}
+	out := RenderIssue(row, detail, 60, false)
+
+	if !strings.Contains(out, "1 comment") {
+		t.Fatalf("issue preview missing singular \"1 comment\":\n%s", out)
+	}
+	if strings.Contains(out, "1 comments") {
+		t.Fatalf("issue preview should use singular header, got plural:\n%s", out)
+	}
+	if !strings.Contains(out, "only comment here delta") {
+		t.Fatalf("issue preview missing comment body:\n%s", out)
+	}
+	if !strings.Contains(out, "carol") {
+		t.Fatalf("issue preview missing comment author:\n%s", out)
+	}
+}
+
+// TestRenderNilDetailNoComments verifies a nil detail keeps the Loading
+// placeholder and renders no comments/CI sections.
+func TestRenderNilDetailNoComments(t *testing.T) {
+	out := RenderPull(samplePull(), nil, 60, false)
+	if !strings.Contains(out, "Loading") {
+		t.Fatalf("nil-detail preview should show Loading:\n%s", out)
+	}
+	for _, absent := range []string{"comment", "Checks:", "Reviews:"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("nil-detail preview should not contain %q:\n%s", absent, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

M1c-2 enriches the preview pane with the context needed to review a PR or issue without opening the browser:

- fetches PR/issue comments and PR reviews into the lazy detail payload
- fetches combined CI status for PR head commits
- renders CI summary/check lines, review badges, and comment threads in the preview
- keeps comments/reviews/CI best-effort so a disabled or flaky secondary endpoint does not block the primary detail pane
- hardens detail state with named review/check/CI state types and `CIStatus.HasCI()`

This PR is stacked on #7 (`m1c-1/preview`) so the diff stays focused on the comments/reviews/CI enrichment layer.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/data ./internal/gitea ./internal/ui/components/prview -v`

## Notes

- Primary detail fetch errors still surface through #7's preview failure state.
- Secondary fetches are intentionally best-effort: comments/reviews/CI render when available and are omitted when their endpoint fails.
