### PR TITLE
Wire PR and issue actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ tea-dash --help
 | `s`             | switch view (PRs/issues/notifications)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
-| `p`             | toggle preview pane     |
-| `e`             | expand preview body     |
-| `ctrl+u/d`      | scroll preview          |
+| `p`             | show / hide preview panel |
+| `e`             | expand / fold preview body |
+| `ctrl+u` / `ctrl+d` | scroll preview       |
 | `o` / `enter`   | open in browser         |
+| `c`             | add comment             |
+| `m`             | merge PR                |
+| `x` / `X`       | close / reopen          |
+| `v`             | submit PR review        |
+| `d`             | open PR diff in external pager |
+| `C`             | checkout PR locally     |
 | `r`             | refresh                 |
 | `q` / `ctrl+c`  | quit                    |
 
@@ -104,6 +110,16 @@ defaults:
   prsLimit: 50           # rows fetched per PR section (0 -> 50)
   issuesLimit: 50        # rows fetched per issue section (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
+
+pager:
+  diff: diffnav     # command that receives PR diff bytes on stdin (falls back to $PAGER, then less -R)
+
+repoPaths:
+  "gbarany/*": "~/dev/sandbox/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
+
+git:
+  remote: origin
+  prBranchTemplate: "pr-{{.PrIndex}}"
 
 # Each section becomes a tab you page through with h/l. Omit prSections to get
 # two "@me"-authored PR defaults: open and closed pull requests. Omit

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ notifications across one or more Gitea instances, without leaving the terminal.
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
 > pull requests, issues, and unread notifications across all your repos (fetched
 > via the Gitea API (Go SDK + REST)), with view switching (`s`), configurable
-> sections you page through with `h`/`l`, preview pane support, and live keyword
-> search (`/`). PR actions are in progress. See
+> sections you page through with `h`/`l`, live keyword search (`/`),
+> default-open preview, and PR / issue actions. See
 > [`docs/architecture.md`](docs/architecture.md) for the design.
 
 ## Why
@@ -72,6 +72,7 @@ tea-dash --help
 | Key             | Action                  |
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
+| `g` / `G`       | first / last row        |
 | `s`             | switch view (PRs/issues/notifications)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
@@ -79,13 +80,15 @@ tea-dash --help
 | `e`             | expand / fold preview body |
 | `ctrl+u` / `ctrl+d` | scroll preview       |
 | `o` / `enter`   | open in browser         |
+| `y` / `Y`       | copy row number / URL   |
 | `c`             | add comment             |
 | `m`             | merge PR                |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
-| `d`             | open PR diff in external pager |
-| `C`             | checkout PR locally     |
-| `r`             | refresh                 |
+| `d` / `ctrl+t`  | open PR diff in external pager |
+| `C` / `space`   | checkout PR locally     |
+| `r` / `R`       | refresh section / all sections |
+| `?`             | show / hide full help   |
 | `q` / `ctrl+c`  | quit                    |
 
 ## Configuration

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -128,7 +128,11 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		return fmt.Sprintf("Reopened %s#%d.", intent.Target.Repo, index), nil
 
 	case uiactions.KindMerge:
-		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: data.MergeStyleMerge})
+		style, err := mergeStyle(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: style})
 		if err != nil {
 			return "", err
 		}
@@ -213,6 +217,23 @@ func reviewEvent(value string) (data.PullReviewEvent, error) {
 		return data.PullReviewEventRequestChanges, nil
 	default:
 		return "", fmt.Errorf("unsupported review action %q", value)
+	}
+}
+
+func mergeStyle(value string) (data.MergeStyle, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", string(data.MergeStyleMerge), "confirm":
+		return data.MergeStyleMerge, nil
+	case string(data.MergeStyleSquash):
+		return data.MergeStyleSquash, nil
+	case string(data.MergeStyleRebase):
+		return data.MergeStyleRebase, nil
+	case string(data.MergeStyleRebaseMerge):
+		return data.MergeStyleRebaseMerge, nil
+	case string(data.MergeStyleFastForwardOnly), "ff-only":
+		return data.MergeStyleFastForwardOnly, nil
+	default:
+		return "", fmt.Errorf("unsupported merge strategy %q", value)
 	}
 }
 

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -1,0 +1,238 @@
+// Package actionrunner executes UI action intents against Gitea, local git, and
+// configured shell commands.
+package actionrunner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/shell"
+	uiactions "github.com/gbarany/tea-dash/internal/ui/actions"
+)
+
+const actionTimeout = 2 * time.Minute
+
+// Client is the subset of the Gitea client used by action dispatch.
+type Client interface {
+	AddComment(owner, repo string, index int64, body string) (data.Comment, error)
+	SetIssueState(owner, repo string, index int64, state data.ItemState) error
+	SetPullState(owner, repo string, index int64, state data.ItemState) error
+	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
+	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
+	GetPullDiff(owner, repo string, index int64) ([]byte, error)
+}
+
+// CheckoutFunc runs or fakes a local PR checkout.
+type CheckoutFunc func(context.Context, localgit.CheckoutOptions) (localgit.CheckoutPlan, error)
+
+// Options configures a Runner.
+type Options struct {
+	Client      Client
+	Config      *config.Config
+	InstanceURL string
+	CWD         string
+	ShellRunner shell.Runner
+	GitRunner   localgit.Runner
+	Checkout    CheckoutFunc
+}
+
+// Runner executes actions and returns ResultMsg values for the UI.
+type Runner struct {
+	client      Client
+	cfg         *config.Config
+	instanceURL string
+	cwd         string
+	shellRunner shell.Runner
+	gitRunner   localgit.Runner
+	checkout    CheckoutFunc
+}
+
+// New constructs a Runner with production defaults for omitted runners.
+func New(opts Options) Runner {
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	shellRunner := opts.ShellRunner
+	if shellRunner == nil {
+		shellRunner = shell.ExecRunner{}
+	}
+	checkout := opts.Checkout
+	if checkout == nil {
+		checkout = localgit.RunCheckout
+	}
+	return Runner{
+		client:      opts.Client,
+		cfg:         cfg,
+		instanceURL: opts.InstanceURL,
+		cwd:         opts.CWD,
+		shellRunner: shellRunner,
+		gitRunner:   opts.GitRunner,
+		checkout:    checkout,
+	}
+}
+
+// Dispatch returns a Bubble Tea command that executes intent off the update
+// path and reports the result back as actions.ResultMsg.
+func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+
+		message, err := r.run(ctx, intent)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultSucceeded, Message: message}
+	}
+}
+
+func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error) {
+	if r.client == nil {
+		return "", fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))
+	}
+	owner, repo, err := splitRepo(intent.Target.Repo)
+	if err != nil {
+		return "", err
+	}
+	index := intent.Target.Number
+
+	switch intent.Kind {
+	case uiactions.KindComment:
+		body := strings.TrimSpace(intent.Prompt.Value)
+		if body == "" {
+			return "", fmt.Errorf("comment body cannot be empty")
+		}
+		if _, err := r.client.AddComment(owner, repo, index, body); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Commented on %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindClose:
+		if err := r.setState(owner, repo, index, intent.Target.RowKind, data.ItemStateClosed); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Closed %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindReopen:
+		if err := r.setState(owner, repo, index, intent.Target.RowKind, data.ItemStateOpen); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Reopened %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindMerge:
+		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: data.MergeStyleMerge})
+		if err != nil {
+			return "", err
+		}
+		if !merged {
+			return fmt.Sprintf("Merge requested for %s#%d.", intent.Target.Repo, index), nil
+		}
+		return fmt.Sprintf("Merged %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindReview:
+		event, err := reviewEvent(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		if _, err := r.client.SubmitPullReview(owner, repo, index, data.PullReviewOptions{Event: event}); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Submitted review for %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindExternalDiff:
+		diff, err := r.client.GetPullDiff(owner, repo, index)
+		if err != nil {
+			return "", err
+		}
+		command := r.cfg.Pager.DiffCommand()
+		cmd := shell.BuildCommand(command, diff, r.cwd)
+		out, err := r.shellRunner.Run(ctx, cmd)
+		if err != nil {
+			msg := strings.TrimSpace(string(out))
+			if msg != "" {
+				return "", fmt.Errorf("run diff pager %q: %w: %s", command, err, msg)
+			}
+			return "", fmt.Errorf("run diff pager %q: %w", command, err)
+		}
+		return fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindCheckout:
+		plan, err := r.checkout(ctx, localgit.CheckoutOptions{
+			RepoName:       intent.Target.Repo,
+			CWD:            r.cwd,
+			InstanceURL:    r.instanceURL,
+			RepoPaths:      r.cfg.RepoPaths,
+			Remote:         r.cfg.Git.Remote,
+			BranchTemplate: r.cfg.Git.PRBranchTemplate,
+			PrIndex:        index,
+			Runner:         r.gitRunner,
+		})
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Checked out %s in %s.", plan.Branch, plan.RepoPath), nil
+	default:
+		return "", fmt.Errorf("unsupported action %q", intent.Kind)
+	}
+}
+
+func (r Runner) setState(owner, repo string, index int64, kind uiactions.RowKind, state data.ItemState) error {
+	switch kind {
+	case uiactions.RowKindPullRequest:
+		return r.client.SetPullState(owner, repo, index, state)
+	case uiactions.RowKindIssue:
+		return r.client.SetIssueState(owner, repo, index, state)
+	default:
+		return fmt.Errorf("unsupported row kind %q", kind)
+	}
+}
+
+func splitRepo(repoName string) (string, string, error) {
+	owner, repo, ok := data.SplitOwnerRepo(repoName)
+	if !ok {
+		return "", "", fmt.Errorf("invalid repository %q", repoName)
+	}
+	return owner, repo, nil
+}
+
+func reviewEvent(value string) (data.PullReviewEvent, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "comment":
+		return data.PullReviewEventComment, nil
+	case "approve", "approved":
+		return data.PullReviewEventApprove, nil
+	case "request_changes", "request-changes", "changes_requested":
+		return data.PullReviewEventRequestChanges, nil
+	default:
+		return "", fmt.Errorf("unsupported review action %q", value)
+	}
+}
+
+func actionLabel(kind uiactions.Kind) string {
+	switch kind {
+	case uiactions.KindComment:
+		return "comment"
+	case uiactions.KindMerge:
+		return "merge"
+	case uiactions.KindClose:
+		return "close"
+	case uiactions.KindReopen:
+		return "reopen"
+	case uiactions.KindReview:
+		return "review"
+	case uiactions.KindExternalDiff:
+		return "external diff"
+	case uiactions.KindCheckout:
+		return "checkout"
+	default:
+		return string(kind)
+	}
+}

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -91,6 +91,16 @@ func TestDispatchMergeAndReview(t *testing.T) {
 		t.Fatalf("merge style = %q, want merge", client.merge.Style)
 	}
 
