### PR TITLE
Add Actions runs data layer

### DIFF
--- a/internal/data/actions.go
+++ b/internal/data/actions.go
@@ -1,0 +1,75 @@
+package data
+
+import "time"
+
+// ActionRun is the domain view of one Gitea Actions workflow run for a repo.
+// It is denormalized with RepoNameWithOwner so a future Actions section can use
+// the same generic row model as pulls, issues, and notifications.
+type ActionRun struct {
+	ID                int64
+	RunNumber         int64
+	RunAttempt        int64
+	DisplayTitle      string
+	WorkflowName      string
+	Event             string
+	Status            string
+	Conclusion        string
+	HeadBranch        string
+	HeadSHA           string
+	Actor             string
+	RepoNameWithOwner string
+	HTMLURL           string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	StartedAt         time.Time
+}
+
+// ActionJob is the domain view of one job within an Actions workflow run.
+type ActionJob struct {
+	ID                int64
+	RunID             int64
+	Name              string
+	Status            string
+	Conclusion        string
+	RunnerName        string
+	RepoNameWithOwner string
+	HTMLURL           string
+	StartedAt         time.Time
+	CompletedAt       time.Time
+	Steps             []ActionStep
+}
+
+// ActionStep is one step within an Actions job.
+type ActionStep struct {
+	Number      int64
+	Name        string
+	Status      string
+	Conclusion  string
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+func (r ActionRun) GetRepoNameWithOwner() string { return r.RepoNameWithOwner }
+
+func (r ActionRun) GetTitle() string {
+	if r.DisplayTitle != "" {
+		return r.DisplayTitle
+	}
+	return r.WorkflowName
+}
+
+func (r ActionRun) GetNumber() int64 {
+	if r.RunNumber != 0 {
+		return r.RunNumber
+	}
+	return r.ID
+}
+
+func (r ActionRun) GetURL() string { return r.HTMLURL }
+
+func (r ActionRun) GetUpdatedAt() time.Time {
+	if !r.UpdatedAt.IsZero() {
+		return r.UpdatedAt
+	}
+	return r.StartedAt
+}

--- a/internal/data/actions_test.go
+++ b/internal/data/actions_test.go
@@ -1,0 +1,80 @@
+package data
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActionRunSatisfiesRowData(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 7, 2, 8, 5, 0, 0, time.UTC)
+	run := ActionRun{
+		ID:                101,
+		RunNumber:         12,
+		DisplayTitle:      "Fix checkout flakes",
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "acme/widgets",
+		HTMLURL:           "https://git.example/acme/widgets/actions/runs/101",
+		StartedAt:         started,
+		UpdatedAt:         updated,
+	}
+
+	var row RowData = run
+	if row.GetRepoNameWithOwner() != "acme/widgets" || row.GetTitle() != "Fix checkout flakes" ||
+		row.GetNumber() != 12 || row.GetURL() != run.HTMLURL || !row.GetUpdatedAt().Equal(updated) {
+		t.Fatalf("RowData projection mismatch: %+v", row)
+	}
+}
+
+func TestActionRunRowDataFallbacks(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+	run := ActionRun{
+		ID:                101,
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "acme/widgets",
+		StartedAt:         started,
+	}
+
+	var row RowData = run
+	if row.GetTitle() != "CI" {
+		t.Fatalf("GetTitle() = %q, want workflow name fallback", row.GetTitle())
+	}
+	if row.GetNumber() != 101 {
+		t.Fatalf("GetNumber() = %d, want ID fallback", row.GetNumber())
+	}
+	if !row.GetUpdatedAt().Equal(started) {
+		t.Fatalf("GetUpdatedAt() = %s, want StartedAt fallback %s", row.GetUpdatedAt(), started)
+	}
+}
+
+func TestActionJobCarriesSteps(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 1, 0, 0, time.UTC)
+	completed := time.Date(2026, 7, 2, 8, 4, 0, 0, time.UTC)
+	job := ActionJob{
+		ID:          201,
+		RunID:       101,
+		Name:        "build",
+		Status:      "success",
+		Conclusion:  "success",
+		RunnerName:  "ubuntu-latest",
+		StartedAt:   started,
+		CompletedAt: completed,
+		Steps: []ActionStep{
+			{
+				Number:      1,
+				Name:        "checkout",
+				Status:      "success",
+				Conclusion:  "success",
+				StartedAt:   started,
+				CompletedAt: completed,
+			},
+		},
+	}
+
+	if job.ID != 201 || job.RunID != 101 || len(job.Steps) != 1 {
+		t.Fatalf("job fields mismatch: %+v", job)
+	}
+	if job.Steps[0].Number != 1 || job.Steps[0].Name != "checkout" {
+		t.Fatalf("step fields mismatch: %+v", job.Steps[0])
+	}
+}

