### PR TITLE
Add notification mark-read backend

### DIFF
--- a/internal/gitea/notifications.go
+++ b/internal/gitea/notifications.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -35,6 +36,42 @@ func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notific
 		rows = append(rows, mapNotificationThread(thread))
 	}
 	return rows, len(rows), nil
+}
+
+// MarkNotificationRead marks one notification thread as read.
+func (c *Client) MarkNotificationRead(_ context.Context, threadID int64) error {
+	return c.markNotification(threadID, sdk.NotifyStatusRead, "read")
+}
+
+// MarkNotificationUnread marks one notification thread as unread.
+func (c *Client) MarkNotificationUnread(_ context.Context, threadID int64) error {
+	return c.markNotification(threadID, sdk.NotifyStatusUnread, "unread")
+}
+
+// MarkAllNotificationsRead marks all unread notification threads as read.
+func (c *Client) MarkAllNotificationsRead(_ context.Context) error {
+	err := c.call(func() error {
+		_, _, e := c.sdk.ReadNotifications(sdk.MarkNotificationOptions{
+			Status:   []sdk.NotifyStatus{sdk.NotifyStatusUnread},
+			ToStatus: sdk.NotifyStatusRead,
+		})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("marking all unread notifications read: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) markNotification(threadID int64, status sdk.NotifyStatus, label string) error {
+	err := c.call(func() error {
+		_, _, e := c.sdk.ReadNotification(threadID, status)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("marking notification %d %s: %w", threadID, label, err)
+	}
+	return nil
 }
 
 func mapNotificationThread(thread *sdk.NotificationThread) data.Notification {

--- a/internal/gitea/notifications_test.go
+++ b/internal/gitea/notifications_test.go
@@ -3,6 +3,7 @@ package gitea
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,7 +70,150 @@ func TestListNotificationsMapsThreads(t *testing.T) {
 	}
 }
 
-func notificationServer(t *testing.T, notifications http.HandlerFunc) *httptest.Server {
+func TestMarkNotificationReadUsesThreadEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"unread":false}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkNotificationRead(context.Background(), 12); err != nil {
+		t.Fatalf("MarkNotificationRead: %v", err)
+	}
+	if !hit {
+		t.Fatal("notification thread endpoint was not called")
+	}
+}
+
+func TestMarkNotificationUnreadUsesThreadEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "unread" {
+				t.Fatalf("to-status = %q, want unread", got)
+			}
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"unread":true}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkNotificationUnread(context.Background(), 12); err != nil {
+		t.Fatalf("MarkNotificationUnread: %v", err)
+	}
+	if !hit {
+		t.Fatal("notification thread endpoint was not called")
+	}
+}
+
+func TestMarkAllNotificationsReadUsesNotificationsEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		q := r.URL.Query()
+		if got := q.Get("to-status"); got != "read" {
+			t.Fatalf("to-status = %q, want read", got)
+		}
+		if got := q["status-types"]; len(got) != 1 || got[0] != "unread" {
+			t.Fatalf("status-types = %v, want [unread]", got)
+		}
+		assertEmptyBody(t, r)
+		fmt.Fprint(w, `[]`)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkAllNotificationsRead(context.Background()); err != nil {
+		t.Fatalf("MarkAllNotificationsRead: %v", err)
+	}
+	if !hit {
+		t.Fatal("notifications endpoint was not called")
+	}
+}
+
+func TestMarkNotificationReadReturnsActionableError(t *testing.T) {
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "patch denied", http.StatusInternalServerError)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = c.MarkNotificationRead(context.Background(), 12)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "marking notification 12 read") ||
+		!strings.Contains(msg, "500") ||
+		!strings.Contains(msg, "patch denied") {
+		t.Fatalf("error %q should include operation, status, and server body", msg)
+	}
+}
+
+func TestMarkAllNotificationsReadReturnsActionableError(t *testing.T) {
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bulk denied", http.StatusBadGateway)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = c.MarkAllNotificationsRead(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "marking all unread notifications read") ||
+		!strings.Contains(msg, "502") ||
+		!strings.Contains(msg, "bulk denied") {
+		t.Fatalf("error %q should include operation, status, and server body", msg)
+	}
+}
+
+type notificationRoute struct {
+	pattern string
+	handler http.HandlerFunc
+}
+
+func notificationServer(t *testing.T, notifications http.HandlerFunc, routes ...notificationRoute) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
@@ -78,8 +222,24 @@ func notificationServer(t *testing.T, notifications http.HandlerFunc) *httptest.
 	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"id":1,"login":"me"}`)
 	})
-	mux.HandleFunc("/api/v1/notifications", notifications)
+	if notifications != nil {
+		mux.HandleFunc("/api/v1/notifications", notifications)
+	}
+	for _, route := range routes {
+		mux.HandleFunc(route.pattern, route.handler)
+	}
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func assertEmptyBody(t *testing.T, r *http.Request) {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("reading request body: %v", err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("body = %q, want empty", body)
+	}
 }


### PR DESCRIPTION
## Summary

Adds SDK-backed notification status mutation helpers on top of the Notifications view branch.

- wraps `ReadNotification` for marking one thread read/unread
- wraps `ReadNotifications` to mark all unread threads read
- adds endpoint and error-path tests for single and bulk mark-read flows

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/gitea -run 'Notification|Mark' -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