+	squash := pullIntent(uiactions.KindMerge)
+	squash.Prompt.Value = "squash"
+	got = runDispatch(t, r, squash)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("squash merge result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleSquash {
+		t.Fatalf("merge style = %q, want squash", client.merge.Style)
+	}
+
 	review := pullIntent(uiactions.KindReview)
 	review.Prompt.Value = "request_changes"
 	got = runDispatch(t, r, review)

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -1,0 +1,211 @@
+package actionrunner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/shell"
+	uiactions "github.com/gbarany/tea-dash/internal/ui/actions"
+)
+
+func runDispatch(t *testing.T, r Runner, intent uiactions.Intent) uiactions.ResultMsg {
+	t.Helper()
+	cmd := r.Dispatch(intent)
+	if cmd == nil {
+		t.Fatal("Dispatch returned nil")
+	}
+	msg := cmd()
+	got, ok := msg.(uiactions.ResultMsg)
+	if !ok {
+		t.Fatalf("Dispatch msg = %T, want actions.ResultMsg", msg)
+	}
+	return got
+}
+
+func pullIntent(kind uiactions.Kind) uiactions.Intent {
+	return uiactions.Intent{
+		Kind: kind,
+		Target: uiactions.Target{
+			RowKind: uiactions.RowKindPullRequest,
+			Repo:    "acme/widgets",
+			Number:  7,
+			Title:   "PR title",
+		},
+	}
+}
+
+func issueIntent(kind uiactions.Kind) uiactions.Intent {
+	in := pullIntent(kind)
+	in.Target.RowKind = uiactions.RowKindIssue
+	return in
+}
+
+func TestDispatchCommentAndClose(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	comment := pullIntent(uiactions.KindComment)
+	comment.Prompt.Value = "hello"
+	got := runDispatch(t, r, comment)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("comment result = %+v", got)
+	}
+	if client.commentBody != "hello" {
+		t.Fatalf("commentBody = %q, want hello", client.commentBody)
+	}
+
+	got = runDispatch(t, r, issueIntent(uiactions.KindClose))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("close issue result = %+v", got)
+	}
+	if client.issueState != data.ItemStateClosed {
+		t.Fatalf("issueState = %q, want closed", client.issueState)
+	}
+
+	got = runDispatch(t, r, pullIntent(uiactions.KindReopen))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("reopen pull result = %+v", got)
+	}
+	if client.pullState != data.ItemStateOpen {
+		t.Fatalf("pullState = %q, want open", client.pullState)
+	}
+}
+
+func TestDispatchMergeAndReview(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("merge result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleMerge {
+		t.Fatalf("merge style = %q, want merge", client.merge.Style)
+	}
+
+	review := pullIntent(uiactions.KindReview)
+	review.Prompt.Value = "request_changes"
+	got = runDispatch(t, r, review)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("review result = %+v", got)
+	}
+	if client.review.Event != data.PullReviewEventRequestChanges {
+		t.Fatalf("review event = %q, want request-changes", client.review.Event)
+	}
+}
+
+func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
+	client := &fakeClient{diff: []byte("diff --git a/a b/a\n+hello\n")}
+	shellRunner := &fakeShellRunner{}
+	r := New(Options{
+		Client:      client,
+		Config:      &config.Config{Pager: config.Pager{Diff: "diffnav"}},
+		CWD:         "/tmp/repo",
+		ShellRunner: shellRunner,
+	})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindExternalDiff))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("diff result = %+v", got)
+	}
+	if shellRunner.command.Name == "" {
+		t.Fatal("shell runner was not called")
+	}
+	if !reflect.DeepEqual(shellRunner.command.Args, []string{"-c", "diffnav"}) {
+		t.Fatalf("shell args = %#v, want shell -c diffnav", shellRunner.command.Args)
+	}
+	if string(shellRunner.command.Stdin) != string(client.diff) || shellRunner.command.Dir != "/tmp/repo" {
+		t.Fatalf("shell command = %+v", shellRunner.command)
+	}
+}
+
+func TestDispatchCheckoutPassesConfig(t *testing.T) {
+	var gotOpts localgit.CheckoutOptions
+	r := New(Options{
+		Client:      &fakeClient{},
+		Config:      &config.Config{RepoPaths: map[string]string{"acme/widgets": "/src/widgets"}, Git: config.Git{Remote: "upstream", PRBranchTemplate: "review-{{.PrIndex}}"}},
+		InstanceURL: "https://git.example",
+		CWD:         "/cwd",
+		Checkout: func(_ context.Context, opts localgit.CheckoutOptions) (localgit.CheckoutPlan, error) {
+			gotOpts = opts
+			return localgit.CheckoutPlan{RepoPath: "/src/widgets", Branch: "review-7"}, nil
+		},
+	})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindCheckout))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("checkout result = %+v", got)
+	}
+	if gotOpts.RepoName != "acme/widgets" || gotOpts.PrIndex != 7 || gotOpts.CWD != "/cwd" ||
+		gotOpts.InstanceURL != "https://git.example" || gotOpts.Remote != "upstream" ||
+		gotOpts.BranchTemplate != "review-{{.PrIndex}}" {
+		t.Fatalf("checkout opts = %+v", gotOpts)
+	}
+}
+
+func TestDispatchReturnsErrorResult(t *testing.T) {
+	client := &fakeClient{err: errors.New("boom")}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultErrored || got.Err == nil || !strings.Contains(got.Err.Error(), "boom") {
+		t.Fatalf("error result = %+v", got)
+	}
+}
+
+type fakeClient struct {
+	err         error
+	commentBody string
+	issueState  data.ItemState
+	pullState   data.ItemState
+	merge       data.MergeOptions
+	review      data.PullReviewOptions
+	diff        []byte
+}
+
+func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
+	f.commentBody = body
+	return data.Comment{Body: body}, f.err
+}
+
+func (f *fakeClient) SetIssueState(_, _ string, _ int64, state data.ItemState) error {
+	f.issueState = state
+	return f.err
+}
+
+func (f *fakeClient) SetPullState(_, _ string, _ int64, state data.ItemState) error {
+	f.pullState = state
+	return f.err
+}
+
+func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOptions) (bool, error) {
+	f.merge = opt
+	return f.err == nil, f.err
+}
+
+func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewOptions) (data.Review, error) {
+	f.review = opt
+	return data.Review{State: data.ReviewState(opt.Event)}, f.err
+}
+
+func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {
+	return f.diff, f.err
+}
+
+type fakeShellRunner struct {
+	command shell.Command
+	err     error
+}
+
+func (f *fakeShellRunner) Run(_ context.Context, cmd shell.Command) ([]byte, error) {
+	f.command = cmd
+	return nil, f.err
+}
+
+var _ tea.Cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,15 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 	"strings"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
@@ -27,6 +31,13 @@ type Config struct {
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
+	// Pager configures external pager commands.
+	Pager Pager `yaml:"pager"`
+	// RepoPaths maps repo names or wildcard patterns (for example "fcmb/*")
+	// to local checkout paths.
+	RepoPaths map[string]string `yaml:"repoPaths"`
+	// Git configures local git checkout behavior.
+	Git Git `yaml:"git"`
 }
 
 // Defaults holds startup and limit defaults. PRsLimit and IssuesLimit set the