--- a/internal/data/utils.go
+++ b/internal/data/utils.go
@@ -30,9 +30,10 @@ func (n Notification) GetNumber() int64             { return n.Number }
 func (n Notification) GetURL() string               { return n.HTMLURL }
 func (n Notification) GetUpdatedAt() time.Time      { return n.UpdatedAt }
 
-// Compile-time assertions that both domain row types satisfy RowData.
+// Compile-time assertions that domain row types satisfy RowData.
 var (
 	_ RowData = PullRequest{}
 	_ RowData = Issue{}
 	_ RowData = Notification{}
+	_ RowData = ActionRun{}
 )

--- a/internal/gitea/actions.go
+++ b/internal/gitea/actions.go
@@ -1,0 +1,315 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+// ActionRunListOptions are the optional filters supported by Gitea's
+// repo-scoped Actions runs endpoint.
+type ActionRunListOptions struct {
+	Event   string
+	Branch  string
+	Status  string
+	Actor   string
+	HeadSHA string
+	Limit   int
+}
+
+type rawActionRun struct {
+	ID           int64     `json:"id"`
+	RunNumber    int64     `json:"run_number"`
+	RunAttempt   int64     `json:"run_attempt"`
+	Name         string    `json:"name"`
+	WorkflowName string    `json:"workflow_name"`
+	DisplayTitle string    `json:"display_title"`
+	Event        string    `json:"event"`
+	Status       string    `json:"status"`
+	Conclusion   string    `json:"conclusion"`
+	HeadBranch   string    `json:"head_branch"`
+	HeadSHA      string    `json:"head_sha"`
+	HTMLURL      string    `json:"html_url"`
+	URL          string    `json:"url"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	RunStartedAt time.Time `json:"run_started_at"`
+	StartedAt    time.Time `json:"started_at"`
+	Actor        *struct {
+		Login string `json:"login"`
+	} `json:"actor"`
+	Repository *struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type rawActionJob struct {
+	ID          int64           `json:"id"`
+	RunID       int64           `json:"run_id"`
+	Name        string          `json:"name"`
+	Status      string          `json:"status"`
+	Conclusion  string          `json:"conclusion"`
+	RunnerName  string          `json:"runner_name"`
+	HTMLURL     string          `json:"html_url"`
+	URL         string          `json:"url"`
+	StartedAt   time.Time       `json:"started_at"`
+	CompletedAt time.Time       `json:"completed_at"`
+	Steps       []rawActionStep `json:"steps"`
+}
+
+type rawActionStep struct {
+	Number      int64     `json:"number"`
+	StepNumber  int64     `json:"step_number"`
+	Name        string    `json:"name"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+type actionRunsEnvelope struct {
+	TotalCount   int            `json:"total_count"`
+	WorkflowRuns []rawActionRun `json:"workflow_runs"`
+	Runs         []rawActionRun `json:"runs"`
+	ActionRuns   []rawActionRun `json:"action_runs"`
+	Data         []rawActionRun `json:"data"`
+}
+
+type actionJobsEnvelope struct {
+	TotalCount int            `json:"total_count"`
+	Jobs       []rawActionJob `json:"jobs"`
+	ActionJobs []rawActionJob `json:"action_jobs"`
+	Data       []rawActionJob `json:"data"`
+}
+
+// ListActionRuns returns one page of repo-scoped Actions workflow runs plus the
+// server's total count when the payload exposes it. Decoding accepts both the
+// documented wrapped shape and bare arrays seen on some Forgejo/Gitea variants.
+func (c *Client) ListActionRuns(ctx context.Context, owner, repo string, opts ActionRunListOptions) ([]data.ActionRun, int, error) {
+	path := actionRunsPath(owner, repo)
+	if q := buildActionRunParams(opts); len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var raw json.RawMessage
+	if _, err := c.rawGet(ctx, path, &raw); err != nil {
+		return nil, 0, err
+	}
+	rows, total, err := decodeActionRuns(raw)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decoding actions runs: %w", err)
+	}
+
+	repoName := owner + "/" + repo
+	runs := make([]data.ActionRun, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, mapActionRun(row, repoName))
+	}
+	return runs, total, nil
+}
+
+// GetActionRun fetches one repo-scoped Actions workflow run.
+func (c *Client) GetActionRun(ctx context.Context, owner, repo string, runID int64) (data.ActionRun, error) {
+	var raw rawActionRun
+	if _, err := c.rawGet(ctx, actionRunPath(owner, repo, runID), &raw); err != nil {
+		return data.ActionRun{}, err
+	}
+	return mapActionRun(raw, owner+"/"+repo), nil
+}
+
+// ListActionJobs returns the jobs attached to one repo-scoped Actions workflow
+// run. Decoding accepts both the documented wrapped shape and bare arrays.
+func (c *Client) ListActionJobs(ctx context.Context, owner, repo string, runID int64) ([]data.ActionJob, error) {
+	var raw json.RawMessage
+	if _, err := c.rawGet(ctx, actionJobsPath(owner, repo, runID), &raw); err != nil {
+		return nil, err
+	}
+	rows, err := decodeActionJobs(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decoding actions jobs: %w", err)
+	}
+
+	repoName := owner + "/" + repo
+	jobs := make([]data.ActionJob, 0, len(rows))
+	for _, row := range rows {
+		jobs = append(jobs, mapActionJob(row, repoName, runID))
+	}
+	return jobs, nil
+}
+
+func buildActionRunParams(opts ActionRunListOptions) url.Values {
+	q := url.Values{}
+	if opts.Event != "" {
+		q.Set("event", opts.Event)
+	}
+	if opts.Branch != "" {
+		q.Set("branch", opts.Branch)
+	}
+	if opts.Status != "" {
+		q.Set("status", opts.Status)
+	}
+	if opts.Actor != "" {
+		q.Set("actor", opts.Actor)
+	}
+	if opts.HeadSHA != "" {
+		q.Set("head_sha", opts.HeadSHA)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	return q
+}
+
+func decodeActionRuns(raw json.RawMessage) ([]rawActionRun, int, error) {
+	var rows []rawActionRun
+	if err := json.Unmarshal(raw, &rows); err == nil {
+		return rows, len(rows), nil
+	}
+
+	var env actionRunsEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, 0, err
+	}
+	switch {
+	case env.WorkflowRuns != nil:
+		rows = env.WorkflowRuns
+	case env.Runs != nil:
+		rows = env.Runs
+	case env.ActionRuns != nil:
+		rows = env.ActionRuns
+	case env.Data != nil:
+		rows = env.Data
+	default:
+		rows = nil
+	}
+	total := env.TotalCount
+	if total == 0 {
+		total = len(rows)
+	}
+	return rows, total, nil
+}
+
+func decodeActionJobs(raw json.RawMessage) ([]rawActionJob, error) {
+	var rows []rawActionJob
+	if err := json.Unmarshal(raw, &rows); err == nil {
+		return rows, nil
+	}
+
+	var env actionJobsEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, err
+	}
+	switch {
+	case env.Jobs != nil:
+		return env.Jobs, nil
+	case env.ActionJobs != nil:
+		return env.ActionJobs, nil
+	case env.Data != nil:
+		return env.Data, nil
+	default:
+		return nil, nil
+	}
+}
+
+func mapActionRun(row rawActionRun, fallbackRepo string) data.ActionRun {
+	workflowName := row.WorkflowName
+	if workflowName == "" {
+		workflowName = row.Name
+	}
+	htmlURL := row.HTMLURL
+	if htmlURL == "" {
+		htmlURL = row.URL
+	}
+	startedAt := row.RunStartedAt
+	if startedAt.IsZero() {
+		startedAt = row.StartedAt
+	}
+	repoName := fallbackRepo
+	if row.Repository != nil && row.Repository.FullName != "" {
+		repoName = row.Repository.FullName
+	}
+
+	run := data.ActionRun{
+		ID:                row.ID,
+		RunNumber:         row.RunNumber,
+		RunAttempt:        row.RunAttempt,
+		DisplayTitle:      row.DisplayTitle,
+		WorkflowName:      workflowName,
+		Event:             row.Event,
+		Status:            row.Status,
+		Conclusion:        row.Conclusion,
+		HeadBranch:        row.HeadBranch,
+		HeadSHA:           row.HeadSHA,
+		RepoNameWithOwner: repoName,
+		HTMLURL:           htmlURL,
+		CreatedAt:         row.CreatedAt,
+		UpdatedAt:         row.UpdatedAt,
+		StartedAt:         startedAt,
+	}
+	if row.Actor != nil {
+		run.Actor = row.Actor.Login
+	}
+	return run
+}
+
+func mapActionJob(row rawActionJob, repoName string, fallbackRunID int64) data.ActionJob {
+	runID := row.RunID
+	if runID == 0 {
+		runID = fallbackRunID
+	}
+	htmlURL := row.HTMLURL
+	if htmlURL == "" {
+		htmlURL = row.URL
+	}
+	job := data.ActionJob{
+		ID:                row.ID,
+		RunID:             runID,
+		Name:              row.Name,
+		Status:            row.Status,
+		Conclusion:        row.Conclusion,
+		RunnerName:        row.RunnerName,
+		RepoNameWithOwner: repoName,
+		HTMLURL:           htmlURL,
+		StartedAt:         row.StartedAt,
+		CompletedAt:       row.CompletedAt,
+	}
+	if len(row.Steps) > 0 {
+		job.Steps = make([]data.ActionStep, 0, len(row.Steps))
+		for _, step := range row.Steps {
+			job.Steps = append(job.Steps, mapActionStep(step))
+		}
+	}
+	return job
+}
+
+func mapActionStep(row rawActionStep) data.ActionStep {
+	number := row.Number
+	if number == 0 {
+		number = row.StepNumber
+	}
+	return data.ActionStep{
+		Number:      number,
+		Name:        row.Name,
+		Status:      row.Status,
+		Conclusion:  row.Conclusion,
+		StartedAt:   row.StartedAt,
+		CompletedAt: row.CompletedAt,
+	}
+}
+
+func actionRunsPath(owner, repo string) string {
+	return "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/actions/runs"
+}
+
+func actionRunPath(owner, repo string, runID int64) string {
+	return actionRunsPath(owner, repo) + "/" + strconv.FormatInt(runID, 10)
+}
+
+func actionJobsPath(owner, repo string, runID int64) string {
+	return actionRunPath(owner, repo, runID) + "/jobs"
+}

