### PR TITLE
Add Actions runs view

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,23 +20,26 @@ type Config struct {
 	// Repos lists repositories to watch. Unused in M0; per-repo sections
 	// return in M1.
 	Repos []string `yaml:"repos"`
-	// PRSections, IssuesSections, and NotificationsSections configure the tabs
-	// for their respective views. Empty falls back to a default section.
+	// PRSections, IssuesSections, NotificationsSections, and ActionsSections
+	// configure the tabs for their respective views. Empty falls back to a
+	// default section.
 	PRSections            []SectionConfig `yaml:"prSections"`
 	IssuesSections        []SectionConfig `yaml:"issuesSections"`
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
+	ActionsSections       []SectionConfig `yaml:"actionsSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 }
 
-// Defaults holds startup and limit defaults. PRsLimit and IssuesLimit set the
-// per-view row-fetch cap used when a section omits its own Limit. Precedence:
-// section Limit -> per-view default -> 50.
+// Defaults holds startup and limit defaults. Per-view limits set the row-fetch
+// cap used when a section omits its own Limit. Precedence: section Limit ->
+// per-view default -> 50.
 type Defaults struct {
-	View               string `yaml:"view"` // "prs" | "issues" | "notifications"
+	View               string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions"
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
+	ActionsLimit       int    `yaml:"actionsLimit"`
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -53,9 +56,10 @@ type Instance struct {
 // SectionConfig describes one dashboard section (a tab).
 type SectionConfig struct {
 	Title  string        `yaml:"title"`
+	Repo   string        `yaml:"repo"`
 	Filter PrIssueFilter `yaml:"filter"`
 	// Limit caps this section's row fetch. 0 falls back to the per-view default
-	// (defaults.prsLimit / defaults.issuesLimit), which in turn falls back to 50.
+	// (defaults.prsLimit / defaults.issuesLimit / etc.), which in turn falls back to 50.
 	// Precedence: section Limit -> per-view default -> 50.
 	Limit int `yaml:"limit"`
 }
@@ -78,6 +82,14 @@ type PrIssueFilter struct {
 	Since           string `yaml:"since"`           // RFC3339 lower bound on updatedAt
 	Sort            string `yaml:"sort"`            // e.g. recentupdate
 	Q               string `yaml:"-"`               // live keyword (set by "/", never persisted)
+
+	// Repo-scoped Actions filters. These are ignored by PR/issue search and are
+	// mapped to Gitea's actions/runs query params by the Actions view.
+	Status  string `yaml:"status"`
+	Branch  string `yaml:"branch"`
+	Event   string `yaml:"event"`
+	HeadSHA string `yaml:"headSha"`
+	Actor   string `yaml:"actor"`
 }
 
 // Validate rejects unsupported me-scoped author values. The cross-repo search
@@ -118,10 +130,18 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	for _, s := range c.ActionsSections {
+		if strings.TrimSpace(s.Repo) == "" {
+			continue
+		}
+		if _, err := ParseRepo(s.Repo); err != nil {
+			return fmt.Errorf("actionsSections.repo: %w", err)
+		}
+	}
 	switch c.Defaults.View {
-	case "", "prs", "issues", "notifications":
+	case "", "prs", "issues", "notifications", "actions":
 	default:
-		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", or \"notifications\"", c.Defaults.View)
+		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", or \"actions\"", c.Defaults.View)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,7 @@ defaults:
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
+  actionsLimit: 20
 prSections:
   - title: My PRs
     filter:
@@ -85,13 +86,23 @@ issuesSections:
 notificationsSections:
   - title: Inbox
     limit: 15
+actionsSections:
+  - title: CI
+    repo: acme/widgets
+    limit: 10
+    filter:
+      status: in_progress
+      branch: main
+      event: push
+      headSha: abc123
+      actor: octo
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
-		c.Defaults.NotificationsLimit != 30 {
+		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -105,6 +116,15 @@ notificationsSections:
 	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
 		c.NotificationsSections[0].Limit != 15 {
 		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
+	}
+	if len(c.ActionsSections) != 1 || c.ActionsSections[0].Title != "CI" ||
+		c.ActionsSections[0].Repo != "acme/widgets" || c.ActionsSections[0].Limit != 10 {
+		t.Fatalf("actionsSections = %+v", c.ActionsSections)
+	}
+	filter := c.ActionsSections[0].Filter
+	if filter.Status != "in_progress" || filter.Branch != "main" || filter.Event != "push" ||
+		filter.HeadSHA != "abc123" || filter.Actor != "octo" {
+		t.Fatalf("actions filter = %+v", filter)
 	}
 }
 
@@ -121,7 +141,7 @@ func TestConfigValidateBadView(t *testing.T) {
 	if err := (&Config{Defaults: Defaults{View: "nope"}}).Validate(); err == nil {
 		t.Fatal("Validate() should reject an unknown defaults.view")
 	}
-	for _, view := range []string{"", "prs", "issues", "notifications"} {
+	for _, view := range []string{"", "prs", "issues", "notifications", "actions"} {
 		if err := (&Config{Defaults: Defaults{View: view}}).Validate(); err != nil {
 			t.Fatalf("Validate() rejected valid view %q: %v", view, err)
 		}
@@ -136,6 +156,20 @@ func TestConfigValidateRejectsBadSectionFilter(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() should reject a section with a non-@me author filter")
+	}
+}
+
+func TestConfigValidateRejectsBadActionRepo(t *testing.T) {
+	if err := (&Config{ActionsSections: []SectionConfig{{
+		Title: "Actions",
+		Repo:  "owner/repo/extra",
+	}}}).Validate(); err == nil {
+		t.Fatal("Validate() should reject malformed actionsSections.repo")
+	}
+	if err := (&Config{ActionsSections: []SectionConfig{{
+		Title: "Actions",
+	}}}).Validate(); err != nil {
+		t.Fatalf("Validate() should allow a blank actions repo for the empty state: %v", err)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -35,6 +36,7 @@ type Model struct {
 	prs           []section.Section
 	issues        []section.Section
 	notifications []section.Section
+	actions       []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
@@ -86,6 +88,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 			view = context.IssuesView
 		case "notifications":
 			view = context.NotificationsView
+		case "actions":
+			view = context.ActionsView
 		}
 	}
 	ctx := &context.ProgramContext{
@@ -128,6 +132,8 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 			sections[i] = issuesection.NewModel(i, ctx, cfg)
 		case context.NotificationsView:
 			sections[i] = notificationsection.NewModel(i, ctx, cfg)
+		case context.ActionsView:
+			sections[i] = actionsection.NewModel(i, ctx, cfg)
 		default:
 			sections[i] = pullsection.NewModel(i, ctx, cfg)
 		}
@@ -294,6 +300,8 @@ func (m Model) View() tea.View {
 		subtitle = "  my issues"
 	case context.NotificationsView:
 		subtitle = "  notifications"
+	case context.ActionsView:
+		subtitle = "  actions"
 	}
 	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
@@ -322,6 +330,8 @@ func (m Model) View() tea.View {
 // currentViewSections returns the section slice for the active view.
 func (m *Model) currentViewSections() []section.Section {
 	switch m.ctx.View {
+	case context.ActionsView:
+		return m.actions
 	case context.NotificationsView:
 		return m.notifications
 	case context.IssuesView:
@@ -334,6 +344,8 @@ func (m *Model) currentViewSections() []section.Section {
 // setCurrentViewSections stores s under the active view and rewires the tab bar.
 func (m *Model) setCurrentViewSections(s []section.Section) {
 	switch m.ctx.View {
+	case context.ActionsView:
+		m.actions = s
 	case context.NotificationsView:
 		m.notifications = s
 	case context.IssuesView:
@@ -458,6 +470,8 @@ func (m *Model) syncSidebar() {
 		rendered = prview.RenderIssue(r, m.issueDetails[key], w, m.expanded)
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
+	case data.ActionRun:
+		rendered = prview.RenderAction(r, w)
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -492,7 +506,7 @@ func (m *Model) clearSelectedPreviewCache() {
 	}
 }
 
-// switchView cycles pulls -> issues -> notifications, lazily building and
+// switchView cycles pulls -> issues -> notifications -> actions, lazily building and
 // fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
 	switch m.ctx.View {
@@ -500,6 +514,8 @@ func (m *Model) switchView() tea.Cmd {
 		m.ctx.View = context.IssuesView
 	case context.IssuesView:
 		m.ctx.View = context.NotificationsView
+	case context.NotificationsView:
+		m.ctx.View = context.ActionsView
 	default:
 		m.ctx.View = context.PullsView
 	}
@@ -567,6 +583,10 @@ func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {
 		if id >= 0 && id < len(m.notifications) {
 			m.notifications[id], cmd = m.notifications[id].Update(msg)
 		}
+	case actionsection.SectionType:
+		if id >= 0 && id < len(m.actions) {
+			m.actions[id], cmd = m.actions[id].Update(msg)
+		}
 	}
 	return cmd
 }
@@ -587,6 +607,9 @@ func (m *Model) syncProgramContext() {
 		s.UpdateProgramContext(m.ctx)
 	}
 	for _, s := range m.notifications {
+		s.UpdateProgramContext(m.ctx)
+	}
+	for _, s := range m.actions {
 		s.UpdateProgramContext(m.ctx)
 	}
 	m.tabs.UpdateProgramContext(m.ctx)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -39,6 +40,17 @@ func notificationFetchedMsg(rows []data.Notification) context.TaskFinishedMsg {
 		TaskId:      "n1",
 		Msg: notificationsection.SectionNotificationsFetchedMsg{
 			Rows: rows, TotalCount: len(rows), TaskId: "n1",
+		},
+	}
+}
+
+func actionFetchedMsg(rows []data.ActionRun) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: actionsection.SectionType,
+		TaskId:      "a1",
+		Msg: actionsection.SectionActionsFetchedMsg{
+			Rows: rows, TotalCount: len(rows), TaskId: "a1",
 		},
 	}
 }
@@ -178,6 +190,28 @@ func TestSwitchViewCyclesToNotifications(t *testing.T) {
 	}
 }
 
+func TestSwitchViewCyclesToActionsAndBackToPulls(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // issues
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = next.(Model)
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("View = %v, want ActionsView", m.ctx.View)
+	}
+	if len(m.actions) == 0 {
+		t.Fatal("expected action sections to be built lazily on switch")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch command after switching to the actions view")
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("View = %v, want PullsView after actions", m.ctx.View)
+	}
+}
+
 func TestSectionSwitchWithTwoSections(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{
@@ -295,6 +329,26 @@ func TestDefaultsViewStartsNotifications(t *testing.T) {
 	}
 }
 
+func TestDefaultsViewStartsActions(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("View = %v, want ActionsView", m.ctx.View)
+	}
+	if len(m.actions) == 0 {
+		t.Fatal("defaults.view=actions should build the action sections at startup")
+	}
+	if len(m.prs) != 0 || len(m.issues) != 0 || len(m.notifications) != 0 {
+		t.Fatalf("prs=%d issues=%d notifications=%d, want inactive views lazy",
+			len(m.prs), len(m.issues), len(m.notifications))
+	}
+}
+
 // TestCrossViewFetchRoutesToOwnSlice verifies a late PR fetch that lands while
 // the Issues view is active is still routed to the pulls slice by (id, type),
 // not to whatever section is currently on screen.
@@ -318,6 +372,7 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 	})
 	// Switch through Notifications back to the pulls view; the fetch must have
 	// landed in m.prs rather than whatever view is on screen.
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	if m.ctx.View != context.PullsView {
@@ -444,6 +499,54 @@ func TestModelRendersLoadedNotifications(t *testing.T) {
 	for _, want := range []string{"#42", "Review the new dashboard", "gbarany/tea-dash", "pull", "unread", "1 notification"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("notifications view is missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
+func TestModelRendersLoadedActions(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"}) // close preview for table assertions
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Actor: "octo", Event: "push",
+		Status: "completed", Conclusion: "success", UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"#77", "CI passed", "gbarany/tea-dash", "@octo push", "completed/success", "1 action run"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("actions view is missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
+func TestActionsPreviewRendersStaticSummary(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Actor: "octo", Event: "push",
+		Status: "completed", Conclusion: "success", HeadBranch: "main", HeadSHA: "abc123",
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"gbarany/tea-dash · #77", "CI passed", "completed/success", "main", "abc123", "push", "@octo"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("actions preview missing %q\n---\n%s", want, view)
 		}
 	}
 }
@@ -601,6 +704,7 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 	})
 
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // actions
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // pulls
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p1",

--- a/internal/ui/components/actionsection/actionsection.go
+++ b/internal/ui/components/actionsection/actionsection.go
@@ -1,0 +1,168 @@
+// Package actionsection is the Actions dashboard section: thin wiring over the
+// generic section.Model parameterized for repo-scoped data.ActionRun rows.
+package actionsection
+
+import (
+	stdctx "context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+// SectionType is the routing type tag for Actions sections.
+const SectionType = "action"
+
+// Model is the Actions section (the generic section specialized for action
+// runs, with wider state columns for status/conclusion).
+type Model struct {
+	*section.Model[data.ActionRun]
+}
+
+// SectionActionsFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
+type SectionActionsFetchedMsg = section.RowsFetchedMsg[data.ActionRun]
+
+var _ section.Section = (*Model)(nil)
+
+// NewModel builds an Actions section.
+func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	base := section.New(section.Options[data.ActionRun]{
+		Id:           id,
+		Ctx:          ctx,
+		Config:       cfg,
+		Type:         SectionType,
+		FilterKind:   "",
+		LoadingText:  "Loading action runs...",
+		EmptyText:    actionEmptyText(cfg),
+		EmptyHint:    actionEmptyHint(cfg),
+		SingularForm: "action run",
+		PluralForm:   "action runs",
+		Limit:        func(c *config.Config) int { return c.Defaults.ActionsLimit },
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.ActionRun, int, error) {
+			repoRef := strings.TrimSpace(cfg.Repo)
+			if repoRef == "" {
+				return nil, 0, nil
+			}
+			if c == nil {
+				return nil, 0, errors.New("Gitea client is not configured")
+			}
+			repo, err := config.ParseRepo(repoRef)
+			if err != nil {
+				return nil, 0, err
+			}
+			if limit <= 0 {
+				limit = 50
+			}
+			return c.ListActionRuns(ctx, repo.Owner, repo.Name, gitea.ActionRunListOptions{
+				Event:   f.Event,
+				Branch:  f.Branch,
+				Status:  f.Status,
+				Actor:   f.Actor,
+				HeadSHA: f.HeadSHA,
+				Limit:   limit,
+			})
+		},
+		BuildRow: actionBuildRow,
+	})
+	m := &Model{Model: base}
+	m.setActionColumns(ctx.MainContentWidth)
+	return m
+}
+
+// Update preserves the actionsection wrapper when the embedded generic section
+// handles a message.
+func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
+	next, cmd := m.Model.Update(msg)
+	if base, ok := next.(*section.Model[data.ActionRun]); ok {
+		m.Model = base
+	}
+	return m, cmd
+}
+
+// UpdateProgramContext resizes the table and reapplies the Actions columns.
+func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
+	m.Model.UpdateProgramContext(ctx)
+	m.setActionColumns(ctx.MainContentWidth)
+}
+
+func (m *Model) setActionColumns(mainWidth int) {
+	m.Columns = actionColumns(mainWidth)
+	m.Table.SetColumns(m.Columns)
+}
+
+func actionEmptyText(cfg config.SectionConfig) string {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return "No configured Actions sections."
+	}
+	return "No action runs match this filter."
+}
+
+func actionEmptyHint(cfg config.SectionConfig) string {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return "Add actionsSections with repo: owner/name to your tea-dash config."
+	}
+	return "This board shows repo-scoped Gitea Actions workflow runs."
+}
+
+func actionColumns(mainWidth int) []table.Column {
+	const (
+		numW     = 8
+		repoW    = 22
+		actorW   = 18
+		stateW   = 18
+		updatedW = 10
+	)
+	titleW := mainWidth - (numW + repoW + actorW + stateW + updatedW) - 6
+	if titleW < 20 {
+		titleW = 20
+	}
+	return []table.Column{
+		{Title: "#", Width: numW},
+		{Title: "Title", Width: titleW},
+		{Title: "Repo", Width: repoW},
+		{Title: "Actor/Event", Width: actorW},
+		{Title: "Status", Width: stateW},
+		{Title: "Updated", Width: updatedW},
+	}
+}
+
+func actionBuildRow(run data.ActionRun) table.Row {
+	return table.Row{
+		fmt.Sprintf("#%d", run.GetNumber()),
+		run.GetTitle(),
+		run.RepoNameWithOwner,
+		actionActorEvent(run),
+		actionStatus(run),
+		section.HumanizeTime(run.GetUpdatedAt()),
+	}
+}
+
+func actionActorEvent(run data.ActionRun) string {
+	var parts []string
+	if run.Actor != "" {
+		parts = append(parts, "@"+run.Actor)
+	}
+	if run.Event != "" {
+		parts = append(parts, run.Event)
+	}
+	return strings.Join(parts, " ")
+}
+
+func actionStatus(run data.ActionRun) string {
+	switch {
+	case run.Status != "" && run.Conclusion != "":
+		return run.Status + "/" + run.Conclusion
+	case run.Conclusion != "":
+		return run.Conclusion
+	default:
+		return run.Status
+	}
+}

--- a/internal/ui/components/actionsection/actionsection_test.go
+++ b/internal/ui/components/actionsection/actionsection_test.go
@@ -1,0 +1,225 @@
+package actionsection
+
+import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	ctx := &appctx.ProgramContext{Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20}
+	return NewModel(0, ctx, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+}
+
+func newFetchModel(t *testing.T, client *gitea.Client, cfg config.SectionConfig) *Model {
+	t.Helper()
+	ctx := &appctx.ProgramContext{
+		Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{Defaults: config.Defaults{ActionsLimit: 25}},
+		Client: client,
+		StartTask: func(appctx.Task) tea.Cmd {
+			return nil
+		},
+	}
+	return NewModel(0, ctx, cfg)
+}
+
+func TestImplementsSection(t *testing.T) {
+	var _ section.Section = (*Model)(nil)
+}
+
+func TestFetchedMsgBuildsRows(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("a1")
+	next, _ := m.Update(SectionActionsFetchedMsg{
+		Rows: []data.ActionRun{{
+			ID: 101, RunNumber: 12, DisplayTitle: "Fix checkout flakes",
+			RepoNameWithOwner: "acme/widgets", Actor: "octo", Event: "push",
+			Status: "completed", Conclusion: "success", UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1, TaskId: "a1",
+	})
+	m = next.(*Model)
+
+	if m.GetTotalCount() != 1 || m.NumRows() != 1 {
+		t.Fatalf("counts: total=%d rows=%d", m.GetTotalCount(), m.NumRows())
+	}
+	if m.GetCurrRow() == nil || m.GetCurrRow().GetNumber() != 12 {
+		t.Fatalf("GetCurrRow = %+v", m.GetCurrRow())
+	}
+	row := m.BuildRows()[0]
+	joined := strings.Join([]string(row), "|")
+	for _, want := range []string{"#12", "Fix checkout flakes", "acme/widgets", "@octo push", "completed/success"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("row %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestFetchRowsNoRepoReturnsEmptyResult(t *testing.T) {
+	m := newFetchModel(t, nil, config.SectionConfig{Title: "Actions"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("blank repo should not error: %v", payload.Err)
+	}
+	if len(payload.Rows) != 0 || payload.TotalCount != 0 {
+		t.Fatalf("blank repo payload = rows %d total %d, want empty", len(payload.Rows), payload.TotalCount)
+	}
+}
+
+func TestFetchRowsNilClientReturnsErrorInsteadOfPanicking(t *testing.T) {
+	m := newFetchModel(t, nil, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err == nil || !strings.Contains(payload.Err.Error(), "Gitea client") {
+		t.Fatalf("nil client payload error = %v, want Gitea client error", payload.Err)
+	}
+}
+
+func TestFetchRowsUsesRepoFiltersAndLimit(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `{
+				"total_count": 1,
+				"workflow_runs": [{
+					"id": 101,
+					"run_number": 12,
+					"display_title": "Fix checkout flakes",
+					"event": "push",
+					"status": "completed",
+					"conclusion": "success",
+					"head_branch": "main",
+					"head_sha": "abc123",
+					"actor": {"login": "octo"},
+					"updated_at": "2026-07-02T08:05:00Z"
+				}]
+			}`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	m := newFetchModel(t, client, config.SectionConfig{
+		Title: "CI",
+		Repo:  "acme/widgets",
+		Limit: 10,
+		Filter: config.PrIssueFilter{
+			Status:  "completed",
+			Branch:  "main",
+			Event:   "push",
+			Actor:   "octo",
+			HeadSHA: "abc123",
+		},
+	})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if payload.TotalCount != 1 || len(payload.Rows) != 1 || payload.Rows[0].RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("payload = total %d rows %+v", payload.TotalCount, payload.Rows)
+	}
+	for _, want := range []string{
+		"status=completed",
+		"branch=main",
+		"event=push",
+		"actor=octo",
+		"head_sha=abc123",
+		"limit=10",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+func TestFetchRowsDefaultsLimitTo50(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `[]`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &appctx.ProgramContext{
+		Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{},
+		Client: client,
+		StartTask: func(appctx.Task) tea.Cmd {
+			return nil
+		},
+	}
+	m := NewModel(0, ctx, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if !strings.Contains(gotQuery, "limit=50") {
+		t.Fatalf("query %q missing default limit=50", gotQuery)
+	}
+}
+
+func runFetchCommand(t *testing.T, cmd tea.Cmd) appctx.TaskFinishedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("FetchRows returned nil command")
+	}
+	msg := cmd()
+	if finished, ok := msg.(appctx.TaskFinishedMsg); ok {
+		return finished
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("FetchRows command returned %T, want TaskFinishedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		got := nested()
+		if finished, ok := got.(appctx.TaskFinishedMsg); ok {
+			return finished
+		}
+	}
+	t.Fatal("FetchRows batch did not contain a TaskFinishedMsg")
+	return appctx.TaskFinishedMsg{}
+}
+
+func actionServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -122,6 +122,45 @@ func RenderNotification(row data.Notification, width int) string {
 	return compose(header, body, false, width, true, nil)
 }
 
+// RenderAction renders a repo-scoped Actions workflow run into the preview. It
+// is intentionally static: opening the run in Gitea is the path to jobs/logs.
+func RenderAction(row data.ActionRun, width int) string {
+	header := []string{
+		locator(row.RepoNameWithOwner, row.GetNumber()),
+		titleLine(row.GetTitle(), width),
+	}
+	if status := actionRunStatus(row); status != "" {
+		header = append(header, pill(strings.ToUpper(status), actionRunColor(row)))
+	}
+
+	var body []string
+	if row.WorkflowName != "" {
+		body = append(body, "Workflow: "+row.WorkflowName)
+	}
+	if status := actionRunStatus(row); status != "" {
+		body = append(body, "Status: "+status)
+	}
+	if row.Event != "" {
+		body = append(body, "Event: "+row.Event)
+	}
+	if row.Actor != "" {
+		body = append(body, "Actor: @"+row.Actor)
+	}
+	if row.HeadBranch != "" {
+		body = append(body, "Branch: "+row.HeadBranch)
+	}
+	if row.HeadSHA != "" {
+		body = append(body, "SHA: "+shortSHA(row.HeadSHA))
+	}
+	if rel := section.HumanizeTime(row.GetUpdatedAt()); rel != "" {
+		body = append(body, "Updated: "+rel)
+	}
+	if len(body) == 0 {
+		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
+	}
+	return compose(header, strings.Join(body, "\n"), false, width, true, nil)
+}
+
 // compose joins the header block with the rendered body, then appends any
 // non-empty extra sections (CI / reviews / comments) below the fold, each
 // separated by a blank line so the viewport scrolls through them. When loading
@@ -225,6 +264,41 @@ func notificationColor(row data.Notification) string {
 	default:
 		return stateColor(row.SubjectState)
 	}
+}
+
+func actionRunStatus(row data.ActionRun) string {
+	switch {
+	case row.Status != "" && row.Conclusion != "":
+		return row.Status + "/" + row.Conclusion
+	case row.Conclusion != "":
+		return row.Conclusion
+	default:
+		return row.Status
+	}
+}
+
+func actionRunColor(row data.ActionRun) string {
+	switch strings.ToLower(row.Conclusion) {
+	case "success":
+		return colOpen
+	case "failure", "cancelled", "timed_out":
+		return colClosed
+	}
+	switch strings.ToLower(row.Status) {
+	case "completed":
+		return colDraft
+	case "queued", "waiting":
+		return "#d29922"
+	default:
+		return "#1f6feb"
+	}
+}
+
+func shortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
 }
 
 // renderCI renders the CI block: a colored "Checks: ✓N ✗M •K" summary line

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -23,6 +23,7 @@ const (
 	PullsView ViewType = iota
 	IssuesView
 	NotificationsView
+	ActionsView
 )
 
 // TaskState is the lifecycle of an async task.
@@ -61,7 +62,7 @@ type ProgramContext struct {
 	Config *config.Config
 	Client *gitea.Client // may be nil in tests
 	User   string        // client.Me(); "" when client is nil
-	View   ViewType      // PullsView | IssuesView | NotificationsView
+	View   ViewType      // PullsView | IssuesView | NotificationsView | ActionsView
 	Error  error
 	Styles Styles
 
@@ -74,6 +75,13 @@ type ProgramContext struct {
 // default section.
 func (c *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 	switch c.View {
+	case ActionsView:
+		if c.Config != nil && len(c.Config.ActionsSections) > 0 {
+			return c.Config.ActionsSections
+		}
+		return []config.SectionConfig{{
+			Title: "Actions",
+		}}
 	case NotificationsView:
 		if c.Config != nil && len(c.Config.NotificationsSections) > 0 {
 			return c.Config.NotificationsSections

--- a/internal/ui/context/context_test.go
+++ b/internal/ui/context/context_test.go
@@ -2,6 +2,8 @@ package context
 
 import (
 	"testing"
+
+	"github.com/gbarany/tea-dash/internal/config"
 )
 
 func TestDefaultStylesNonZero(t *testing.T) {
@@ -38,5 +40,28 @@ func TestGetViewSectionsConfigIssues(t *testing.T) {
 	}
 	if secs[0].Filter.CreatedBy != "@me" || secs[0].Filter.State != "open" {
 		t.Fatalf("default issues filter = %+v, want CreatedBy=@me State=open", secs[0].Filter)
+	}
+}
+
+func TestGetViewSectionsConfigActions(t *testing.T) {
+	ctx := &ProgramContext{View: ActionsView}
+	secs := ctx.GetViewSectionsConfig()
+	if len(secs) != 1 || secs[0].Title != "Actions" {
+		t.Fatalf("GetViewSectionsConfig(ActionsView) = %+v, want one empty-state section", secs)
+	}
+	if secs[0].Repo != "" {
+		t.Fatalf("default actions repo = %q, want blank repo for no-config empty state", secs[0].Repo)
+	}
+
+	ctx = &ProgramContext{
+		View: ActionsView,
+		Config: &config.Config{ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "acme/widgets",
+		}}},
+	}
+	secs = ctx.GetViewSectionsConfig()
+	if len(secs) != 1 || secs[0].Title != "CI" || secs[0].Repo != "acme/widgets" {
+		t.Fatalf("configured actions sections = %+v", secs)
 	}
 }


### PR DESCRIPTION
## Summary

Adds the first Actions UI slice on top of the Actions data layer.

- supports `defaults.view: actions`, `defaults.actionsLimit`, and `actionsSections`
- adds `actionsection` for repo-scoped `data.ActionRun` rows
- cycles views with `s`: PRs -> Issues -> Notifications -> Actions -> PRs
- fetches workflow runs via `Client.ListActionRuns`
- renders a static Actions run preview in the preview pane

## Notes

This is intentionally the first UI slice only. It does not add rerun/cancel controls, log viewing, or job-detail navigation yet.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/ui ./internal/ui/components/actionsection ./internal/data ./internal/gitea -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache make build`