@@ -37,6 +48,45 @@ type Defaults struct {
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
+}
+
+// Pager configures external pager commands.
+type Pager struct {
+	Diff string `yaml:"diff"`
+}
+
+// DiffCommand returns the configured diff pager command, then $PAGER, then the
+// less fallback that preserves ANSI color.
+func (p Pager) DiffCommand() string {
+	if diff := strings.TrimSpace(p.Diff); diff != "" {
+		return diff
+	}
+	if pager := strings.TrimSpace(os.Getenv("PAGER")); pager != "" {
+		return pager
+	}
+	return "less -R"
+}
+
+// Git configures local git checkout behavior.
+type Git struct {
+	Remote           string `yaml:"remote"`
+	PRBranchTemplate string `yaml:"prBranchTemplate"`
+}
+
+// RemoteName returns the configured remote name or the origin default.
+func (g Git) RemoteName() string {
+	if remote := strings.TrimSpace(g.Remote); remote != "" {
+		return remote
+	}
+	return "origin"
+}
+
+// BranchTemplate returns the configured PR branch template or the default.
+func (g Git) BranchTemplate() string {
+	if tmpl := strings.TrimSpace(g.PRBranchTemplate); tmpl != "" {
+		return tmpl
+	}
+	return "pr-{{.PrIndex}}"
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -153,6 +203,85 @@ func ParseRepo(s string) (Repo, error) {
 		return Repo{}, fmt.Errorf("invalid repo %q, want \"owner/name\"", s)
 	}
 	return Repo{Owner: owner, Name: name}, nil
+}
+
+// ExpandPath expands a leading "~" or "~/" to the current user's home
+// directory. Other paths are returned unchanged.
+func ExpandPath(p string) (string, error) {
+	switch {
+	case p == "~":
+		return os.UserHomeDir()
+	case strings.HasPrefix(p, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, p[2:]), nil
+	default:
+		return p, nil
+	}
+}
+
+// MatchRepoPath returns the path mapped for repoName, preferring an exact key
+// before evaluating wildcard patterns such as "fcmb/*". Mapped paths may use
+// {{.Owner}}, {{.Repo}}, and {{.RepoName}} template variables, and are expanded
+// through ExpandPath before being returned.
+func MatchRepoPath(repoName string, repoPaths map[string]string) (string, bool, error) {
+	repoName = strings.TrimSpace(repoName)
+	if repoName == "" || len(repoPaths) == 0 {
+		return "", false, nil
+	}
+	if p, ok := repoPaths[repoName]; ok {
+		expanded, err := expandRepoPathMapping(p, repoName)
+		return expanded, true, err
+	}
+
+	patterns := make([]string, 0, len(repoPaths))
+	for pattern := range repoPaths {
+		if strings.ContainsAny(pattern, "*?[") {
+			patterns = append(patterns, pattern)
+		}
+	}
+	sort.Strings(patterns)
+	for _, pattern := range patterns {
+		ok, err := path.Match(pattern, repoName)
+		if err != nil {
+			return "", false, fmt.Errorf("repoPaths pattern %q: %w", pattern, err)
+		}
+		if !ok {
+			continue
+		}
+		expanded, err := expandRepoPathMapping(repoPaths[pattern], repoName)
+		return expanded, true, err
+	}
+	return "", false, nil
+}
+
+func expandRepoPathMapping(p, repoName string) (string, error) {
+	if strings.Contains(p, "{{") {
+		r, err := ParseRepo(repoName)
+		if err != nil {
+			return "", err
+		}
+		tmpl, err := template.New("repoPath").Option("missingkey=error").Parse(p)
+		if err != nil {
+			return "", fmt.Errorf("repoPaths template %q: %w", p, err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, struct {
+			Owner    string
+			Repo     string
+			RepoName string
+		}{
+			Owner:    r.Owner,
+			Repo:     r.Name,
+			RepoName: repoName,
+		}); err != nil {
+			return "", fmt.Errorf("repoPaths template %q: %w", p, err)
+		}
+		p = buf.String()
+	}
+	return ExpandPath(p)
 }
 
 // ParsedRepos returns the configured repos parsed into Repo values.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -105,6 +106,100 @@ notificationsSections:
 	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
 		c.NotificationsSections[0].Limit != 15 {
 		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
+	}
+}
+
+func TestUnmarshalPagerRepoPathsAndGit(t *testing.T) {
+	const y = `
+pager:
+  diff: delta --paging=always
+repoPaths:
+  fcmb/api: ~/src/fcmb-api
+  fcmb/*: ~/src/fcmb/{{.Repo}}
+git:
+  remote: upstream
+  prBranchTemplate: review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Pager.Diff != "delta --paging=always" {
+		t.Fatalf("pager.diff = %q", c.Pager.Diff)
+	}
+	if c.RepoPaths["fcmb/api"] != "~/src/fcmb-api" || c.RepoPaths["fcmb/*"] != "~/src/fcmb/{{.Repo}}" {
+		t.Fatalf("repoPaths = %+v", c.RepoPaths)
+	}
+	if c.Git.Remote != "upstream" || c.Git.PRBranchTemplate != "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}" {
+		t.Fatalf("git = %+v", c.Git)
+	}
+}
+
+func TestPagerDiffCommandDefaults(t *testing.T) {
+	t.Setenv("PAGER", "bat --plain")
+	if got := (Pager{}).DiffCommand(); got != "bat --plain" {
+		t.Fatalf("DiffCommand() = %q, want env pager", got)
+	}
+	t.Setenv("PAGER", "")
+	if got := (Pager{}).DiffCommand(); got != "less -R" {
+		t.Fatalf("DiffCommand() = %q, want less -R fallback", got)
+	}
+	if got := (Pager{Diff: "delta"}).DiffCommand(); got != "delta" {
+		t.Fatalf("DiffCommand() = %q, want configured command", got)
+	}
+}
+
+func TestGitDefaults(t *testing.T) {
+	var g Git
+	if got := g.RemoteName(); got != "origin" {
+		t.Fatalf("RemoteName() = %q, want origin", got)
+	}
+	if got := g.BranchTemplate(); got != "pr-{{.PrIndex}}" {
+		t.Fatalf("BranchTemplate() = %q, want default template", got)
+	}
+	g = Git{Remote: "upstream", PRBranchTemplate: "review/{{.PrIndex}}"}
+	if got := g.RemoteName(); got != "upstream" {
+		t.Fatalf("RemoteName() = %q, want upstream", got)
+	}
+	if got := g.BranchTemplate(); got != "review/{{.PrIndex}}" {
+		t.Fatalf("BranchTemplate() = %q, want configured template", got)
+	}
+}
+
+func TestMatchRepoPathExactBeforeWildcardAndExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths := map[string]string{
+		"fcmb/*":   "~/src/fcmb/{{.Repo}}",
+		"fcmb/api": "~/src/exact",
+	}
+	got, ok, err := MatchRepoPath("fcmb/api", paths)
+	if err != nil {
+		t.Fatalf("MatchRepoPath exact: %v", err)
+	}
+	if !ok {
+		t.Fatal("MatchRepoPath exact did not match")
+	}
+	if want := filepath.Join(home, "src", "exact"); got != want {
+		t.Fatalf("MatchRepoPath exact = %q, want %q", got, want)
+	}
+
+	got, ok, err = MatchRepoPath("fcmb/web", paths)
+	if err != nil {
+		t.Fatalf("MatchRepoPath wildcard: %v", err)
+	}
+	if !ok {
+		t.Fatal("MatchRepoPath wildcard did not match")
+	}
+	if want := filepath.Join(home, "src", "fcmb", "web"); got != want {
+		t.Fatalf("MatchRepoPath wildcard = %q, want %q", got, want)
+	}
+}
+
+func TestMatchRepoPathRejectsBadWildcard(t *testing.T) {
+	_, _, err := MatchRepoPath("fcmb/api", map[string]string{"fcmb/[": "/tmp/repo"})
+	if err == nil || !strings.Contains(err.Error(), "fcmb/[") {
+		t.Fatalf("MatchRepoPath bad wildcard error = %v", err)
 	}
 }
 

--- a/internal/data/mutation.go
+++ b/internal/data/mutation.go
@@ -1,0 +1,68 @@
+package data
+
+// ItemKind identifies whether a repo item is a pull request or an issue.
+type ItemKind string
+
+const (
+	ItemKindPull  ItemKind = "pull"
+	ItemKindIssue ItemKind = "issue"
+)
+
+// ItemRef identifies one mutable repo item.
+type ItemRef struct {
+	Owner  string
+	Repo   string
+	Number int64
+	Kind   ItemKind
+}
+
+// ItemState is the mutable open/closed state shared by issues and pulls.
+type ItemState string
+
+const (
+	ItemStateOpen   ItemState = "open"
+	ItemStateClosed ItemState = "closed"
+)
+
+// MergeStyle is the server-supported pull-request merge strategy.
+type MergeStyle string
+
+const (
+	MergeStyleMerge           MergeStyle = "merge"
+	MergeStyleRebase          MergeStyle = "rebase"
+	MergeStyleRebaseMerge     MergeStyle = "rebase-merge"
+	MergeStyleSquash          MergeStyle = "squash"
+	MergeStyleFastForwardOnly MergeStyle = "fast-forward-only"
+)
+
+// MergeOptions carries the editable fields for merging a pull request.
+type MergeOptions struct {
+	Style        MergeStyle
+	Title        string
+	Message      string
+	DeleteBranch bool
+	ForceMerge   bool
+	HeadCommitID string
+}
+
+// PullReviewEvent is the user's review action. The transport maps these event
+// names onto Gitea's submitted review states.
+type PullReviewEvent string
+
+const (
+	PullReviewEventApprove        PullReviewEvent = "approve"
+	PullReviewEventRequestChanges PullReviewEvent = "request-changes"
+	PullReviewEventComment        PullReviewEvent = "comment"
+)
+
+const (
+	PullReviewStateApproved       ReviewState = ReviewStateApproved
+	PullReviewStateRequestChanges ReviewState = ReviewStateRequestChanges
+	PullReviewStateComment        ReviewState = ReviewStateComment
+)
+
+// PullReviewOptions carries the submitted review action and body.
+type PullReviewOptions struct {
+	Event PullReviewEvent
+	Body  string
+}

--- a/internal/data/mutation_test.go
+++ b/internal/data/mutation_test.go
@@ -1,0 +1,24 @@
+package data
+
+import "testing"
+
+func TestMutationDomainConstants(t *testing.T) {
+	if ItemKindPull != "pull" || ItemKindIssue != "issue" {
+		t.Fatalf("item kinds = %q/%q, want pull/issue", ItemKindPull, ItemKindIssue)
+	}
+	if ItemStateOpen != "open" || ItemStateClosed != "closed" {
+		t.Fatalf("item states = %q/%q, want open/closed", ItemStateOpen, ItemStateClosed)
+	}
+	if MergeStyleMerge != "merge" ||
+		MergeStyleRebase != "rebase" ||
+		MergeStyleRebaseMerge != "rebase-merge" ||
+		MergeStyleSquash != "squash" ||
+		MergeStyleFastForwardOnly != "fast-forward-only" {
+		t.Fatalf("merge style constants changed")
+	}
+	if PullReviewEventApprove != "approve" ||
+		PullReviewEventRequestChanges != "request-changes" ||
+		PullReviewEventComment != "comment" {
+		t.Fatalf("review event constants changed")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,384 @@
+// Package git contains local checkout helpers for pull requests.
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/gbarany/tea-dash/internal/config"
+)
+
+// RemoteRef is the parsed owner/repo identity from a git remote URL.
+type RemoteRef struct {
+	Host  string
+	Owner string
+	Repo  string
+}
+
+// FullName returns "owner/repo".
+func (r RemoteRef) FullName() string {
+	if r.Owner == "" || r.Repo == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+// MatchesInstanceURL reports whether this remote points at the configured
+// Gitea/Forgejo instance host.
+func (r RemoteRef) MatchesInstanceURL(instanceURL string) bool {
+	want := normalizeRemoteHost(instanceURLHost(instanceURL))
+	if want == "" {
+		return false
+	}
+	return normalizeRemoteHost(r.Host) == want
+}
+
+// ParseRemoteURL parses common HTTPS and SSH git remote URL forms.
+func ParseRemoteURL(raw string) (RemoteRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return RemoteRef{}, errors.New("empty remote URL")
+	}
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return RemoteRef{}, err
+		}
+		owner, repo, err := parseRemotePath(u.Path)
+		if err != nil {
+			return RemoteRef{}, err
+		}
+		return RemoteRef{Host: normalizeRemoteHost(u.Host), Owner: owner, Repo: repo}, nil
+	}
+
+	hostPart, remotePath, ok := strings.Cut(raw, ":")
+	if !ok || hostPart == "" || remotePath == "" {
+		return RemoteRef{}, fmt.Errorf("unsupported remote URL %q", raw)
+	}
+	if at := strings.LastIndex(hostPart, "@"); at >= 0 {
+		hostPart = hostPart[at+1:]
+	}
+	owner, repo, err := parseRemotePath(remotePath)
+	if err != nil {
+		return RemoteRef{}, err
+	}
+	return RemoteRef{Host: normalizeRemoteHost(hostPart), Owner: owner, Repo: repo}, nil
+}
+
+func parseRemotePath(rawPath string) (string, string, error) {
+	p := strings.Trim(rawPath, "/")
+	p = strings.TrimSuffix(p, ".git")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("remote path %q does not contain owner/repo", rawPath)
+	}
+	owner := parts[len(parts)-2]
+	repo := parts[len(parts)-1]
+	if owner == "" || repo == "" {
+		return "", "", fmt.Errorf("remote path %q does not contain owner/repo", rawPath)
+	}
+	return owner, repo, nil
+}
+
+func instanceURLHost(instanceURL string) string {
+	instanceURL = strings.TrimSpace(instanceURL)
+	if instanceURL == "" {
+		return ""
+	}
+	u, err := url.Parse(instanceURL)
+	if err != nil || u.Host == "" {
+		return instanceURL
+	}
+	return u.Host
+}
+
+func normalizeRemoteHost(host string) string {
+	return strings.ToLower(strings.TrimSpace(host))
+}
+
+// ResolveRepoPath resolves repoName to a local checkout path from configured
+// repoPaths first, then from cwd when cwd's origin remote matches repoName and
+// instanceURL.
+func ResolveRepoPath(repoName, cwd, instanceURL string, repoPaths map[string]string) (string, error) {
+	if p, ok, err := config.MatchRepoPath(repoName, repoPaths); err != nil {
+		return "", err
+	} else if ok {
+		return p, nil
+	}
+
+	if cwd != "" {
+		if remoteURL, err := originRemoteURL(cwd); err == nil {
+			if remote, err := ParseRemoteURL(remoteURL); err == nil &&
+				remote.FullName() == strings.TrimSpace(repoName) &&
+				(instanceURL == "" || remote.MatchesInstanceURL(instanceURL)) {
+				return cwd, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no local checkout for %s; configure repoPaths", repoName)
+}
+
+func originRemoteURL(cwd string) (string, error) {
+	configPath, err := gitConfigPath(cwd)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	inOrigin := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") {
+			inOrigin = strings.Contains(line, `remote "origin"`) || strings.Contains(line, `remote 'origin'`)
+			continue
+		}
+		if !inOrigin {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(key) == "url" {
+			return strings.TrimSpace(val), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("origin remote URL not found")
+}
+
+func gitConfigPath(cwd string) (string, error) {
+	gitPath := filepath.Join(cwd, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return filepath.Join(gitPath, "config"), nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("%s is not a gitdir file", gitPath)
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(cwd, gitDir)
+	}
+	return filepath.Join(gitDir, "config"), nil
+}
+
+// BranchNameFromTemplate renders a local branch name for a pull request.
+func BranchNameFromTemplate(tmpl, repoName string, prIndex int64) (string, error) {
+	r, err := config.ParseRepo(repoName)
+	if err != nil {
+		return "", err
+	}
+	tmpl = (config.Git{PRBranchTemplate: tmpl}).BranchTemplate()
+	t, err := template.New("branch").Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, struct {
+		Owner    string
+		Repo     string
+		RepoName string
+		PrIndex  int64
+	}{
+		Owner:    r.Owner,
+		Repo:     r.Name,
+		RepoName: repoName,
+		PrIndex:  prIndex,
+	}); err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(buf.String())
+	if branch == "" {
+		return "", errors.New("branch template rendered an empty branch name")
+	}
+	return branch, nil
+}
+
+// Command is a git command invocation.
+type Command struct {
+	Dir  string
+	Name string
+	Args []string
+}
+
+// Result is a completed command result. Non-zero ExitCode means the process ran
+// and failed; a non-nil Runner error means it could not be started or observed.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Runner runs git commands.
+type Runner interface {
+	Run(context.Context, Command) (Result, error)
+}
+
+// ExecRunner runs git commands with os/exec.
+type ExecRunner struct{}
+
+// Run executes cmd and captures stdout/stderr.
+func (ExecRunner) Run(ctx context.Context, cmd Command) (Result, error) {
+	c := exec.CommandContext(ctx, cmd.Name, cmd.Args...)
+	c.Dir = cmd.Dir
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	res := Result{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: 0}
+	if err == nil {
+		return res, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		res.ExitCode = exitErr.ExitCode()
+		return res, nil
+	}
+	return Result{}, err
+}
+
+// CheckoutOptions configures pull-request checkout.
+type CheckoutOptions struct {
+	RepoName       string
+	CWD            string
+	InstanceURL    string
+	RepoPaths      map[string]string
+	Remote         string
+	BranchTemplate string
+	PrIndex        int64
+	Runner         Runner
+}
+
+// CheckoutPlan is the resolved local checkout plan.
+type CheckoutPlan struct {
+	RepoPath     string
+	Remote       string
+	Branch       string
+	FetchRefspec string
+	RemoteRef    string
+}
+
+// PlanCheckout resolves paths, branch names, and refspecs without running git.
+func PlanCheckout(opts CheckoutOptions) (CheckoutPlan, error) {
+	if opts.PrIndex <= 0 {
+		return CheckoutPlan{}, fmt.Errorf("invalid PR index %d", opts.PrIndex)
+	}
+	repoPath, err := ResolveRepoPath(opts.RepoName, opts.CWD, opts.InstanceURL, opts.RepoPaths)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	remote := (config.Git{Remote: opts.Remote}).RemoteName()
+	branch, err := BranchNameFromTemplate(opts.BranchTemplate, opts.RepoName, opts.PrIndex)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	remoteRef := fmt.Sprintf("refs/remotes/%s/pull/%d/head", remote, opts.PrIndex)
+	return CheckoutPlan{
+		RepoPath:     repoPath,
+		Remote:       remote,
+		Branch:       branch,
+		FetchRefspec: fmt.Sprintf("+refs/pull/%d/head:%s", opts.PrIndex, remoteRef),
+		RemoteRef:    remoteRef,
+	}, nil
+}
+
+// RunCheckout fetches and checks out a pull request branch. It refuses dirty
+// worktrees. Existing local branches are advanced only through --ff-only.
+func RunCheckout(ctx context.Context, opts CheckoutOptions) (CheckoutPlan, error) {
+	plan, err := PlanCheckout(opts)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	status, err := runGit(ctx, runner, plan.RepoPath, "status", "--porcelain")
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	if strings.TrimSpace(status.Stdout) != "" {
+		return CheckoutPlan{}, fmt.Errorf("refusing checkout in dirty worktree %s", plan.RepoPath)
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "fetch", plan.Remote, plan.FetchRefspec); err != nil {
+		return CheckoutPlan{}, err
+	}
+
+	exists, err := branchExists(ctx, runner, plan.RepoPath, plan.Branch)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	if !exists {
+		if _, err := runGit(ctx, runner, plan.RepoPath, "switch", "-c", plan.Branch, plan.RemoteRef); err != nil {
+			return CheckoutPlan{}, err
+		}
+		return plan, nil
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "switch", plan.Branch); err != nil {
+		return CheckoutPlan{}, err
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "merge", "--ff-only", plan.RemoteRef); err != nil {
+		return CheckoutPlan{}, fmt.Errorf("fast-forward existing branch %s: %w", plan.Branch, err)
+	}
+	return plan, nil
+}
+
+func branchExists(ctx context.Context, runner Runner, dir, branch string) (bool, error) {
+	res, err := runner.Run(ctx, Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}})
+	if err != nil {
+		return false, err
+	}
+	switch res.ExitCode {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, commandError(Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}}, res)
+	}
+}
+
+func runGit(ctx context.Context, runner Runner, dir string, args ...string) (Result, error) {
+	cmd := Command{Dir: dir, Name: "git", Args: args}
+	res, err := runner.Run(ctx, cmd)
+	if err != nil {
+		return Result{}, err
+	}
+	if res.ExitCode != 0 {
+		return res, commandError(cmd, res)
+	}
+	return res, nil
+}
+
+func commandError(cmd Command, res Result) error {
+	msg := strings.TrimSpace(res.Stderr)
+	if msg == "" {
+		msg = strings.TrimSpace(res.Stdout)
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("exit %d", res.ExitCode)
+	}
+	return fmt.Errorf("%s %s failed: %s", cmd.Name, strings.Join(cmd.Args, " "), msg)
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,295 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		host   string
+		owner  string
+		repo   string
+		remote string
+	}{
+		{
+			name:   "https with git suffix",
+			raw:    "https://git.example.com/acme/widgets.git",
+			host:   "git.example.com",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "https with port",
+			raw:    "http://git.example.com:3000/acme/widgets",
+			host:   "git.example.com:3000",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "ssh URL with port",
+			raw:    "ssh://git@git.example.com:2222/acme/widgets.git",
+			host:   "git.example.com:2222",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "ssh URL preserves explicit port 443",
+			raw:    "ssh://git@git.example.com:443/acme/widgets.git",
+			host:   "git.example.com:443",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "scp SSH",
+			raw:    "git@git.example.com:acme/widgets.git",
+			host:   "git.example.com",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRemoteURL(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseRemoteURL: %v", err)
+			}
+			if got.Host != tt.host || got.Owner != tt.owner || got.Repo != tt.repo || got.FullName() != tt.remote {
+				t.Fatalf("ParseRemoteURL = %+v, FullName=%q", got, got.FullName())
+			}
+		})
+	}
+}
+
+func TestRemoteMatchesInstanceURL(t *testing.T) {
+	remote, err := ParseRemoteURL("git@gitea.example.com:fcmb/api.git")
+	if err != nil {
+		t.Fatalf("ParseRemoteURL: %v", err)
+	}
+	if !remote.MatchesInstanceURL("https://gitea.example.com") {
+		t.Fatal("remote should match same instance host")
+	}
+	if remote.MatchesInstanceURL("https://other.example.com") {
+		t.Fatal("remote should not match a different instance host")
+	}
+
+	withPort, err := ParseRemoteURL("ssh://git@gitea.example.com:2222/fcmb/api.git")
+	if err != nil {
+		t.Fatalf("ParseRemoteURL with port: %v", err)
+	}
+	if !withPort.MatchesInstanceURL("https://gitea.example.com:2222") {
+		t.Fatal("remote with port should match same instance host and port")
+	}
+	if withPort.MatchesInstanceURL("https://gitea.example.com") {
+		t.Fatal("remote with port should not match instance without that port")
+	}
+}
+
+func TestResolveRepoPathExactWildcardAndCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths := map[string]string{
+		"fcmb/*":   "~/work/fcmb/{{.Repo}}",
+		"fcmb/api": "~/work/exact-api",
+	}
+
+	got, err := ResolveRepoPath("fcmb/api", "/not/used", "https://gitea.example.com", paths)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath exact: %v", err)
+	}
+	if want := filepath.Join(home, "work", "exact-api"); got != want {
+		t.Fatalf("ResolveRepoPath exact = %q, want %q", got, want)
+	}
+
+	got, err = ResolveRepoPath("fcmb/web", "/not/used", "https://gitea.example.com", paths)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath wildcard: %v", err)
+	}
+	if want := filepath.Join(home, "work", "fcmb", "web"); got != want {
+		t.Fatalf("ResolveRepoPath wildcard = %q, want %q", got, want)
+	}
+
+	cwd := makeGitDir(t, "https://gitea.example.com/fcmb/api.git")
+	got, err = ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath cwd: %v", err)
+	}
+	if got != cwd {
+		t.Fatalf("ResolveRepoPath cwd = %q, want %q", got, cwd)
+	}
+}
+
+func TestResolveRepoPathRejectsCWDHostMismatch(t *testing.T) {
+	cwd := makeGitDir(t, "https://other.example.com/fcmb/api.git")
+	_, err := ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	if err == nil || !strings.Contains(err.Error(), "no local checkout") {
+		t.Fatalf("ResolveRepoPath host mismatch error = %v", err)
+	}
+}
+
+func TestBranchNameFromTemplate(t *testing.T) {
+	got, err := BranchNameFromTemplate("review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}", "fcmb/api", 42)
+	if err != nil {
+		t.Fatalf("BranchNameFromTemplate: %v", err)
+	}
+	if got != "review/fcmb-api-42" {
+		t.Fatalf("BranchNameFromTemplate = %q", got)
+	}
+
+	got, err = BranchNameFromTemplate("", "fcmb/api", 42)
+	if err != nil {
+		t.Fatalf("BranchNameFromTemplate default: %v", err)
+	}
+	if got != "pr-42" {
+		t.Fatalf("BranchNameFromTemplate default = %q", got)
+	}
+}
+
+func TestRunCheckoutDirtyTreeRefusal(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{Stdout: " M file.txt\n", ExitCode: 0}}}
+
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:  "fcmb/api",
+		RepoPaths: map[string]string{"fcmb/api": repo},
+		PrIndex:   42,
+		Runner:    runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("RunCheckout dirty error = %v", err)
+	}
+	if len(runner.commands) != 1 || !reflect.DeepEqual(runner.commands[0].Args, []string{"status", "--porcelain"}) {
+		t.Fatalf("commands = %#v", runner.commands)
+	}
+}
+
+func TestRunCheckoutFetchesAndCreatesMissingBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 0}, // fetch
+		{ExitCode: 1}, // show-ref missing branch
+		{ExitCode: 0}, // switch -c
+	}}
+
+	plan, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:       "fcmb/api",
+		RepoPaths:      map[string]string{"fcmb/api": repo},
+		Remote:         "upstream",
+		BranchTemplate: "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}",
+		PrIndex:        42,
+		Runner:         runner,
+	})
+	if err != nil {
+		t.Fatalf("RunCheckout: %v", err)
+	}
+	if plan.Branch != "review/fcmb-api-42" {
+		t.Fatalf("Branch = %q", plan.Branch)
+	}
+	if plan.FetchRefspec != "+refs/pull/42/head:refs/remotes/upstream/pull/42/head" {
+		t.Fatalf("FetchRefspec = %q", plan.FetchRefspec)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"fetch", "upstream", "+refs/pull/42/head:refs/remotes/upstream/pull/42/head"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/review/fcmb-api-42"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "-c", "review/fcmb-api-42", "refs/remotes/upstream/pull/42/head"}},
+	})
+}
+
+func TestRunCheckoutExistingBranchFastForwardOnly(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 0}, // fetch
+		{ExitCode: 0}, // show-ref existing branch
+		{ExitCode: 0}, // switch branch
+		{ExitCode: 0}, // merge --ff-only
+	}}
+
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:  "fcmb/api",
+		RepoPaths: map[string]string{"fcmb/api": repo},
+		PrIndex:   7,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("RunCheckout: %v", err)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"fetch", "origin", "+refs/pull/7/head:refs/remotes/origin/pull/7/head"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/pr-7"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "pr-7"}},
+		{Dir: repo, Name: "git", Args: []string{"merge", "--ff-only", "refs/remotes/origin/pull/7/head"}},
+	})
+}
+
+func TestRunCheckoutMissingRepoPath(t *testing.T) {
+	runner := &fakeRunner{}
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:    "fcmb/api",
+		CWD:         t.TempDir(),
+		InstanceURL: "https://gitea.example.com",
+		PrIndex:     7,
+		Runner:      runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no local checkout") {
+		t.Fatalf("RunCheckout missing repo error = %v", err)
+	}
+	if len(runner.commands) != 0 {
+		t.Fatalf("runner should not be called, commands = %#v", runner.commands)
+	}
+}
+
+func makeGitDir(t *testing.T, remoteURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := "[remote \"origin\"]\n\turl = " + remoteURL + "\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+type fakeRunner struct {
+	results  []Result
+	err      error
+	commands []Command
+}
+
+func (f *fakeRunner) Run(_ context.Context, cmd Command) (Result, error) {
+	f.commands = append(f.commands, cmd)
+	if f.err != nil {
+		return Result{}, f.err
+	}
+	if len(f.results) == 0 {
+		return Result{}, errors.New("unexpected command: " + strings.Join(cmd.Args, " "))
+	}
+	res := f.results[0]
+	f.results = f.results[1:]
+	return res, nil
+}
+
+func assertCommands(t *testing.T, got, want []Command) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands:\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/internal/gitea/diff.go
+++ b/internal/gitea/diff.go
@@ -1,0 +1,21 @@
+package gitea
+
+import (
+	"fmt"
+
+	sdk "code.gitea.io/sdk/gitea"
+)
+
+// GetPullDiff fetches the raw unified diff bytes for a pull request.
+func (c *Client) GetPullDiff(owner, repo string, index int64) ([]byte, error) {
+	var diff []byte
+	err := c.call(func() error {
+		var e error
+		diff, _, e = c.sdk.GetPullRequestDiff(owner, repo, index, sdk.PullRequestDiffOptions{Binary: true})
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get pull diff %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return diff, nil
+}

--- a/internal/gitea/diff_test.go
+++ b/internal/gitea/diff_test.go
@@ -1,0 +1,67 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+)
+
+func TestGetPullDiffReturnsBytes(t *testing.T) {
+	const want = "diff --git a/file.txt b/file.txt\n+hello\n"
+	c := newDiffTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/7.diff" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "token t" {
+			t.Fatalf("Authorization = %q, want token t", got)
+		}
+		fmt.Fprint(w, want)
+	}))
+
+	got, err := c.GetPullDiff("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetPullDiff: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("GetPullDiff = %q, want %q", string(got), want)
+	}
+}
+
+func TestGetPullDiffWrapsErrors(t *testing.T) {
+	c := newDiffTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+
+	_, err := c.GetPullDiff("acme", "widgets", 7)
+	if err == nil {
+		t.Fatal("GetPullDiff expected an error")
+	}
+	if !strings.Contains(err.Error(), "get pull diff acme/widgets#7") {
+		t.Fatalf("GetPullDiff error = %v, want wrapped pull context", err)
+	}
+}
+
+func newDiffTestClient(t *testing.T, diffHandler http.Handler) *Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me","full_name":"Me"}`)
+	})
+	mux.Handle("/api/v1/repos/acme/widgets/pulls/7.diff", diffHandler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -1,0 +1,118 @@
+package gitea
+
+import (
+	"fmt"
+
+	sdk "code.gitea.io/sdk/gitea"
+
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+// AddComment creates an issue/PR comment and maps the returned comment into the
+// domain shape used by detail views.
+func (c *Client) AddComment(owner, repo string, index int64, body string) (data.Comment, error) {
+	var comment *sdk.Comment
+	err := c.call(func() error {
+		var e error
+		comment, _, e = c.sdk.CreateIssueComment(owner, repo, index, sdk.CreateIssueCommentOption{
+			Body: body,
+		})
+		return e
+	})
+	if err != nil {
+		return data.Comment{}, fmt.Errorf("add comment %s/%s#%d: %w", owner, repo, index, err)
+	}
+	mapped := mapComments([]*sdk.Comment{comment})
+	if len(mapped) == 0 {
+		return data.Comment{}, nil
+	}
+	return mapped[0], nil
+}
+
+// SetIssueState opens or closes an issue.
+func (c *Client) SetIssueState(owner, repo string, index int64, state data.ItemState) error {
+	s := sdk.StateType(state)
+	err := c.call(func() error {
+		_, _, e := c.sdk.EditIssue(owner, repo, index, sdk.EditIssueOption{State: &s})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("set issue state %s/%s#%d to %s: %w", owner, repo, index, state, err)
+	}
+	return nil
+}
+
+// SetPullState opens or closes a pull request.
+func (c *Client) SetPullState(owner, repo string, index int64, state data.ItemState) error {
+	s := sdk.StateType(state)
+	err := c.call(func() error {
+		_, _, e := c.sdk.EditPullRequest(owner, repo, index, sdk.EditPullRequestOption{State: &s})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("set pull state %s/%s#%d to %s: %w", owner, repo, index, state, err)
+	}
+	return nil
+}
+
+// MergePullRequest merges a pull request with the requested strategy and
+// optional server-side controls.
+func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {
+	deleteBranch := opt.DeleteBranch
+	var merged bool
+	err := c.call(func() error {
+		var e error
+		merged, _, e = c.sdk.MergePullRequest(owner, repo, index, sdk.MergePullRequestOption{
+			Style:                  sdk.MergeStyle(opt.Style),
+			Title:                  opt.Title,
+			Message:                opt.Message,
+			DeleteBranchAfterMerge: &deleteBranch,
+			ForceMerge:             opt.ForceMerge,
+			HeadCommitId:           opt.HeadCommitID,
+		})
+		return e
+	})
+	if err != nil {
+		return false, fmt.Errorf("merge pull %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return merged, nil
+}
+
+// SubmitPullReview creates a submitted pull-request review.
+func (c *Client) SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error) {
+	event, err := mapPullReviewEvent(opt.Event)
+	if err != nil {
+		return data.Review{}, fmt.Errorf("submit pull review %s/%s#%d: %w", owner, repo, index, err)
+	}
+
+	var review *sdk.PullReview
+	err = c.call(func() error {
+		var e error
+		review, _, e = c.sdk.CreatePullReview(owner, repo, index, sdk.CreatePullReviewOptions{
+			State: event,
+			Body:  opt.Body,
+		})
+		return e
+	})
+	if err != nil {
+		return data.Review{}, fmt.Errorf("submit pull review %s/%s#%d: %w", owner, repo, index, err)
+	}
+	mapped := mapReviews([]*sdk.PullReview{review})
+	if len(mapped) == 0 {
+		return data.Review{}, nil
+	}
+	return mapped[0], nil
+}
+
+func mapPullReviewEvent(event data.PullReviewEvent) (sdk.ReviewStateType, error) {
+	switch event {
+	case data.PullReviewEventApprove:
+		return sdk.ReviewStateApproved, nil
+	case data.PullReviewEventRequestChanges:
+		return sdk.ReviewStateRequestChanges, nil
+	case data.PullReviewEventComment:
+		return sdk.ReviewStateComment, nil
+	default:
+		return "", fmt.Errorf("unsupported pull review event %q", event)
+	}
+}

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -1,0 +1,209 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+func mutationClient(t *testing.T, mutate http.HandlerFunc) *Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me","full_name":"Me"}`)
+	})
+	mux.HandleFunc("/", mutate)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func decodeMutationBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	return body
+}
+
+func TestAddCommentPostsBodyAndMapsResponse(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/7/comments" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		if body["body"] != "hello world" {
+			t.Fatalf("body = %#v", body)
+		}
+		fmt.Fprint(w, `{"id":10,"body":"hello world","created_at":"2026-07-01T10:00:00Z","user":{"login":"alice"}}`)
+	})
+
+	got, err := c.AddComment("acme", "widgets", 7, "hello world")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	wantCreated := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if got.Author != "alice" || got.Body != "hello world" || !got.CreatedAt.Equal(wantCreated) {
+		t.Fatalf("comment = %+v", got)
+	}
+}
+
+func TestSetIssueStatePatchesState(t *testing.T) {
+	var states []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/42" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		state, _ := body["state"].(string)
+		states = append(states, state)
+		fmt.Fprintf(w, `{"number":42,"state":%q}`, state)
+	})
+
+	if err := c.SetIssueState("acme", "widgets", 42, data.ItemStateClosed); err != nil {
+		t.Fatalf("close issue: %v", err)
+	}
+	if err := c.SetIssueState("acme", "widgets", 42, data.ItemStateOpen); err != nil {
+		t.Fatalf("reopen issue: %v", err)
+	}
+	if len(states) != 2 || states[0] != "closed" || states[1] != "open" {
+		t.Fatalf("states = %v, want [closed open]", states)
+	}
+}
+
+func TestSetPullStatePatchesPullState(t *testing.T) {
+	var states []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/43" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		state, _ := body["state"].(string)
+		states = append(states, state)
+		fmt.Fprintf(w, `{"number":43,"state":%q}`, state)
+	})
+
+	if err := c.SetPullState("acme", "widgets", 43, data.ItemStateClosed); err != nil {
+		t.Fatalf("close pull: %v", err)
+	}
+	if err := c.SetPullState("acme", "widgets", 43, data.ItemStateOpen); err != nil {
+		t.Fatalf("reopen pull: %v", err)
+	}
+	if len(states) != 2 || states[0] != "closed" || states[1] != "open" {
+		t.Fatalf("states = %v, want [closed open]", states)
+	}
+}
+
+func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44/merge" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		checks := map[string]any{
+			"Do":                        "squash",
+			"MergeTitleField":           "merge title",
+			"MergeMessageField":         "merge message",
+			"delete_branch_after_merge": true,
+			"force_merge":               true,
+			"head_commit_id":            "abc123",
+		}
+		for key, want := range checks {
+			if body[key] != want {
+				t.Fatalf("%s = %#v, want %#v in body %#v", key, body[key], want, body)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	merged, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{
+		Style:        data.MergeStyleSquash,
+		Title:        "merge title",
+		Message:      "merge message",
+		DeleteBranch: true,
+		ForceMerge:   true,
+		HeadCommitID: "abc123",
+	})
+	if err != nil {
+		t.Fatalf("MergePullRequest: %v", err)
+	}
+	if !merged {
+		t.Fatal("merged = false, want true")
+	}
+}
+
+func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/45/reviews" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		if body["event"] != "REQUEST_CHANGES" || body["body"] != "needs work" {
+			t.Fatalf("body = %#v", body)
+		}
+		fmt.Fprint(w, `{"id":2,"state":"REQUEST_CHANGES","body":"needs work","submitted_at":"2026-07-01T11:00:00Z","user":{"login":"reviewer"}}`)
+	})
+
+	got, err := c.SubmitPullReview("acme", "widgets", 45, data.PullReviewOptions{
+		Event: data.PullReviewEventRequestChanges,
+		Body:  "needs work",
+	})
+	if err != nil {
+		t.Fatalf("SubmitPullReview: %v", err)
+	}
+	wantSubmitted := time.Date(2026, 7, 1, 11, 0, 0, 0, time.UTC)
+	if got.Author != "reviewer" || got.State != data.ReviewStateRequestChanges || got.Body != "needs work" || !got.SubmittedAt.Equal(wantSubmitted) {
+		t.Fatalf("review = %+v", got)
+	}
+}
+
+func TestAddCommentWrapsServerError(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/7/comments" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	_, err := c.AddComment("acme", "widgets", 7, "hello")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "add comment acme/widgets#7") || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %q", err)
+	}
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,50 @@
+// Package shell builds and runs user shell commands through the user's shell.
+package shell
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// Command is an executable shell command plus execution context.
+type Command struct {
+	Name  string
+	Args  []string
+	Stdin []byte
+	Dir   string
+}
+
+// BuildCommand builds a command that runs command through "$SHELL -c", falling
+// back to /bin/sh when SHELL is unset. It does not execute the command.
+func BuildCommand(command string, stdin []byte, dir string) Command {
+	name := os.Getenv("SHELL")
+	if name == "" {
+		name = "/bin/sh"
+	}
+	return Command{
+		Name:  name,
+		Args:  []string{"-c", command},
+		Stdin: stdin,
+		Dir:   dir,
+	}
+}
+
+// Runner runs shell commands.
+type Runner interface {
+	Run(context.Context, Command) ([]byte, error)
+}
+
+// ExecRunner runs commands through os/exec.
+type ExecRunner struct{}
+
+// Run executes cmd and returns combined stdout/stderr.
+func (ExecRunner) Run(ctx context.Context, cmd Command) ([]byte, error) {
+	c := exec.CommandContext(ctx, cmd.Name, cmd.Args...)
+	c.Dir = cmd.Dir
+	if cmd.Stdin != nil {
+		c.Stdin = bytes.NewReader(cmd.Stdin)
+	}
+	return c.CombinedOutput()
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,39 @@
+package shell
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestBuildCommandUsesShellCWithStdinAndDir(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+
+	cmd := BuildCommand("delta --paging=always", []byte("diff"), "/tmp/repo")
+
+	if cmd.Name != "/bin/zsh" {
+		t.Fatalf("Name = %q, want /bin/zsh", cmd.Name)
+	}
+	if want := []string{"-c", "delta --paging=always"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
+	}
+	if !bytes.Equal(cmd.Stdin, []byte("diff")) {
+		t.Fatalf("Stdin = %q, want diff bytes", string(cmd.Stdin))
+	}
+	if cmd.Dir != "/tmp/repo" {
+		t.Fatalf("Dir = %q, want /tmp/repo", cmd.Dir)
+	}
+}
+
+func TestBuildCommandDefaultsToBinSh(t *testing.T) {
+	t.Setenv("SHELL", "")
+
+	cmd := BuildCommand("less -R", nil, "")
+
+	if cmd.Name != "/bin/sh" {
+		t.Fatalf("Name = %q, want /bin/sh", cmd.Name)
+	}
+	if want := []string{"-c", "less -R"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
+	}
+}

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -1,0 +1,77 @@
+// Package actions defines UI-level action intents. It deliberately carries no
+// transport or local-git behavior; callers provide a dispatcher seam.
+package actions
+
+// Kind identifies the action the user requested.
+type Kind string
+
+const (
+	KindComment      Kind = "comment"
+	KindMerge        Kind = "merge"
+	KindClose        Kind = "close"
+	KindReopen       Kind = "reopen"
+	KindReview       Kind = "review"
+	KindExternalDiff Kind = "external_diff"
+	KindCheckout     Kind = "checkout"
+)
+
+// RowKind identifies the selected row's domain type.
+type RowKind string
+
+const (
+	RowKindPullRequest RowKind = "pull_request"
+	RowKindIssue       RowKind = "issue"
+)
+
+// PromptMode records which kind of prompt produced a submitted value.
+type PromptMode string
+
+const (
+	PromptConfirm PromptMode = "confirm"
+	PromptText    PromptMode = "text"
+	PromptPicker  PromptMode = "picker"
+)
+
+// Target is the immutable row/section context for an action.
+type Target struct {
+	SectionID   int
+	SectionType string
+	RowKind     RowKind
+	Repo        string
+	Number      int64
+	Title       string
+	URL         string
+}
+
+// Prompt carries the prompt payload that was submitted with the intent.
+type Prompt struct {
+	Mode  PromptMode
+	Value string
+	Label string
+}
+
+// Intent is the value passed through the app-level dispatcher seam.
+type Intent struct {
+	Kind   Kind
+	Target Target
+	Prompt Prompt
+}
+
+// ResultStatus describes feedback returned by a dispatcher command.
+type ResultStatus string
+
+const (
+	ResultStarted   ResultStatus = "start"
+	ResultSucceeded ResultStatus = "success"
+	ResultErrored   ResultStatus = "error"
+	ResultCanceled  ResultStatus = "cancel"
+)
+
+// ResultMsg is an optional Bubble Tea message a dispatcher can return so the UI
+// can show action feedback without knowing how the action was executed.
+type ResultMsg struct {
+	Intent  Intent
+	Status  ResultStatus
+	Message string
+	Err     error
+}

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -1,0 +1,39 @@
+package actions
+
+import "testing"
+
+func TestKindConstants(t *testing.T) {
+	tests := map[Kind]string{
+		KindComment:      "comment",
+		KindMerge:        "merge",
+		KindClose:        "close",
+		KindReopen:       "reopen",
+		KindReview:       "review",
+		KindExternalDiff: "external_diff",
+		KindCheckout:     "checkout",
+	}
+	for got, want := range tests {
+		if string(got) != want {
+			t.Fatalf("kind constant = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestIntentCarriesTargetAndPrompt(t *testing.T) {
+	intent := Intent{
+		Kind: KindComment,
+		Target: Target{
+			SectionID:   2,
+			SectionType: "pr",
+			RowKind:     RowKindPullRequest,
+			Repo:        "gbarany/tea-dash",
+			Number:      42,
+			Title:       "Add action UI",
+			URL:         "https://example.test/pr/42",
+		},
+		Prompt: Prompt{Mode: PromptText, Value: "ship it"},
+	}
+	if intent.Kind != KindComment || intent.Target.Repo != "gbarany/tea-dash" || intent.Prompt.Value != "ship it" {
+		t.Fatalf("intent did not retain values: %+v", intent)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -197,6 +197,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case actions.ResultMsg:
 		m.notice = ""
 		m.actionFeedback = m.actionFeedback.Set(feedbackFromActionResult(msg))
+		if msg.Status == actions.ResultSucceeded {
+			m.clearPreviewCacheForAction(msg.Intent.Target)
+			if s := m.getCurrSection(); s != nil &&
+				s.GetId() == msg.Intent.Target.SectionID &&
+				s.GetType() == msg.Intent.Target.SectionType {
+				if m.ctx.PreviewOpen {
+					m.syncSidebar()
+				}
+				return m, tea.Batch(s.FetchRows(), m.enrichCurrRow())
+			}
+		}
 		return m, nil
 
 	case enrichedMsg:
@@ -355,7 +366,7 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x close · q quit"))
+		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x/X close/reopen · v review · d diff · C checkout · q quit"))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
@@ -531,6 +542,21 @@ func (m *Model) clearSelectedPreviewCache() {
 			delete(m.issueDetails, key)
 			delete(m.issueEnrichErr, key)
 		}
+	}
+}
+
+func (m *Model) clearPreviewCacheForAction(target actions.Target) {
+	if target.Repo == "" || target.Number <= 0 {
+		return
+	}
+	key := fmt.Sprintf("%s#%d", target.Repo, target.Number)
+	switch target.RowKind {
+	case actions.RowKindPullRequest:
+		delete(m.pullDetails, key)
+		delete(m.pullEnrichErr, key)
+	case actions.RowKindIssue:
+		delete(m.issueDetails, key)
+		delete(m.issueEnrichErr, key)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,9 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/actions"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionfeedback"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionprompt"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -36,6 +39,11 @@ type Model struct {
 	issues        []section.Section
 	notifications []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
+
+	actionDispatcher func(actions.Intent) tea.Cmd
+	actionPrompt     actionprompt.Model
+	pendingAction    actions.Intent
+	actionFeedback   actionfeedback.Model
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
 	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
@@ -107,6 +115,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		tabs:           tabs.New(ctx),
 		sidebar:        sidebar.New(ctx),
 		tasks:          tasks,
+		actionPrompt:   actionprompt.New(),
+		actionFeedback: actionfeedback.New(),
 		pullDetails:    map[string]*data.PullDetail{},
 		issueDetails:   map[string]*data.IssueDetail{},
 		pullEnrichErr:  map[string]error{},
@@ -116,6 +126,12 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
 	m.setCurrentViewSections(buildSections(view, ctx))
 	return m
+}
+
+// SetActionDispatcher wires the frontend action-intent seam. The dispatcher is
+// responsible for all backend or local-git side effects.
+func (m *Model) SetActionDispatcher(dispatcher func(actions.Intent) tea.Cmd) {
+	m.actionDispatcher = dispatcher
 }
 
 // buildSections constructs the section models for a view from its config list.
@@ -146,6 +162,9 @@ func (m Model) Init() tea.Cmd {
 
 // Update routes messages: layout, async results, keys, then generic fallthrough.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(tea.KeyPressMsg); ok && m.actionPrompt.Active() {
+		return m, m.updateActionPrompt(msg)
+	}
 	// While the current section's search bar is focused, route key presses
 	// straight to it so typing isn't eaten by nav/quit keys. Resize and async
 	// messages still flow through the normal switch below.
@@ -173,6 +192,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case openFailedMsg:
 		m.notice = fmt.Sprintf("Couldn't open browser: %v — copy: %s", msg.err, msg.url)
+		return m, nil
+
+	case actions.ResultMsg:
+		m.notice = ""
+		m.actionFeedback = m.actionFeedback.Set(feedbackFromActionResult(msg))
 		return m, nil
 
 	case enrichedMsg:
@@ -209,6 +233,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m.notice = "" // any key dismisses a transient notice
 		switch {
+		case key.Matches(msg, m.keys.Comment):
+			return m, m.startAction(actions.KindComment)
+		case key.Matches(msg, m.keys.Merge):
+			return m, m.startAction(actions.KindMerge)
+		case key.Matches(msg, m.keys.Close):
+			return m, m.startAction(actions.KindClose)
+		case key.Matches(msg, m.keys.Reopen):
+			return m, m.startAction(actions.KindReopen)
+		case key.Matches(msg, m.keys.Review):
+			return m, m.startAction(actions.KindReview)
+		case key.Matches(msg, m.keys.ExternalDiff):
+			return m, m.startAction(actions.KindExternalDiff)
+		case key.Matches(msg, m.keys.Checkout):
+			return m, m.startAction(actions.KindCheckout)
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.Refresh):
@@ -302,8 +340,12 @@ func (m Model) View() tea.View {
 		parts = append(parts, tv)
 	}
 	status := m.statusLine()
-	if m.notice != "" {
+	if m.actionPrompt.Active() {
+		status = m.actionPrompt.View(m.ctx.ScreenWidth - 4)
+	} else if m.notice != "" {
 		status = m.ctx.Styles.ErrorText.Render(m.notice)
+	} else if !m.actionFeedback.Empty() {
+		status = m.actionFeedback.View(m.ctx.ScreenWidth - 4)
 	}
 	body := ""
 	if s := m.getCurrSection(); s != nil {
@@ -313,7 +355,7 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · e expand · r refresh · o open · q quit"))
+		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x close · q quit"))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
@@ -549,6 +591,177 @@ func (m Model) openSelected() tea.Cmd {
 			return openFailedMsg{url: url, err: err}
 		}
 		return nil
+	}
+}
+
+func (m *Model) startAction(kind actions.Kind) tea.Cmd {
+	target, ok := m.selectedActionTarget()
+	if !ok {
+		m.notice = "Select a row before running an action."
+		return nil
+	}
+	if actionRequiresPullRequest(kind) && target.RowKind != actions.RowKindPullRequest {
+		m.notice = fmt.Sprintf("%s is only available for pull requests.", actionLabel(kind))
+		return nil
+	}
+	intent := actions.Intent{
+		Kind:   kind,
+		Target: target,
+		Prompt: actions.Prompt{Mode: promptModeForAction(kind)},
+	}
+	m.pendingAction = intent
+	m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(kind, target))
+	return nil
+}
+
+func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
+	var result actionprompt.Result
+	var cmd tea.Cmd
+	m.actionPrompt, result, cmd = m.actionPrompt.Update(msg)
+	if result.Canceled {
+		m.pendingAction = actions.Intent{}
+		m.actionFeedback = m.actionFeedback.Set(actionfeedback.Cancel("Action cancelled."))
+		return cmd
+	}
+	if !result.Submitted {
+		return cmd
+	}
+	intent := m.pendingAction
+	intent.Prompt.Value = result.Value
+	intent.Prompt.Label = result.Label
+	m.pendingAction = actions.Intent{}
+	if m.actionDispatcher == nil {
+		m.notice = "Action not wired yet."
+		return cmd
+	}
+	m.actionFeedback = m.actionFeedback.Set(actionfeedback.Start(actionStartText(intent)))
+	dispatchCmd := m.actionDispatcher(intent)
+	if cmd == nil {
+		return dispatchCmd
+	}
+	if dispatchCmd == nil {
+		return cmd
+	}
+	return tea.Batch(cmd, dispatchCmd)
+}
+
+func (m Model) selectedActionTarget() (actions.Target, bool) {
+	s := m.getCurrSection()
+	row := m.getCurrRowData()
+	if s == nil || row == nil {
+		return actions.Target{}, false
+	}
+	rowKind := actions.RowKind(s.GetType())
+	switch row.(type) {
+	case data.PullRequest:
+		rowKind = actions.RowKindPullRequest
+	case data.Issue:
+		rowKind = actions.RowKindIssue
+	}
+	return actions.Target{
+		SectionID:   s.GetId(),
+		SectionType: s.GetType(),
+		RowKind:     rowKind,
+		Repo:        row.GetRepoNameWithOwner(),
+		Number:      row.GetNumber(),
+		Title:       row.GetTitle(),
+		URL:         row.GetURL(),
+	}, true
+}
+
+func actionRequiresPullRequest(kind actions.Kind) bool {
+	switch kind {
+	case actions.KindMerge, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
+		return true
+	default:
+		return false
+	}
+}
+
+func promptModeForAction(kind actions.Kind) actions.PromptMode {
+	switch kind {
+	case actions.KindComment:
+		return actions.PromptText
+	case actions.KindReview:
+		return actions.PromptPicker
+	default:
+		return actions.PromptConfirm
+	}
+}
+
+func promptConfigForAction(kind actions.Kind, target actions.Target) actionprompt.Config {
+	title := fmt.Sprintf("%s #%d", actionLabel(kind), target.Number)
+	message := fmt.Sprintf("%s - %s", target.Repo, target.Title)
+	switch kind {
+	case actions.KindComment:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Write a comment",
+		}
+	case actions.KindReview:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModePicker,
+			Title:   title,
+			Message: message,
+			Options: []actionprompt.Option{
+				{Label: "Comment", Value: "comment"},
+				{Label: "Approve", Value: "approve"},
+				{Label: "Request changes", Value: "request_changes"},
+			},
+		}
+	default:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModeConfirm,
+			Title:   title,
+			Message: message,
+		}
+	}
+}
+
+func actionLabel(kind actions.Kind) string {
+	switch kind {
+	case actions.KindComment:
+		return "Comment"
+	case actions.KindMerge:
+		return "Merge"
+	case actions.KindClose:
+		return "Close"
+	case actions.KindReopen:
+		return "Reopen"
+	case actions.KindReview:
+		return "Review"
+	case actions.KindExternalDiff:
+		return "External diff"
+	case actions.KindCheckout:
+		return "Checkout"
+	default:
+		return string(kind)
+	}
+}
+
+func actionStartText(intent actions.Intent) string {
+	return fmt.Sprintf("Starting %s for %s#%d.", actionLabel(intent.Kind), intent.Target.Repo, intent.Target.Number)
+}
+
+func feedbackFromActionResult(msg actions.ResultMsg) actionfeedback.Message {
+	text := msg.Message
+	if text == "" && msg.Err != nil {
+		text = msg.Err.Error()
+	}
+	if text == "" {
+		text = actionStartText(msg.Intent)
+	}
+	switch msg.Status {
+	case actions.ResultSucceeded:
+		return actionfeedback.Success(text)
+	case actions.ResultErrored:
+		return actionfeedback.Error(text)
+	case actions.ResultCanceled:
+		return actionfeedback.Cancel(text)
+	default:
+		return actionfeedback.Start(text)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -708,7 +708,7 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 	switch kind {
 	case actions.KindComment:
 		return actions.PromptText
-	case actions.KindReview:
+	case actions.KindMerge, actions.KindReview:
 		return actions.PromptPicker
 	default:
 		return actions.PromptConfirm
@@ -735,6 +735,19 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 				{Label: "Comment", Value: "comment"},
 				{Label: "Approve", Value: "approve"},
 				{Label: "Request changes", Value: "request_changes"},
+			},
+		}
+	case actions.KindMerge:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModePicker,
+			Title:   title,
+			Message: message,
+			Options: []actionprompt.Option{
+				{Label: "Merge", Value: string(data.MergeStyleMerge)},
+				{Label: "Squash", Value: string(data.MergeStyleSquash)},
+				{Label: "Rebase", Value: string(data.MergeStyleRebase)},
+				{Label: "Rebase merge", Value: string(data.MergeStyleRebaseMerge)},
+				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
 			},
 		}
 	default:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -44,6 +44,8 @@ type Model struct {
 	actionPrompt     actionprompt.Model
 	pendingAction    actions.Intent
 	actionFeedback   actionfeedback.Model
+	copyToClipboard  func(string) error
+	showHelp         bool
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
 	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
@@ -67,6 +69,11 @@ type Model struct {
 type openFailedMsg struct {
 	url string
 	err error
+}
+
+type copyResultMsg struct {
+	value string
+	err   error
 }
 
 // enrichedMsg carries the result of a lazy detail fetch back to the root, keyed
@@ -110,17 +117,18 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 	}
 
 	m := Model{
-		ctx:            ctx,
-		keys:           defaultKeyMap(),
-		tabs:           tabs.New(ctx),
-		sidebar:        sidebar.New(ctx),
-		tasks:          tasks,
-		actionPrompt:   actionprompt.New(),
-		actionFeedback: actionfeedback.New(),
-		pullDetails:    map[string]*data.PullDetail{},
-		issueDetails:   map[string]*data.IssueDetail{},
-		pullEnrichErr:  map[string]error{},
-		issueEnrichErr: map[string]error{},
+		ctx:             ctx,
+		keys:            defaultKeyMap(),
+		tabs:            tabs.New(ctx),
+		sidebar:         sidebar.New(ctx),
+		tasks:           tasks,
+		actionPrompt:    actionprompt.New(),
+		actionFeedback:  actionfeedback.New(),
+		copyToClipboard: writeClipboard,
+		pullDetails:     map[string]*data.PullDetail{},
+		issueDetails:    map[string]*data.IssueDetail{},
+		pullEnrichErr:   map[string]error{},
+		issueEnrichErr:  map[string]error{},
 	}
 	// Build only the starting view's sections; the other slice stays nil until
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
@@ -192,6 +200,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case openFailedMsg:
 		m.notice = fmt.Sprintf("Couldn't open browser: %v — copy: %s", msg.err, msg.url)
+		return m, nil
+
+	case copyResultMsg:
+		if msg.err != nil {
+			m.notice = fmt.Sprintf("Couldn't copy: %v", msg.err)
+		} else {
+			m.notice = fmt.Sprintf("Copied %s.", msg.value)
+		}
 		return m, nil
 
 	case actions.ResultMsg:
@@ -269,8 +285,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, s.FetchRows()
 			}
 			return m, nil