--- a/internal/gitea/actions_test.go
+++ b/internal/gitea/actions_test.go
@@ -1,0 +1,227 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+)
+
+const actionRunsJSON = `{
+  "total_count": 12,
+  "workflow_runs": [
+    {
+      "id": 101,
+      "run_number": 12,
+      "run_attempt": 2,
+      "name": "CI",
+      "display_title": "Fix checkout flakes",
+      "event": "push",
+      "status": "in_progress",
+      "conclusion": "",
+      "head_branch": "main",
+      "head_sha": "abc123",
+      "html_url": "https://git.example/acme/widgets/actions/runs/101",
+      "actor": {"login": "octo"},
+      "created_at": "2026-07-02T08:00:00Z",
+      "updated_at": "2026-07-02T08:05:00Z",
+      "run_started_at": "2026-07-02T08:01:00Z"
+    }
+  ]
+}`
+
+func TestListActionRunsMapsWrappedResponseAndFilters(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			if r.Header.Get("Authorization") != "token t" {
+				t.Fatalf("Authorization header = %q, want token auth", r.Header.Get("Authorization"))
+			}
+			fmt.Fprint(w, actionRunsJSON)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	runs, total, err := c.ListActionRuns(context.Background(), "acme", "widgets", ActionRunListOptions{
+		Event:   "push",
+		Branch:  "main",
+		Status:  "in_progress",
+		Actor:   "octo",
+		HeadSHA: "abc123",
+		Limit:   25,
+	})
+	if err != nil {
+		t.Fatalf("ListActionRuns: %v", err)
+	}
+	if total != 12 || len(runs) != 1 {
+		t.Fatalf("got total=%d len=%d, want total 12 and one run", total, len(runs))
+	}
+	run := runs[0]
+	if run.ID != 101 || run.RunNumber != 12 || run.RunAttempt != 2 ||
+		run.DisplayTitle != "Fix checkout flakes" || run.WorkflowName != "CI" ||
+		run.Event != "push" || run.Status != "in_progress" || run.Conclusion != "" ||
+		run.HeadBranch != "main" || run.HeadSHA != "abc123" || run.Actor != "octo" ||
+		run.RepoNameWithOwner != "acme/widgets" || run.HTMLURL != "https://git.example/acme/widgets/actions/runs/101" {
+		t.Fatalf("mapped run = %+v", run)
+	}
+	wantStarted := time.Date(2026, 7, 2, 8, 1, 0, 0, time.UTC)
+	wantUpdated := time.Date(2026, 7, 2, 8, 5, 0, 0, time.UTC)
+	if !run.StartedAt.Equal(wantStarted) || !run.UpdatedAt.Equal(wantUpdated) {
+		t.Fatalf("run times = started %s updated %s", run.StartedAt, run.UpdatedAt)
+	}
+	for _, want := range []string{
+		"event=push",
+		"branch=main",
+		"status=in_progress",
+		"actor=octo",
+		"head_sha=abc123",
+		"limit=25",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+func TestListActionRunsMapsArrayResponse(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `[
+			  {
+			    "id": 102,
+			    "name": "Nightly",
+			    "status": "success",
+			    "repository": {"full_name": "acme/widgets"},
+			    "html_url": "https://git.example/acme/widgets/actions/runs/102"
+			  }
+			]`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	runs, total, err := c.ListActionRuns(context.Background(), "acme", "widgets", ActionRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListActionRuns: %v", err)
+	}
+	if total != 1 || len(runs) != 1 {
+		t.Fatalf("got total=%d len=%d, want one array-decoded run", total, len(runs))
+	}
+	if runs[0].ID != 102 || runs[0].WorkflowName != "Nightly" || runs[0].Status != "success" {
+		t.Fatalf("mapped run = %+v", runs[0])
+	}
+}
+
+func TestGetActionRunMapsSingleRun(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{
+			  "id": 101,
+			  "run_number": 12,
+			  "name": "CI",
+			  "status": "failure",
+			  "conclusion": "failure",
+			  "html_url": "https://git.example/acme/widgets/actions/runs/101"
+			}`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	run, err := c.GetActionRun(context.Background(), "acme", "widgets", 101)
+	if err != nil {
+		t.Fatalf("GetActionRun: %v", err)
+	}
+	if run.ID != 101 || run.RunNumber != 12 || run.WorkflowName != "CI" ||
+		run.Status != "failure" || run.Conclusion != "failure" || run.RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("mapped run = %+v", run)
+	}
+}
+
+func TestListActionJobsMapsWrappedResponse(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101/jobs", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{
+			  "total_count": 1,
+			  "jobs": [
+			    {
+			      "id": 201,
+			      "run_id": 101,
+			      "name": "build",
+			      "status": "success",
+			      "conclusion": "success",
+			      "runner_name": "ubuntu-latest",
+			      "html_url": "https://git.example/acme/widgets/actions/runs/101/jobs/201",
+			      "started_at": "2026-07-02T08:01:00Z",
+			      "completed_at": "2026-07-02T08:04:00Z",
+			      "steps": [
+			        {
+			          "number": 1,
+			          "name": "checkout",
+			          "status": "success",
+			          "conclusion": "success",
+			          "started_at": "2026-07-02T08:01:00Z",
+			          "completed_at": "2026-07-02T08:02:00Z"
+			        }
+			      ]
+			    }
+			  ]
+			}`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	jobs, err := c.ListActionJobs(context.Background(), "acme", "widgets", 101)
+	if err != nil {
+		t.Fatalf("ListActionJobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	job := jobs[0]
+	if job.ID != 201 || job.RunID != 101 || job.Name != "build" ||
+		job.Status != "success" || job.Conclusion != "success" ||
+		job.RunnerName != "ubuntu-latest" || job.RepoNameWithOwner != "acme/widgets" ||
+		job.HTMLURL != "https://git.example/acme/widgets/actions/runs/101/jobs/201" {
+		t.Fatalf("mapped job = %+v", job)
+	}
+	if len(job.Steps) != 1 || job.Steps[0].Number != 1 || job.Steps[0].Name != "checkout" ||
+		job.Steps[0].Status != "success" || job.Steps[0].Conclusion != "success" {
+		t.Fatalf("mapped steps = %+v", job.Steps)
+	}
+}
+
+func actionServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}


### PR DESCRIPTION
## Summary

Adds the data-layer foundation for an Actions / CI runs view, stacked on the Notifications view branch.

- adds `data.ActionRun`, `data.ActionJob`, and `data.ActionStep`
- makes `ActionRun` satisfy the shared `RowData` table contract
- adds raw-client methods for repo-scoped Actions runs:
  - `ListActionRuns`
  - `GetActionRun`
  - `ListActionJobs`
- decodes tolerant response shapes for Gitea/Forgejo variants: wrapped `workflow_runs`, `runs`, `action_runs`, `jobs`, `data`, and bare arrays
- adds request/filter mapping and row-mapping tests

## Notes

This is backend-only. It does not add the Actions view UI yet, and it intentionally leaves job log retrieval for the follow-up UI/detail slice.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/data ./internal/gitea -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
