### PR TITLE
Wire notification mark-read keys

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,7 +2,9 @@
 package ui
 
 import (
+	stdctx "context"
 	"fmt"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -70,6 +72,12 @@ type enrichedMsg struct {
 	pull        *data.PullDetail
 	issue       *data.IssueDetail
 	err         error
+}
+
+type notificationActionMsg struct {
+	sectionID int
+	all       bool
+	err       error
 }
 
 // New builds the root model. client may be nil in tests (only FetchRows uses it).
@@ -194,6 +202,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncSidebar()
 		return m, nil
 
+	case notificationActionMsg:
+		return m.handleNotificationAction(msg)
+
 	case spinner.TickMsg:
 		// A tick belongs to whichever section started the spinner, but sibling
 		// sections in the current view share one animation; route it to every one
@@ -222,6 +233,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case key.Matches(msg, m.keys.Open):
 			return m, m.openSelected()
+		case key.Matches(msg, m.keys.MarkRead):
+			return m.markSelectedNotificationRead()
+		case key.Matches(msg, m.keys.MarkAllRead):
+			return m.markAllNotificationsRead()
 		case key.Matches(msg, m.keys.NextSection):
 			if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 				m.currSectionId++
@@ -313,7 +328,7 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · e expand · r refresh · o open · q quit"))
+		helpStyle.Render(m.helpText()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
@@ -550,6 +565,86 @@ func (m Model) openSelected() tea.Cmd {
 		}
 		return nil
 	}
+}
+
+func (m Model) markSelectedNotificationRead() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.Notification)
+	if !ok {
+		m.notice = "Select a notification to mark read."
+		return m, nil
+	}
+	if row.ID == 0 {
+		m.notice = "Selected notification has no thread id."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to mark notifications read."
+		return m, nil
+	}
+	return m, markNotificationReadCmd(m.ctx.Client, m.currSectionId, row.ID)
+}
+
+func (m Model) markAllNotificationsRead() (Model, tea.Cmd) {
+	if m.ctx.View != context.NotificationsView {
+		m.notice = "Switch to notifications to mark all read."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to mark notifications read."
+		return m, nil
+	}
+	return m, markAllNotificationsReadCmd(m.ctx.Client, m.currSectionId)
+}
+
+func markNotificationReadCmd(client *gitea.Client, sectionID int, threadID int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			err:       client.MarkNotificationRead(ctx, threadID),
+		}
+	}
+}
+
+func markAllNotificationsReadCmd(client *gitea.Client, sectionID int) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			all:       true,
+			err:       client.MarkAllNotificationsRead(ctx),
+		}
+	}
+}
+
+func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.Cmd) {
+	if msg.err != nil {
+		if msg.all {
+			m.notice = fmt.Sprintf("Couldn't mark all notifications read: %v", msg.err)
+		} else {
+			m.notice = fmt.Sprintf("Couldn't mark notification read: %v", msg.err)
+		}
+		return m, nil
+	}
+	if msg.all {
+		m.notice = "Marked all notifications read."
+	} else {
+		m.notice = "Marked notification read."
+	}
+	if msg.sectionID < 0 || msg.sectionID >= len(m.notifications) {
+		return m, nil
+	}
+	return m, m.notifications[msg.sectionID].FetchRows()
+}
+
+func (m Model) helpText() string {
+	text := "↑/↓ move · h/l section · s view · / search · p preview · e expand · r refresh · o open"
+	if m.ctx.View == context.NotificationsView {
+		text += " · m read · M all read"
+	}
+	return text + " · q quit"
 }
 
 func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,14 +1,20 @@
 package ui
 
 import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -448,6 +454,116 @@ func TestModelRendersLoadedNotifications(t *testing.T) {
 	}
 }
 