+		case key.Matches(msg, m.keys.RefreshAll):
+			return m, m.refreshAllSections()
 		case key.Matches(msg, m.keys.Open):
 			return m, m.openSelected()
+		case key.Matches(msg, m.keys.CopyNumber):
+			return m, m.copySelectedNumber()
+		case key.Matches(msg, m.keys.CopyURL):
+			return m, m.copySelectedURL()
+		case key.Matches(msg, m.keys.Help):
+			m.showHelp = !m.showHelp
+			return m, nil
 		case key.Matches(msg, m.keys.NextSection):
 			if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 				m.currSectionId++
@@ -366,10 +391,17 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x/X close/reopen · v review · d diff · C checkout · q quit"))
+		helpStyle.Render(m.helpLine()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
+}
+
+func (m Model) helpLine() string {
+	if m.showHelp {
+		return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout · q quit"
+	}
+	return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh · c comment · m merge · d/ctrl+t diff · C/space checkout · ? help · q quit"
 }
 
 // currentViewSections returns the section slice for the active view.
@@ -618,6 +650,51 @@ func (m Model) openSelected() tea.Cmd {
 		}
 		return nil
 	}
+}
+
+func (m Model) copySelectedNumber() tea.Cmd {
+	row := m.getCurrRowData()
+	if row == nil {
+		return nil
+	}
+	return m.copyValue(fmt.Sprintf("%d", row.GetNumber()))
+}
+
+func (m Model) copySelectedURL() tea.Cmd {
+	row := m.getCurrRowData()
+	if row == nil || row.GetURL() == "" {
+		return nil
+	}
+	return m.copyValue(row.GetURL())
+}
+
+func (m Model) copyValue(value string) tea.Cmd {
+	copyFn := m.copyToClipboard
+	if copyFn == nil {
+		copyFn = writeClipboard
+	}
+	return func() tea.Msg {
+		return copyResultMsg{value: value, err: copyFn(value)}
+	}
+}
+
+func (m *Model) refreshAllSections() tea.Cmd {
+	var cmds []tea.Cmd
+	switch m.ctx.View {
+	case context.IssuesView:
+		m.issueDetails = map[string]*data.IssueDetail{}
+		m.issueEnrichErr = map[string]error{}
+	default:
+		m.pullDetails = map[string]*data.PullDetail{}
+		m.pullEnrichErr = map[string]error{}
+	}
+	for _, s := range m.currentViewSections() {
+		cmds = append(cmds, s.FetchRows())
+	}
+	if m.ctx.PreviewOpen {
+		m.syncSidebar()
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) startAction(kind actions.Kind) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -862,6 +862,43 @@ func TestNilActionDispatcherShowsNoticeOnSubmit(t *testing.T) {
 	}
 }
 
