### PR TITLE
Add notifications view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ tea-dash is a keyboard-driven TUI for triaging pull requests, issues and
 notifications across one or more Gitea instances, without leaving the terminal.
 
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
-> pull requests and issues across all your repos (fetched via the Gitea API
-> (Go SDK + REST)), with view switching (`s`), configurable sections you page
-> through with `h`/`l`, and live keyword search (`/`). Notifications and PR
-> actions are next. See [`docs/architecture.md`](docs/architecture.md) for the
-> design.
+> pull requests, issues, and unread notifications across all your repos (fetched
+> via the Gitea API (Go SDK + REST)), with view switching (`s`), configurable
+> sections you page through with `h`/`l`, preview pane support, and live keyword
+> search (`/`). PR actions are in progress. See
+> [`docs/architecture.md`](docs/architecture.md) for the design.
 
 ## Why
 
@@ -72,9 +72,12 @@ tea-dash --help
 | Key             | Action                  |
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
-| `s`             | switch view (PRs/issues)|
+| `s`             | switch view (PRs/issues/notifications)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
+| `p`             | toggle preview pane     |
+| `e`             | expand preview body     |
+| `ctrl+u/d`      | scroll preview          |
 | `o` / `enter`   | open in browser         |
 | `r`             | refresh                 |
 | `q` / `ctrl+c`  | quit                    |
@@ -97,9 +100,10 @@ instance:
   # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
 
 defaults:
-  view: prs        # startup view: "prs" or "issues"
-  prsLimit: 50     # rows fetched per PR section (0 -> 50)
-  issuesLimit: 50  # rows fetched per issue section (0 -> 50)
+  view: prs              # startup view: "prs", "issues", or "notifications"
+  prsLimit: 50           # rows fetched per PR section (0 -> 50)
+  issuesLimit: 50        # rows fetched per issue section (0 -> 50)
+  notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
 
 # Each section becomes a tab you page through with h/l. Omit prSections to get
 # two "@me"-authored PR defaults: open and closed pull requests. Omit
@@ -125,6 +129,10 @@ issuesSections:
       assignedBy: "@me"
       labels: [bug, urgent]  # AND-ed
       milestone: v2
+
+notificationsSections:
+  - title: Unread
+    limit: 50
 ```
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
@@ -137,9 +145,10 @@ issuesSections:
 > author filter.
 
 With or without a config file, tea-dash shows the pull requests and issues you
-authored across every repo you can access on your Gitea instance. The default
-PR view has separate open and closed-history tabs; sections and filters let you
-tailor what each tab shows.
+authored, plus unread notifications, across every repo you can access on your
+Gitea instance. The default PR view has separate open and closed-history tabs;
+sections and filters let you tailor what each tab shows. Notification sections
+currently support title/limit configuration and default to unread threads.
 
 ## Development
 
@@ -155,10 +164,10 @@ Project layout:
 
 ```
 main.go                 entrypoint + flag handling; loads config, starts the TUI
-internal/ui/            Bubble Tea model, table, keybindings, styles
-internal/gitea/         Gitea Go SDK client wrapper + me-scoped PR search
+internal/ui/            Bubble Tea model, table, preview, keybindings, styles
+internal/gitea/         Gitea Go SDK client wrapper + PR/issue/notification APIs
 internal/auth/          resolves instance URL + token from the tea config