+func TestMarkSelectedNotificationReadRefreshesNotifications(t *testing.T) {
+	var hit bool
+	client := newNotificationActionClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/notifications/threads/12" {
+				http.NotFound(w, r)
+				return
+			}
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			fmt.Fprint(w, `{"id":12,"unread":false}`)
+		},
+		nil,
+	)
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: true, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if cmd == nil {
+		t.Fatal("'m' on a notification should return a mark-read command")
+	}
+	m = next.(Model)
+	msg := cmd()
+	if !hit {
+		t.Fatal("mark-read command did not call the notification thread endpoint")
+	}
+	next, refresh := m.Update(msg)
+	m = next.(Model)
+	if refresh == nil {
+		t.Fatal("successful mark-read should refresh the notifications section")
+	}
+	if !strings.Contains(m.notice, "Marked notification read") {
+		t.Fatalf("notice = %q, want mark-read confirmation", m.notice)
+	}
+}
+
+func TestMarkAllNotificationsReadRefreshesNotifications(t *testing.T) {
+	var hit bool
+	client := newNotificationActionClient(t,
+		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", r.Method)
+			}
+			q := r.URL.Query()
+			if got := q.Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			if got := q["status-types"]; len(got) != 1 || got[0] != "unread" {
+				t.Fatalf("status-types = %v, want [unread]", got)
+			}
+			fmt.Fprint(w, `[]`)
+		},
+	)
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: true, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'M', Text: "M"})
+	if cmd == nil {
+		t.Fatal("'M' in notifications should return a mark-all-read command")
+	}
+	m = next.(Model)
+	msg := cmd()
+	if !hit {
+		t.Fatal("mark-all command did not call the notifications endpoint")
+	}
+	next, refresh := m.Update(msg)
+	m = next.(Model)
+	if refresh == nil {
+		t.Fatal("successful mark-all-read should refresh the notifications section")
+	}
+	if !strings.Contains(m.notice, "Marked all notifications read") {
+		t.Fatalf("notice = %q, want mark-all confirmation", m.notice)
+	}
+}
+
+func TestMarkSelectedReadOnNonNotificationShowsNotice(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Not a notification", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("'m' on a pull request should be a no-op, got %v", cmd)
+	}
+	if !strings.Contains(m.notice, "Select a notification") {
+		t.Fatalf("notice = %q, want non-notification guidance", m.notice)
+	}
+}
+
 // TestPreviewStartsOpenAndToggles verifies the preview pane is visible by
 // default: the initial window size gives it dimensions and the composed View()
 // renders the sidebar region. 'p' still toggles it closed and open again.
@@ -719,3 +835,32 @@ var errBoom = errBoomType("boom")
 type errBoomType string
 
 func (e errBoomType) Error() string { return string(e) }
+
+func newNotificationActionClient(
+	t *testing.T,
+	threadHandler http.HandlerFunc,
+	notificationsHandler http.HandlerFunc,
+) *gitea.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	if threadHandler != nil {
+		mux.HandleFunc("/api/v1/notifications/threads/12", threadHandler)
+	}
+	if notificationsHandler != nil {
+		mux.HandleFunc("/api/v1/notifications", notificationsHandler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -16,6 +16,8 @@ type keyMap struct {
 	ScrollUp      key.Binding
 	ScrollDown    key.Binding
 	Expand        key.Binding
+	MarkRead      key.Binding
+	MarkAllRead   key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -63,6 +65,14 @@ func defaultKeyMap() keyMap {
 		Expand: key.NewBinding(
 			key.WithKeys("e"),
 			key.WithHelp("e", "expand"),
+		),
+		MarkRead: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "mark read"),
+		),
+		MarkAllRead: key.NewBinding(
+			key.WithKeys("M"),
+			key.WithHelp("M", "mark all read"),
 		),
 	}
 }


### PR DESCRIPTION
## Summary

Wires the notification mark-read backend into the Notifications view.

- `m` marks the selected notification read, then refreshes the Notifications section
- `M` marks all unread notifications read, then refreshes
- non-notification rows show a no-op guidance notice
- keeps `o` / `enter` open-in-browser behavior unchanged

## Caveat

This branch is stacked on PR #12. There is no confirmation prompt on this branch yet, so `M` executes immediately and reports via the transient notice.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui ./internal/gitea -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