+func TestSuccessfulActionRefreshesRowsAndClearsPreviewCache(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+	key := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:  key,
+		pull: &data.PullDetail{Body: "staledetailtoken", BaseRef: "main", HeadRef: "feature"},
+	})
+	if _, ok := m.pullDetails[key]; !ok {
+		t.Fatalf("test setup: expected cached pull detail for %q", key)
+	}
+
+	next, cmd := m.Update(actions.ResultMsg{
+		Intent: actions.Intent{Kind: actions.KindClose, Target: actions.Target{
+			SectionID: 0, SectionType: pullsection.SectionType, RowKind: actions.RowKindPullRequest,
+			Repo: "gbarany/tea-dash", Number: 42,
+		}},
+		Status:  actions.ResultSucceeded,
+		Message: "Closed gbarany/tea-dash#42.",
+	})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("successful action should refresh the affected section")
+	}
+	if _, ok := m.pullDetails[key]; ok {
+		t.Fatalf("successful action should clear cached pull detail for %q", key)
+	}
+	view := m.View().Content
+	if strings.Contains(view, "staledetailtoken") || !strings.Contains(view, "Loading") {
+		t.Fatalf("successful action should replace stale preview with loading state:\n%s", view)
+	}
+}
+
 // isQuitCmd reports whether running cmd yields a tea.QuitMsg.
 func isQuitCmd(cmd tea.Cmd) bool {
 	if cmd == nil {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -773,7 +773,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
 		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
+		{name: "external diff ctrl-t alias", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, kind: actions.KindExternalDiff},
 		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
+		{name: "checkout space alias", key: tea.KeyPressMsg{Code: ' ', Text: " "}, kind: actions.KindCheckout},
 	}
 
 	for _, tt := range tests {
@@ -825,6 +827,124 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
 			}
 		})