-internal/data/          TUI-agnostic domain model (PullRequest)
+internal/data/          TUI-agnostic domain models
 internal/config/        ~/.config/tea-dash/config.yml loading
 internal/build/         version metadata (set via -ldflags)
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,11 @@ type Config struct {
 	// Repos lists repositories to watch. Unused in M0; per-repo sections
 	// return in M1.
 	Repos []string `yaml:"repos"`
-	// PRSections and IssuesSections configure the tabs for the pulls and issues
-	// views respectively. Empty falls back to a single me-scoped default section.
-	PRSections     []SectionConfig `yaml:"prSections"`
-	IssuesSections []SectionConfig `yaml:"issuesSections"`
+	// PRSections, IssuesSections, and NotificationsSections configure the tabs
+	// for their respective views. Empty falls back to a default section.
+	PRSections            []SectionConfig `yaml:"prSections"`
+	IssuesSections        []SectionConfig `yaml:"issuesSections"`
+	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 }
@@ -32,9 +33,10 @@ type Config struct {
 // per-view row-fetch cap used when a section omits its own Limit. Precedence:
 // section Limit -> per-view default -> 50.
 type Defaults struct {
-	View        string `yaml:"view"` // "prs" | "issues"
-	PRsLimit    int    `yaml:"prsLimit"`
-	IssuesLimit int    `yaml:"issuesLimit"`
+	View               string `yaml:"view"` // "prs" | "issues" | "notifications"
+	PRsLimit           int    `yaml:"prsLimit"`
+	IssuesLimit        int    `yaml:"issuesLimit"`
+	NotificationsLimit int    `yaml:"notificationsLimit"`
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -111,10 +113,15 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	for _, s := range c.NotificationsSections {
+		if err := s.Filter.Validate(); err != nil {
+			return err
+		}
+	}
 	switch c.Defaults.View {
-	case "", "prs", "issues":
+	case "", "prs", "issues", "notifications":
 	default:
-		return fmt.Errorf("defaults.view = %q: want \"prs\" or \"issues\"", c.Defaults.View)
+		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", or \"notifications\"", c.Defaults.View)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,9 +65,10 @@ instance:
 func TestUnmarshalSectionsAndDefaults(t *testing.T) {
 	const y = `
 defaults:
-  view: issues
+  view: notifications
   prsLimit: 25
   issuesLimit: 40
+  notificationsLimit: 30
 prSections:
   - title: My PRs
     filter:
@@ -81,12 +82,16 @@ issuesSections:
     filter:
       state: open
       createdBy: "@me"
+notificationsSections:
+  - title: Inbox
+    limit: 15
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if c.Defaults.View != "issues" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 {
+	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
+		c.Defaults.NotificationsLimit != 30 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -96,6 +101,10 @@ issuesSections:
 	if len(c.IssuesSections) != 1 || c.IssuesSections[0].Title != "My Issues" ||
 		c.IssuesSections[0].Filter.CreatedBy != "@me" {
 		t.Fatalf("issuesSections = %+v", c.IssuesSections)
+	}
+	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
+		c.NotificationsSections[0].Limit != 15 {
+		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
 	}
 }
 
@@ -112,7 +121,7 @@ func TestConfigValidateBadView(t *testing.T) {
 	if err := (&Config{Defaults: Defaults{View: "nope"}}).Validate(); err == nil {
 		t.Fatal("Validate() should reject an unknown defaults.view")
 	}
-	for _, view := range []string{"", "prs", "issues"} {
+	for _, view := range []string{"", "prs", "issues", "notifications"} {
 		if err := (&Config{Defaults: Defaults{View: view}}).Validate(); err != nil {
 			t.Fatalf("Validate() rejected valid view %q: %v", view, err)
 		}

--- a/internal/data/model.go
+++ b/internal/data/model.go
@@ -48,6 +48,23 @@ type Issue struct {
 	Labels            []Label
 }
 
+// Notification is the domain view of a Gitea notification thread. Notifications
+// can point at issues, pulls, commits, or repositories; Number is populated for
+// issue/pull subjects when the API URL exposes a per-repo index.
+type Notification struct {
+	ID                int64
+	Number            int64
+	SubjectTitle      string
+	SubjectType       string // "Issue" | "Pull" | "Commit" | "Repository"
+	SubjectState      string // "open" | "closed" | "merged" when available
+	RepoNameWithOwner string // "owner/repo"
+	Unread            bool
+	Pinned            bool
+	HTMLURL           string
+	LatestCommentURL  string
+	UpdatedAt         time.Time
+}
+
 // SplitOwnerRepo splits "owner/name" into its parts. ok is false for anything
 // that is not exactly one owner and one name.
 func SplitOwnerRepo(full string) (owner, name string, ok bool) {

--- a/internal/data/notification_test.go
+++ b/internal/data/notification_test.go
@@ -1,0 +1,24 @@
+package data
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNotificationSatisfiesRowData(t *testing.T) {
+	updated := time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC)
+	n := Notification{
+		ID:                12,
+		SubjectTitle:      "Fix the dashboard",
+		RepoNameWithOwner: "gbarany/tea-dash",
+		Number:            42,
+		HTMLURL:           "https://git.example/gbarany/tea-dash/pulls/42",
+		UpdatedAt:         updated,
+	}
+
+	var row RowData = n
+	if row.GetRepoNameWithOwner() != "gbarany/tea-dash" || row.GetTitle() != "Fix the dashboard" ||
+		row.GetNumber() != 42 || row.GetURL() != n.HTMLURL || !row.GetUpdatedAt().Equal(updated) {
+		t.Fatalf("RowData projection mismatch: %+v", row)
+	}
+}

--- a/internal/data/utils.go
+++ b/internal/data/utils.go
@@ -24,8 +24,15 @@ func (i Issue) GetNumber() int64             { return i.Number }
 func (i Issue) GetURL() string               { return i.HTMLURL }
 func (i Issue) GetUpdatedAt() time.Time      { return i.UpdatedAt }
 
+func (n Notification) GetRepoNameWithOwner() string { return n.RepoNameWithOwner }
+func (n Notification) GetTitle() string             { return n.SubjectTitle }
+func (n Notification) GetNumber() int64             { return n.Number }
+func (n Notification) GetURL() string               { return n.HTMLURL }
+func (n Notification) GetUpdatedAt() time.Time      { return n.UpdatedAt }
+
 // Compile-time assertions that both domain row types satisfy RowData.
 var (
 	_ RowData = PullRequest{}
 	_ RowData = Issue{}
+	_ RowData = Notification{}
 )

--- a/internal/gitea/notifications.go
+++ b/internal/gitea/notifications.go
@@ -1,0 +1,94 @@
+package gitea
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"strings"
+
+	sdk "code.gitea.io/sdk/gitea"
+
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+// ListNotifications returns the authenticated user's notification threads.
+// Gitea's notification list response does not expose X-Total-Count through the
+// SDK response, so total is the number of rows returned for this page.
+func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notification, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var threads []*sdk.NotificationThread
+	err := c.call(func() error {
+		var e error
+		threads, _, e = c.sdk.ListNotifications(sdk.ListNotificationOptions{
+			ListOptions: sdk.ListOptions{PageSize: limit},
+			Status:      []sdk.NotifyStatus{sdk.NotifyStatusUnread},
+		})
+		return e
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	rows := make([]data.Notification, 0, len(threads))
+	for _, thread := range threads {
+		rows = append(rows, mapNotificationThread(thread))
+	}
+	return rows, len(rows), nil
+}
+
+func mapNotificationThread(thread *sdk.NotificationThread) data.Notification {
+	if thread == nil {
+		return data.Notification{}
+	}
+	n := data.Notification{
+		ID:        thread.ID,
+		Unread:    thread.Unread,
+		Pinned:    thread.Pinned,
+		UpdatedAt: thread.UpdatedAt,
+	}
+	if thread.Repository != nil {
+		n.RepoNameWithOwner = thread.Repository.FullName
+	}
+	if thread.Subject != nil {
+		n.Number = notificationSubjectNumber(thread.Subject)
+		n.SubjectTitle = thread.Subject.Title
+		n.SubjectType = string(thread.Subject.Type)
+		n.SubjectState = string(thread.Subject.State)
+		n.HTMLURL = thread.Subject.HTMLURL
+		n.LatestCommentURL = thread.Subject.LatestCommentHTMLURL
+	}
+	return n
+}
+
+func notificationSubjectNumber(subject *sdk.NotificationSubject) int64 {
+	if subject == nil {
+		return 0
+	}
+	for _, raw := range []string{subject.URL, subject.HTMLURL} {
+		if n := trailingIndex(raw); n != 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+func trailingIndex(raw string) int64 {
+	if raw == "" {
+		return 0
+	}
+	if u, err := url.Parse(raw); err == nil && u.Path != "" {
+		raw = u.Path
+	}
+	raw = strings.TrimRight(raw, "/")
+	if raw == "" {
+		return 0
+	}
+	parts := strings.Split(raw, "/")
+	tail := parts[len(parts)-1]
+	n, err := strconv.ParseInt(tail, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/gitea/notifications_test.go
+++ b/internal/gitea/notifications_test.go
@@ -1,0 +1,85 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+)
+
+const notificationJSON = `[
+  {
+    "id": 12,
+    "repository": {"full_name": "acme/widgets"},
+    "subject": {
+      "title": "Fix the dashboard",
+      "url": "https://git.example/api/v1/repos/acme/widgets/pulls/42",
+      "html_url": "https://git.example/acme/widgets/pulls/42",
+      "latest_comment_html_url": "https://git.example/acme/widgets/pulls/42#comment-9",
+      "type": "Pull",
+      "state": "open"
+    },
+    "unread": true,
+    "pinned": false,
+    "updated_at": "2026-07-02T09:00:00Z",
+    "url": "https://git.example/api/v1/notifications/threads/12"
+  }
+]`
+
+func TestListNotificationsMapsThreads(t *testing.T) {
+	var gotQuery string
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		fmt.Fprint(w, notificationJSON)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	rows, total, err := c.ListNotifications(context.Background(), 25)
+	if err != nil {
+		t.Fatalf("ListNotifications: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("got total=%d len=%d, want one notification", total, len(rows))
+	}
+	n := rows[0]
+	if n.ID != 12 || n.Number != 42 || n.SubjectTitle != "Fix the dashboard" ||
+		n.SubjectType != "Pull" || n.SubjectState != "open" || n.RepoNameWithOwner != "acme/widgets" ||
+		!n.Unread || n.Pinned || n.HTMLURL != "https://git.example/acme/widgets/pulls/42" ||
+		n.LatestCommentURL != "https://git.example/acme/widgets/pulls/42#comment-9" {
+		t.Fatalf("mapped notification = %+v", n)
+	}
+	wantUpdated := time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC)
+	if !n.UpdatedAt.Equal(wantUpdated) {
+		t.Fatalf("UpdatedAt = %s, want %s", n.UpdatedAt, wantUpdated)
+	}
+	if !strings.Contains(gotQuery, "limit=25") {
+		t.Fatalf("query %q missing limit=25", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "status-types=unread") {
+		t.Fatalf("query %q missing unread status filter", gotQuery)
+	}
+}
+
+func notificationServer(t *testing.T, notifications http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/notifications", notifications)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
+	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/section"
@@ -22,8 +23,8 @@ import (
 )
 
 // Model is the root tea-dash model: a set of sections rendered as tabs. Each
-// view (pulls, issues) owns its own section slice; the inactive view's slice is
-// nil until the first switch (lazy build).
+// view (pulls, issues, notifications) owns its own section slice; inactive
+// views stay nil until first switch (lazy build).
 type Model struct {
 	ctx           *context.ProgramContext
 	keys          keyMap
@@ -33,6 +34,7 @@ type Model struct {
 	currSectionId int
 	prs           []section.Section
 	issues        []section.Section
+	notifications []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
@@ -78,8 +80,13 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		user = client.Me()
 	}
 	view := context.PullsView
-	if cfg != nil && cfg.Defaults.View == "issues" {
-		view = context.IssuesView
+	if cfg != nil {
+		switch cfg.Defaults.View {
+		case "issues":
+			view = context.IssuesView
+		case "notifications":
+			view = context.NotificationsView
+		}
 	}
 	ctx := &context.ProgramContext{
 		Config:      cfg,
@@ -116,9 +123,12 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 	cfgs := ctx.GetViewSectionsConfig()
 	sections := make([]section.Section, len(cfgs))
 	for i, cfg := range cfgs {
-		if view == context.IssuesView {
+		switch view {
+		case context.IssuesView:
 			sections[i] = issuesection.NewModel(i, ctx, cfg)
-		} else {
+		case context.NotificationsView:
+			sections[i] = notificationsection.NewModel(i, ctx, cfg)
+		default:
 			sections[i] = pullsection.NewModel(i, ctx, cfg)
 		}
 	}
@@ -279,8 +289,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // status line, help.
 func (m Model) View() tea.View {
 	subtitle := "  my pull requests"
-	if m.ctx.View == context.IssuesView {
+	switch m.ctx.View {
+	case context.IssuesView:
 		subtitle = "  my issues"
+	case context.NotificationsView:
+		subtitle = "  notifications"
 	}
 	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
@@ -309,6 +322,8 @@ func (m Model) View() tea.View {
 // currentViewSections returns the section slice for the active view.
 func (m *Model) currentViewSections() []section.Section {
 	switch m.ctx.View {
+	case context.NotificationsView:
+		return m.notifications
 	case context.IssuesView:
 		return m.issues
 	default:
@@ -319,6 +334,8 @@ func (m *Model) currentViewSections() []section.Section {
 // setCurrentViewSections stores s under the active view and rewires the tab bar.
 func (m *Model) setCurrentViewSections(s []section.Section) {
 	switch m.ctx.View {
+	case context.NotificationsView:
+		m.notifications = s
 	case context.IssuesView:
 		m.issues = s
 	default:
@@ -380,6 +397,8 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 			if _, ok := m.issueDetails[key]; ok {
 				return nil
 			}
+		default:
+			return nil
 		}
 	}
 	row := m.getCurrRowData()
@@ -437,6 +456,8 @@ func (m *Model) syncSidebar() {
 			return
 		}
 		rendered = prview.RenderIssue(r, m.issueDetails[key], w, m.expanded)
+	case data.Notification:
+		rendered = prview.RenderNotification(r, w)
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -471,13 +492,16 @@ func (m *Model) clearSelectedPreviewCache() {
 	}
 }
 
-// switchView toggles between the pulls and issues views, lazily building and
+// switchView cycles pulls -> issues -> notifications, lazily building and
 // fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
-	if m.ctx.View == context.IssuesView {
-		m.ctx.View = context.PullsView
-	} else {
+	switch m.ctx.View {
+	case context.PullsView:
 		m.ctx.View = context.IssuesView
+	case context.IssuesView:
+		m.ctx.View = context.NotificationsView
+	default:
+		m.ctx.View = context.PullsView
 	}
 	m.syncMainContentDimensions()
 	var cmds []tea.Cmd
@@ -539,6 +563,10 @@ func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {
 		if id >= 0 && id < len(m.issues) {
 			m.issues[id], cmd = m.issues[id].Update(msg)
 		}
+	case notificationsection.SectionType:
+		if id >= 0 && id < len(m.notifications) {
+			m.notifications[id], cmd = m.notifications[id].Update(msg)
+		}
 	}
 	return cmd
 }
@@ -556,6 +584,9 @@ func (m *Model) syncProgramContext() {
 		s.UpdateProgramContext(m.ctx)
 	}
 	for _, s := range m.issues {
+		s.UpdateProgramContext(m.ctx)
+	}
+	for _, s := range m.notifications {
 		s.UpdateProgramContext(m.ctx)
 	}
 	m.tabs.UpdateProgramContext(m.ctx)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
+	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
 	"github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -27,6 +28,17 @@ func fetchedMsg(prs []data.PullRequest) context.TaskFinishedMsg {
 		TaskId:      "t1",
 		Msg: pullsection.SectionPullRequestsFetchedMsg{
 			Rows: prs, TotalCount: len(prs), TaskId: "t1",
+		},
+	}
+}
+
+func notificationFetchedMsg(rows []data.Notification) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: notificationsection.SectionType,
+		TaskId:      "n1",
+		Msg: notificationsection.SectionNotificationsFetchedMsg{
+			Rows: rows, TotalCount: len(rows), TaskId: "n1",
 		},
 	}
 }
@@ -150,6 +162,22 @@ func TestSwitchViewBuildsIssues(t *testing.T) {
 	}
 }
 
+func TestSwitchViewCyclesToNotifications(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = next.(Model)
+	if m.ctx.View != context.NotificationsView {
+		t.Fatalf("View = %v, want NotificationsView", m.ctx.View)
+	}
+	if len(m.notifications) == 0 {
+		t.Fatal("expected notification sections to be built lazily on switch")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch command after switching to the notifications view")
+	}
+}
+
 func TestSectionSwitchWithTwoSections(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{
@@ -254,6 +282,19 @@ func TestDefaultsViewStartsIssues(t *testing.T) {
 	}
 }
 
+func TestDefaultsViewStartsNotifications(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, nil)
+	if m.ctx.View != context.NotificationsView {
+		t.Fatalf("View = %v, want NotificationsView", m.ctx.View)
+	}
+	if len(m.notifications) == 0 {
+		t.Fatal("defaults.view=notifications should build the notification sections at startup")
+	}
+	if len(m.prs) != 0 || len(m.issues) != 0 {
+		t.Fatalf("prs=%d issues=%d, want inactive views lazy", len(m.prs), len(m.issues))
+	}
+}
+
 // TestCrossViewFetchRoutesToOwnSlice verifies a late PR fetch that lands while
 // the Issues view is active is still routed to the pulls slice by (id, type),
 // not to whatever section is currently on screen.
@@ -275,7 +316,9 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 			TotalCount: 1, TaskId: "t1",
 		},
 	})
-	// Switch back to the pulls view; the fetch must have landed in m.prs.
+	// Switch through Notifications back to the pulls view; the fetch must have
+	// landed in m.prs rather than whatever view is on screen.
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	if m.ctx.View != context.PullsView {
 		t.Fatalf("View = %v, want PullsView", m.ctx.View)
@@ -383,6 +426,25 @@ func TestModelRendersLoadedIssues(t *testing.T) {
 	view = m.View().Content
 	if !strings.Contains(view, "1 issue") || strings.Contains(view, "1 issues") {
 		t.Fatalf("status line should read singular \"1 issue\":\n%s", view)
+	}
+}
+
+func TestModelRendersLoadedNotifications(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"}) // close preview for table assertions
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: true, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"#42", "Review the new dashboard", "gbarany/tea-dash", "pull", "unread", "1 notification"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("notifications view is missing %q\n---\n%s", want, view)
+		}
 	}
 }
 
@@ -538,7 +600,8 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 		issue: &data.IssueDetail{Body: "issuebodytoken"},
 	})
 
-	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // pulls
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p1",
 		Msg: pullsection.SectionPullRequestsFetchedMsg{
@@ -551,7 +614,7 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 	})
 	m = update(t, m, enrichedMsg{key: key, sectionType: pullsection.SectionType, err: errBoom})
 
-	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // issues
 	view := m.View().Content
 	if !strings.Contains(view, "issuebodytoken") {
 		t.Fatalf("issue detail with the same repo/number should remain visible:\n%s", view)

--- a/internal/ui/components/notificationsection/notificationsection.go
+++ b/internal/ui/components/notificationsection/notificationsection.go
@@ -1,0 +1,76 @@
+// Package notificationsection is the notifications dashboard section: thin
+// wiring over the generic section.Model parameterized for data.Notification.
+package notificationsection
+
+import (
+	stdctx "context"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+// SectionType is the routing type tag for notification sections.
+const SectionType = "notification"
+
+// Model is the notifications section (the generic section specialized for
+// notifications).
+type Model = section.Model[data.Notification]
+
+// SectionNotificationsFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
+type SectionNotificationsFetchedMsg = section.RowsFetchedMsg[data.Notification]
+
+// NewModel builds a notifications section.
+func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	return section.New(section.Options[data.Notification]{
+		Id:           id,
+		Ctx:          ctx,
+		Config:       cfg,
+		Type:         SectionType,
+		FilterKind:   "",
+		LoadingText:  "Loading notifications…",
+		EmptyText:    "No notifications.",
+		EmptyHint:    "This board shows notification threads from your Gitea instance.",
+		SingularForm: "notification",
+		PluralForm:   "notifications",
+		Limit:        func(c *config.Config) int { return c.Defaults.NotificationsLimit },
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, _ config.PrIssueFilter, limit int) ([]data.Notification, int, error) {
+			return c.ListNotifications(ctx, limit)
+		},
+		BuildRow: notificationBuildRow,
+	})
+}
+
+func notificationBuildRow(n data.Notification) table.Row {
+	number := fmt.Sprintf("#%d", n.Number)
+	if n.Number == 0 {
+		number = fmt.Sprintf("n%d", n.ID)
+	}
+	return table.Row{
+		number,
+		n.SubjectTitle,
+		n.RepoNameWithOwner,
+		strings.ToLower(n.SubjectType),
+		notificationState(n),
+		section.HumanizeTime(n.UpdatedAt),
+	}
+}
+
+func notificationState(n data.Notification) string {
+	switch {
+	case n.Unread:
+		return "unread"
+	case n.Pinned:
+		return "pinned"
+	case n.SubjectState != "":
+		return n.SubjectState
+	default:
+		return "read"
+	}
+}

--- a/internal/ui/components/notificationsection/notificationsection_test.go
+++ b/internal/ui/components/notificationsection/notificationsection_test.go
@@ -1,0 +1,69 @@
+package notificationsection
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	"github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	ctx := &context.ProgramContext{Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20}
+	return NewModel(0, ctx, config.SectionConfig{Title: "Notifications"})
+}
+
+func TestImplementsSection(t *testing.T) {
+	var _ section.Section = (*Model)(nil)
+}
+
+func TestFetchedMsgBuildsRows(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("n1")
+	next, _ := m.Update(SectionNotificationsFetchedMsg{
+		Rows: []data.Notification{{
+			ID: 9, Number: 42, SubjectTitle: "Fix notifications",
+			RepoNameWithOwner: "gbarany/tea-dash", SubjectType: "Pull",
+			SubjectState: "open", Unread: true, UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1, TaskId: "n1",
+	})
+	m = next.(*Model)
+
+	if m.GetTotalCount() != 1 || m.NumRows() != 1 {
+		t.Fatalf("counts: total=%d rows=%d", m.GetTotalCount(), m.NumRows())
+	}
+	if m.GetCurrRow() == nil || m.GetCurrRow().GetNumber() != 42 {
+		t.Fatalf("GetCurrRow = %+v", m.GetCurrRow())
+	}
+	row := m.BuildRows()[0]
+	joined := strings.Join([]string(row), "|")
+	for _, want := range []string{"#42", "Fix notifications", "gbarany/tea-dash", "pull", "unread"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("row %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestFetchedMsgUsesThreadIDWhenSubjectHasNoNumber(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("n1")
+	next, _ := m.Update(SectionNotificationsFetchedMsg{
+		Rows: []data.Notification{{
+			ID: 91, SubjectTitle: "Repository notification",
+			RepoNameWithOwner: "gbarany/tea-dash", SubjectType: "Repository",
+			UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1, TaskId: "n1",
+	})
+	m = next.(*Model)
+
+	row := m.BuildRows()[0]
+	if !strings.Contains(row[0], "n91") {
+		t.Fatalf("number cell = %q, want notification thread id fallback", row[0])
+	}
+}

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -99,6 +99,29 @@ func RenderIssue(row data.Issue, detail *data.IssueDetail, width int, expanded b
 	return compose(header, body, detail == nil, width, expanded, extras)
 }
 
+// RenderNotification renders a notification row into the preview. Notifications
+// are list records, not detail records; this view gives enough context and lets
+// open-in-browser handle the full thread.
+func RenderNotification(row data.Notification, width int) string {
+	number := fmt.Sprintf("#%d", row.Number)
+	if row.Number == 0 {
+		number = fmt.Sprintf("notification %d", row.ID)
+	}
+	header := []string{
+		row.RepoNameWithOwner + " · " + number,
+		titleLine(row.SubjectTitle, width),
+		pill(notificationStatus(row), notificationColor(row)),
+	}
+	if row.SubjectType != "" {
+		header = append(header, subtleRef.Render(row.SubjectType))
+	}
+	body := "Open this notification to read the full thread in Gitea."
+	if row.LatestCommentURL != "" {
+		body += "\nLatest comment available."
+	}
+	return compose(header, body, false, width, true, nil)
+}
+
 // compose joins the header block with the rendered body, then appends any
 // non-empty extra sections (CI / reviews / comments) below the fold, each
 // separated by a blank line so the viewport scrolls through them. When loading
@@ -177,6 +200,30 @@ func stateColor(state string) string {
 		return colMerged
 	default:
 		return colOpen
+	}
+}
+
+func notificationStatus(row data.Notification) string {
+	switch {
+	case row.Unread:
+		return "UNREAD"
+	case row.Pinned:
+		return "PINNED"
+	case row.SubjectState != "":
+		return strings.ToUpper(row.SubjectState)
+	default:
+		return "READ"
+	}
+}
+
+func notificationColor(row data.Notification) string {
+	switch {
+	case row.Unread:
+		return "#1f6feb"
+	case row.Pinned:
+		return "#d29922"
+	default:
+		return stateColor(row.SubjectState)
 	}
 }
 

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -16,12 +16,13 @@ import (
 // Dimensions is a width/height pair.
 type Dimensions struct{ Width, Height int }
 
-// ViewType enumerates the top-level views. M1b adds IssuesView.
+// ViewType enumerates the top-level views.
 type ViewType int
 
 const (
 	PullsView ViewType = iota
 	IssuesView
+	NotificationsView
 )
 
 // TaskState is the lifecycle of an async task.
@@ -60,7 +61,7 @@ type ProgramContext struct {
 	Config *config.Config
 	Client *gitea.Client // may be nil in tests
 	User   string        // client.Me(); "" when client is nil
-	View   ViewType      // PullsView | IssuesView
+	View   ViewType      // PullsView | IssuesView | NotificationsView
 	Error  error
 	Styles Styles
 
@@ -73,6 +74,14 @@ type ProgramContext struct {
 // default section.
 func (c *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 	switch c.View {
+	case NotificationsView:
+		if c.Config != nil && len(c.Config.NotificationsSections) > 0 {
+			return c.Config.NotificationsSections
+		}
+		return []config.SectionConfig{{
+			Title: "Notifications",
+			Limit: 50,
+		}}
 	case IssuesView:
 		if c.Config != nil && len(c.Config.IssuesSections) > 0 {
 			return c.Config.IssuesSections


### PR DESCRIPTION
## Summary

Adds a third top-level Notifications view alongside PRs and Issues.

- maps Gitea notification threads into a `data.Notification` row model
- adds `Client.ListNotifications` using the Gitea SDK, defaulting to unread threads
- adds a generic `notificationsection` with table/status/search plumbing
- cycles views with `s`: PRs -> Issues -> Notifications -> PRs
- supports `defaults.view: notifications`, `defaults.notificationsLimit`, and optional `notificationsSections`
- renders a static notification preview in the default-open preview pane
- refreshes README usage/config docs for the third view

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache make build`