+	}
+}
+
+func TestHelpKeyTogglesFullHelp(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("full help should be hidden before '?' is pressed")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	view := m.View().Content
+	for _, want := range []string{"R refresh all", "y copy number", "Y copy URL", "C/space checkout"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("full help missing %q:\n%s", want, view)
+		}
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	if strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("second '?' should hide full help")
+	}
+}
+
+func TestRefreshAllFetchesEveryCurrentSection(t *testing.T) {
+	cfg := &config.Config{
+		PRSections: []config.SectionConfig{
+			{Title: "Mine", Filter: config.PrIssueFilter{CreatedBy: "@me"}},
+			{Title: "Review", Filter: config.PrIssueFilter{ReviewRequested: "@me"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p0",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: []data.PullRequest{{
+				Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open",
+			}},
+			TotalCount: 1, TaskId: "p0",
+		},
+	})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 1, SectionType: pullsection.SectionType, TaskId: "p1",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: []data.PullRequest{{
+				Number: 2, Title: "Second row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open",
+			}},
+			TotalCount: 1, TaskId: "p1",
+		},
+	})
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("'R' should batch refresh commands for all current sections")
+	}
+	if len(m.tasks) != 2 {
+		t.Fatalf("len(tasks) = %d, want both sections to register refresh tasks", len(m.tasks))
+	}
+}
+
+func TestCopyHotkeysUseSelectedRow(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		want string
+	}{
+		{name: "copy number", key: tea.KeyPressMsg{Code: 'y', Text: "y"}, want: "42"},
+		{name: "copy url", key: tea.KeyPressMsg{Code: 'Y', Text: "Y"}, want: "https://example.test/gbarany/tea-dash/pulls/42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var copied string
+			m := New(&config.Config{}, nil)
+			m.copyToClipboard = func(s string) error {
+				copied = s
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedMsg([]data.PullRequest{{
+				Number: 42, Title: "Copy row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+			}}))
+
+			next, cmd := m.Update(tt.key)
+			m = next.(Model)
+			if cmd == nil {
+				t.Fatalf("%s should return a clipboard command", tt.name)
+			}
+			m = update(t, m, cmd())
+			if copied != tt.want {
+				t.Fatalf("copied = %q, want %q", copied, tt.want)
+			}
+			if !strings.Contains(m.View().Content, "Copied") {
+				t.Fatalf("copy result should be visible in the status area:\n%s", m.View().Content)
+			}
+		})
+	}
+}
+
+func TestGHDashFirstLastHotkeysMoveSelection(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("'G' selected #%d, want #2", got)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'g', Text: "g"})
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("'g' selected #%d, want #1", got)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -751,12 +751,24 @@ func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
 
 func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 	tests := []struct {
-		name string
-		key  tea.KeyPressMsg
-		kind actions.Kind
+		name        string
+		key         tea.KeyPressMsg
+		kind        actions.Kind
+		beforeEnter []tea.KeyPressMsg
+		wantPrompt  actions.Prompt
 	}{
 		{name: "comment", key: tea.KeyPressMsg{Code: 'c', Text: "c"}, kind: actions.KindComment},
-		{name: "merge", key: tea.KeyPressMsg{Code: 'm', Text: "m"}, kind: actions.KindMerge},
+		{
+			name:        "merge",
+			key:         tea.KeyPressMsg{Code: 'm', Text: "m"},
+			kind:        actions.KindMerge,
+			beforeEnter: []tea.KeyPressMsg{{Code: 'j', Text: "j"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptPicker,
+				Value: "squash",
+				Label: "Squash",
+			},
+		},
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
@@ -786,6 +798,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				m = update(t, m, tea.KeyPressMsg{Code: 'o', Text: "o"})
 				m = update(t, m, tea.KeyPressMsg{Code: 'k', Text: "k"})
 			}
+			for _, key := range tt.beforeEnter {
+				m = update(t, m, key)
+			}
 			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
 
 			if len(got) != 1 {
@@ -805,6 +820,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 			}
 			if tt.kind == actions.KindComment && got[0].Prompt.Value != "ok" {
 				t.Fatalf("comment prompt value = %q, want ok", got[0].Prompt.Value)
+			}
+			if tt.wantPrompt != (actions.Prompt{}) && got[0].Prompt != tt.wantPrompt {
+				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
 			}
 		})
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -740,8 +740,8 @@ func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
 		t.Fatalf("'s' while an action prompt is active must not switch views: %v", m.ctx.View)
 	}
 	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
-	if m.ctx.PreviewOpen {
-		t.Fatal("'p' while an action prompt is active must not toggle preview")
+	if !m.ctx.PreviewOpen {
+		t.Fatal("'p' while an action prompt is active must not toggle the default-open preview")
 	}
 	m = update(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
 	if m.getCurrSection().IsSearchFocused() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -39,6 +40,17 @@ func notificationFetchedMsg(rows []data.Notification) context.TaskFinishedMsg {
 		TaskId:      "n1",
 		Msg: notificationsection.SectionNotificationsFetchedMsg{
 			Rows: rows, TotalCount: len(rows), TaskId: "n1",
+		},
+	}
+}
+
+func fetchedIssuesMsg(issues []data.Issue) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: issuesection.SectionType,
+		TaskId:      "i1",
+		Msg: issuesection.SectionIssuesFetchedMsg{
+			Rows: issues, TotalCount: len(issues), TaskId: "i1",
 		},
 	}
 }
@@ -702,6 +714,151 @@ func TestPreviewToggleGatedWhileSearching(t *testing.T) {
 	}
 	if got := m.getCurrSection().(*pullsection.Model).SearchBar.Value(); !strings.Contains(got, "p") {
 		t.Fatalf("search value = %q, want it to contain the typed \"p\"", got)
+	}
+}
+
+func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Prompt row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'c', Text: "c"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("'c' should open an action prompt")
+	}
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	m = next.(Model)
+	if isQuitCmd(cmd) {
+		t.Fatal("'q' while an action prompt is active must not quit")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("'s' while an action prompt is active must not switch views: %v", m.ctx.View)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
+	if m.ctx.PreviewOpen {
+		t.Fatal("'p' while an action prompt is active must not toggle preview")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+	if m.getCurrSection().IsSearchFocused() {
+		t.Fatal("'/' while an action prompt is active must not focus search")
+	}
+}
+
+func TestActionKeysDispatchExpectedIntents(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		kind actions.Kind
+	}{
+		{name: "comment", key: tea.KeyPressMsg{Code: 'c', Text: "c"}, kind: actions.KindComment},
+		{name: "merge", key: tea.KeyPressMsg{Code: 'm', Text: "m"}, kind: actions.KindMerge},
+		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
+		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
+		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
+		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
+		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedMsg([]data.PullRequest{{
+				Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+			}}))
+
+			m = update(t, m, tt.key)
+			if !m.actionPrompt.Active() {
+				t.Fatalf("%s key should open an action prompt", tt.name)
+			}
+			if tt.kind == actions.KindComment {
+				m = update(t, m, tea.KeyPressMsg{Code: 'o', Text: "o"})
+				m = update(t, m, tea.KeyPressMsg{Code: 'k', Text: "k"})
+			}
+			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:   0,
+				SectionType: pullsection.SectionType,
+				RowKind:     actions.RowKindPullRequest,
+				Repo:        "gbarany/tea-dash",
+				Number:      42,
+				Title:       "Action row",
+				URL:         "https://example.test/gbarany/tea-dash/pulls/42",
+			}
+			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want kind %q target %+v", got[0], tt.kind, wantTarget)
+			}
+			if tt.kind == actions.KindComment && got[0].Prompt.Value != "ok" {
+				t.Fatalf("comment prompt value = %q, want ok", got[0].Prompt.Value)
+			}
+		})
+	}
+}
+
+func TestInvalidActionOnIssueShowsNotice(t *testing.T) {
+	var dispatched bool
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m.actionDispatcher = func(actions.Intent) tea.Cmd {
+		dispatched = true
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 7, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if dispatched {
+		t.Fatal("merge on an issue must not dispatch")
+	}
+	if m.actionPrompt.Active() {
+		t.Fatal("merge on an issue must not open a prompt")
+	}
+	if !strings.Contains(m.notice, "pull requests") {
+		t.Fatalf("invalid action notice = %q, want pull requests message", m.notice)
+	}
+	if view := m.View().Content; !strings.Contains(view, "pull requests") {
+		t.Fatalf("invalid action notice should render in the view:\n%s", view)
+	}
+}
+
+func TestNilActionDispatcherShowsNoticeOnSubmit(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("'m' should open an action prompt")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.actionPrompt.Active() {
+		t.Fatal("submitted prompt should close")
+	}
+	if !strings.Contains(m.notice, "Action not wired yet") {
+		t.Fatalf("nil dispatcher notice = %q, want action-not-wired message", m.notice)
+	}
+	if view := m.View().Content; !strings.Contains(view, "Action not wired yet") {
+		t.Fatalf("nil dispatcher notice should render in the view:\n%s", view)
 	}
 }
 

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func writeClipboard(value string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return runClipboardCommand(value, "pbcopy")
+	case "windows":
+		return runClipboardCommand(value, "clip")
+	default:
+		candidates := [][]string{
+			{"wl-copy"},
+			{"xclip", "-selection", "clipboard"},
+			{"xsel", "--clipboard", "--input"},
+		}
+		for _, args := range candidates {
+			if _, err := exec.LookPath(args[0]); err != nil {
+				continue
+			}
+			return runClipboardCommand(value, args...)
+		}
+		return fmt.Errorf("no clipboard command found (tried wl-copy, xclip, xsel)")
+	}
+}
+
+func runClipboardCommand(value string, args ...string) error {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = strings.NewReader(value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/ui/components/actionfeedback/actionfeedback.go
+++ b/internal/ui/components/actionfeedback/actionfeedback.go
@@ -1,0 +1,62 @@
+// Package actionfeedback renders compact footer feedback for action results.
+package actionfeedback
+
+// Kind identifies the feedback state.
+type Kind string
+
+const (
+	KindStart   Kind = "start"
+	KindSuccess Kind = "success"
+	KindError   Kind = "error"
+	KindCancel  Kind = "cancel"
+)
+
+// Message is the root-owned feedback value rendered by this component.
+type Message struct {
+	Kind Kind
+	Text string
+}
+
+func Start(text string) Message   { return Message{Kind: KindStart, Text: text} }
+func Success(text string) Message { return Message{Kind: KindSuccess, Text: text} }
+func Error(text string) Message   { return Message{Kind: KindError, Text: text} }
+func Cancel(text string) Message  { return Message{Kind: KindCancel, Text: text} }
+
+// Model stores the last action feedback message.
+type Model struct {
+	msg Message
+}
+
+func New() Model { return Model{} }
+
+func (m Model) Set(msg Message) Model {
+	m.msg = msg
+	return m
+}
+
+func (m Model) Clear() Model {
+	m.msg = Message{}
+	return m
+}
+
+func (m Model) Empty() bool { return m.msg.Text == "" }
+
+func (m Model) View(width int) string {
+	if m.msg.Text == "" {
+		return ""
+	}
+	return fit(m.msg.Text, width)
+}
+
+func fit(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if len(s) <= width {
+		return s
+	}
+	if width <= 3 {
+		return s[:width]
+	}
+	return s[:width-3] + "..."
+}

--- a/internal/ui/components/actionfeedback/actionfeedback_test.go
+++ b/internal/ui/components/actionfeedback/actionfeedback_test.go
@@ -1,0 +1,42 @@
+package actionfeedback
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFeedbackRendersKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want string
+	}{
+		{name: "start", msg: Start("Starting merge"), want: "Starting merge"},
+		{name: "success", msg: Success("Merged"), want: "Merged"},
+		{name: "error", msg: Error("Merge failed"), want: "Merge failed"},
+		{name: "cancel", msg: Cancel("Action cancelled"), want: "Action cancelled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := New().Set(tt.msg).View(80)
+			if !strings.Contains(view, tt.want) {
+				t.Fatalf("feedback view missing %q:\n%s", tt.want, view)
+			}
+		})
+	}
+}
+
+func TestFeedbackSmallWidthRender(t *testing.T) {
+	view := New().Set(Error("This message is too long for the footer")).View(10)
+	if view == "" {
+		t.Fatal("feedback with a message should render")
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if len(line) > 10 {
+			t.Fatalf("line %q is wider than 10 columns in:\n%s", line, view)
+		}
+	}
+	if !strings.Contains(view, "...") {
+		t.Fatalf("small-width render should truncate with ..., got:\n%s", view)
+	}
+}

--- a/internal/ui/components/actionprompt/actionprompt.go
+++ b/internal/ui/components/actionprompt/actionprompt.go
@@ -1,0 +1,204 @@
+// Package actionprompt implements the small blocking prompt used by root-level
+// action keys.
+package actionprompt
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+)
+
+// Mode selects the prompt interaction.
+type Mode string
+
+const (
+	ModeConfirm Mode = "confirm"
+	ModeText    Mode = "text"
+	ModePicker  Mode = "picker"
+)
+
+// Option is a selectable picker entry.
+type Option struct {
+	Label string
+	Value string
+}
+
+// Config describes a prompt instance.
+type Config struct {
+	Mode        Mode
+	Title       string
+	Message     string
+	Placeholder string
+	Options     []Option
+	Initial     string
+}
+
+// Result reports whether a prompt completed and what it submitted.
+type Result struct {
+	Submitted bool
+	Canceled  bool
+	Value     string
+	Label     string
+}
+
+// Model owns the active prompt state.
+type Model struct {
+	active   bool
+	cfg      Config
+	input    textinput.Model
+	selected int
+}
+
+func New() Model {
+	return Model{input: newInput(Config{})}
+}
+
+// Focus opens the prompt with cfg and initializes its local state.
+func (m Model) Focus(cfg Config) Model {
+	if cfg.Mode == "" {
+		cfg.Mode = ModeConfirm
+	}
+	m.active = true
+	m.cfg = cfg
+	m.input = newInput(cfg)
+	m.selected = 0
+	return m
+}
+
+func (m Model) Active() bool { return m.active }
+
+func (m Model) Value() string {
+	if !m.active && m.cfg.Mode != ModeText {
+		return ""
+	}
+	return m.input.Value()
+}
+
+func (m Model) Update(msg tea.Msg) (Model, Result, tea.Cmd) {
+	if !m.active {
+		return m, Result{}, nil
+	}
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, Result{}, nil
+	}
+	switch key.String() {
+	case "esc", "ctrl+c":
+		m.active = false
+		return m, Result{Canceled: true}, nil
+	case "enter":
+		return m.submit(), m.result(), nil
+	}
+
+	switch m.cfg.Mode {
+	case ModeText:
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, Result{}, cmd
+	case ModePicker:
+		switch key.String() {
+		case "j", "down", "right":
+			if m.selected < len(m.cfg.Options)-1 {
+				m.selected++
+			}
+		case "k", "up", "left":
+			if m.selected > 0 {
+				m.selected--
+			}
+		}
+	case ModeConfirm:
+		switch strings.ToLower(key.String()) {
+		case "y":
+			return m.submit(), m.result(), nil
+		case "n":
+			m.active = false
+			return m, Result{Canceled: true}, nil
+		}
+	}
+	return m, Result{}, nil
+}
+
+func (m Model) View(width int) string {
+	if !m.active {
+		return ""
+	}
+	var lines []string
+	if m.cfg.Title != "" {
+		lines = append(lines, "Action: "+m.cfg.Title)
+	}
+	if m.cfg.Message != "" {
+		lines = append(lines, m.cfg.Message)
+	}
+	switch m.cfg.Mode {
+	case ModeText:
+		value := m.input.Value()
+		if value == "" && m.cfg.Placeholder != "" {
+			value = m.cfg.Placeholder
+		}
+		lines = append(lines, "> "+value)
+	case ModePicker:
+		if len(m.cfg.Options) == 0 {
+			lines = append(lines, "No choices available")
+		}
+		for i, option := range m.cfg.Options {
+			prefix := "  "
+			if i == m.selected {
+				prefix = "> "
+			}
+			lines = append(lines, prefix+option.Label)
+		}
+	default:
+		lines = append(lines, "enter: confirm | esc: cancel")
+	}
+	if m.cfg.Mode != ModeConfirm {
+		lines = append(lines, "enter: submit | esc: cancel")
+	}
+	for i, line := range lines {
+		lines[i] = fit(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func newInput(cfg Config) textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = "> "
+	ti.Placeholder = cfg.Placeholder
+	ti.SetValue(cfg.Initial)
+	ti.Focus()
+	ti.CursorEnd()
+	return ti
+}
+
+func (m Model) submit() Model {
+	m.active = false
+	return m
+}
+
+func (m Model) result() Result {
+	switch m.cfg.Mode {
+	case ModeText:
+		return Result{Submitted: true, Value: m.input.Value()}
+	case ModePicker:
+		if len(m.cfg.Options) == 0 {
+			return Result{Submitted: true}
+		}
+		option := m.cfg.Options[m.selected]
+		return Result{Submitted: true, Value: option.Value, Label: option.Label}
+	default:
+		return Result{Submitted: true, Value: "confirm"}
+	}
+}
+
+func fit(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if len(s) <= width {
+		return s
+	}
+	if width <= 3 {
+		return s[:width]
+	}
+	return s[:width-3] + "..."
+}

--- a/internal/ui/components/actionprompt/actionprompt_test.go
+++ b/internal/ui/components/actionprompt/actionprompt_test.go
@@ -1,0 +1,121 @@
+package actionprompt
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func testKey(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+func TestConfirmSubmitAndCancel(t *testing.T) {
+	m := New()
+	m = m.Focus(Config{Mode: ModeConfirm, Title: "Merge", Message: "Merge #42?"})
+	if !m.Active() {
+		t.Fatal("prompt should be active after Focus")
+	}
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Canceled {
+		t.Fatalf("enter should submit confirm prompt: %+v", result)
+	}
+	if result.Value != "confirm" {
+		t.Fatalf("confirm value = %q, want confirm", result.Value)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after submit")
+	}
+
+	m = New().Focus(Config{Mode: ModeConfirm, Title: "Close", Message: "Close #42?"})
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Submitted {
+		t.Fatalf("esc should cancel confirm prompt: %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after cancel")
+	}
+}
+
+func TestTextSubmitAndCancel(t *testing.T) {
+	m := New().Focus(Config{Mode: ModeText, Title: "Comment", Placeholder: "Body"})
+	for _, r := range "ship it" {
+		var result Result
+		m, result, _ = m.Update(testKey(r))
+		if result.Submitted || result.Canceled {
+			t.Fatalf("typing %q should not finish prompt: %+v", r, result)
+		}
+	}
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Value != "ship it" {
+		t.Fatalf("enter should submit typed text, got %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after text submit")
+	}
+
+	m = New().Focus(Config{Mode: ModeText, Title: "Comment"})
+	m, _, _ = m.Update(testKey('x'))
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Value != "" {
+		t.Fatalf("esc should cancel text prompt without payload: %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after text cancel")
+	}
+}
+
+func TestPickerSubmitAndCancel(t *testing.T) {
+	cfg := Config{
+		Mode:  ModePicker,
+		Title: "Review",
+		Options: []Option{
+			{Label: "Comment", Value: "comment"},
+			{Label: "Approve", Value: "approve"},
+		},
+	}
+	m := New().Focus(cfg)
+	m, _, _ = m.Update(testKey('j'))
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Value != "approve" || result.Label != "Approve" {
+		t.Fatalf("enter should submit selected picker option, got %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after picker submit")
+	}
+
+	m = New().Focus(cfg)
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Submitted {
+		t.Fatalf("esc should cancel picker prompt: %+v", result)
+	}
+}
+
+func TestSmallWidthRender(t *testing.T) {
+	m := New().Focus(Config{
+		Mode:        ModeText,
+		Title:       "Comment on a long pull request title",
+		Message:     "This footer should stay within the available terminal width.",
+		Placeholder: "Write a useful comment",
+	})
+
+	view := m.View(12)
+	if view == "" {
+		t.Fatal("active prompt should render")
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if len(line) > 12 {
+			t.Fatalf("line %q is wider than 12 columns in:\n%s", line, view)
+		}
+	}
+	if !strings.Contains(view, "...") {
+		t.Fatalf("small-width render should truncate long text with ..., got:\n%s", view)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -6,6 +6,7 @@ import "charm.land/bubbles/v2/key"
 // keys) is handled by the underlying table widget.
 type keyMap struct {
 	Refresh       key.Binding
+	RefreshAll    key.Binding
 	Open          key.Binding
 	Quit          key.Binding
 	NextSection   key.Binding
@@ -23,6 +24,9 @@ type keyMap struct {
 	Review        key.Binding
 	ExternalDiff  key.Binding
 	Checkout      key.Binding
+	CopyNumber    key.Binding
+	CopyURL       key.Binding
+	Help          key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -30,6 +34,10 @@ func defaultKeyMap() keyMap {
 		Refresh: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
+		),
+		RefreshAll: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "refresh all"),
 		),
 		Open: key.NewBinding(
 			key.WithKeys("o", "enter"),
@@ -92,12 +100,24 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("v", "review"),
 		),
 		ExternalDiff: key.NewBinding(
-			key.WithKeys("d"),
-			key.WithHelp("d", "external diff"),
+			key.WithKeys("d", "ctrl+t"),
+			key.WithHelp("d/ctrl+t", "external diff"),
 		),
 		Checkout: key.NewBinding(
-			key.WithKeys("C"),
-			key.WithHelp("C", "checkout"),
+			key.WithKeys("C", " ", "space"),
+			key.WithHelp("C/space", "checkout"),
+		),
+		CopyNumber: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "copy number"),
+		),
+		CopyURL: key.NewBinding(
+			key.WithKeys("Y"),
+			key.WithHelp("Y", "copy URL"),
+		),
+		Help: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
 		),
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -16,6 +16,13 @@ type keyMap struct {
 	ScrollUp      key.Binding
 	ScrollDown    key.Binding
 	Expand        key.Binding
+	Comment       key.Binding
+	Merge         key.Binding
+	Close         key.Binding
+	Reopen        key.Binding
+	Review        key.Binding
+	ExternalDiff  key.Binding
+	Checkout      key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -63,6 +70,34 @@ func defaultKeyMap() keyMap {
 		Expand: key.NewBinding(
 			key.WithKeys("e"),
 			key.WithHelp("e", "expand"),
+		),
+		Comment: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "comment"),
+		),
+		Merge: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "merge"),
+		),
+		Close: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "close"),
+		),
+		Reopen: key.NewBinding(
+			key.WithKeys("X"),
+			key.WithHelp("X", "reopen"),
+		),
+		Review: key.NewBinding(
+			key.WithKeys("v"),
+			key.WithHelp("v", "review"),
+		),
+		ExternalDiff: key.NewBinding(
+			key.WithKeys("d"),
+			key.WithHelp("d", "external diff"),
+		),
+		Checkout: key.NewBinding(
+			key.WithKeys("C"),
+			key.WithHelp("C", "checkout"),
 		),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/actionrunner"
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/build"
 	"github.com/gbarany/tea-dash/internal/config"
@@ -63,7 +64,17 @@ func run() error {
 		return fmt.Errorf("connecting to %s: %w", authCfg.URL, err)
 	}
 
-	p := tea.NewProgram(ui.New(cfg, client))
+	model := ui.New(cfg, client)
+	cwd, _ := os.Getwd()
+	runner := actionrunner.New(actionrunner.Options{
+		Client:      client,
+		Config:      cfg,
+		InstanceURL: authCfg.URL,
+		CWD:         cwd,
+	})
+	model.SetActionDispatcher(runner.Dispatch)
+
+	p := tea.NewProgram(model)
 	_, err = p.Run()
 	return err
 }


### PR DESCRIPTION
## Summary
- Adds Gitea mutation backends for comments, close/reopen, merge, and submitted PR reviews.
- Adds action prompt/feedback UI and wires action keys (`c`, `m`, `x`, `X`, `v`, `d`, `C`) to a real action runner.
- Adds external diff paging plus local PR checkout helpers using `pager.diff`, `repoPaths`, and `git` config.
- Refreshes the affected section and clears stale preview detail after successful actions.

## Test Plan
- `GOCACHE=/tmp/tea-dash-go-cache make check`

## Notes
- Merge currently uses the default Gitea merge strategy (`merge`). A richer merge-style picker can follow once the basic action path is merged.
- Checkout requires a matching local repo path via `repoPaths` or current working directory remote detection.