### PR TITLE
Add Actions run detail preview

### DIFF
--- a/internal/data/actions.go
+++ b/internal/data/actions.go
@@ -49,6 +49,12 @@ type ActionStep struct {
 	CompletedAt time.Time
 }
 
+// ActionRunDetail is the preview detail payload for one Actions workflow run.
+type ActionRunDetail struct {
+	Run  ActionRun
+	Jobs []ActionJob
+}
+
 func (r ActionRun) GetRepoNameWithOwner() string { return r.RepoNameWithOwner }
 
 func (r ActionRun) GetTitle() string {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,6 +2,7 @@
 package ui
 
 import (
+	stdctx "context"
 	"fmt"
 
 	"charm.land/bubbles/v2/key"
@@ -39,18 +40,18 @@ type Model struct {
 	actions       []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
-	// pullDetails and issueDetails memoize fetched detail views keyed by
-	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
-	// syncSidebar reads the right one without any runtime type assertion.
-	pullDetails  map[string]*data.PullDetail
-	issueDetails map[string]*data.IssueDetail
-	// pullEnrichErr and issueEnrichErr record the last failed detail fetch per
-	// key so the preview can show an error block (instead of a perpetual
-	// "Loading…") while keeping the row retryable. They are kept separate, just
-	// like the detail maps, because PRs and issues in the same repo can share a
-	// number ("owner/repo#num").
-	pullEnrichErr  map[string]error
-	issueEnrichErr map[string]error
+	// Detail maps memoize fetched preview detail keyed by "owner/repo#num".
+	// syncSidebar reads the map matching the selected row kind.
+	pullDetails   map[string]*data.PullDetail
+	issueDetails  map[string]*data.IssueDetail
+	actionDetails map[string]*data.ActionRunDetail
+	// Enrich error maps record the last failed detail fetch per key so the
+	// preview can show an error block while keeping the row retryable. They are
+	// kept separate, just like the detail maps, because row kinds can share a
+	// number in the same repo ("owner/repo#num").
+	pullEnrichErr   map[string]error
+	issueEnrichErr  map[string]error
+	actionEnrichErr map[string]error
 	// expanded controls whether the preview shows the full body or the folded
 	// (read-more) form. Reset to false each time the preview is (re)opened.
 	expanded bool
@@ -71,6 +72,7 @@ type enrichedMsg struct {
 	sectionType string
 	pull        *data.PullDetail
 	issue       *data.IssueDetail
+	action      *data.ActionRunDetail
 	err         error
 }
 
@@ -106,15 +108,17 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 	}
 
 	m := Model{
-		ctx:            ctx,
-		keys:           defaultKeyMap(),
-		tabs:           tabs.New(ctx),
-		sidebar:        sidebar.New(ctx),
-		tasks:          tasks,
-		pullDetails:    map[string]*data.PullDetail{},
-		issueDetails:   map[string]*data.IssueDetail{},
-		pullEnrichErr:  map[string]error{},
-		issueEnrichErr: map[string]error{},
+		ctx:             ctx,
+		keys:            defaultKeyMap(),
+		tabs:            tabs.New(ctx),
+		sidebar:         sidebar.New(ctx),
+		tasks:           tasks,
+		pullDetails:     map[string]*data.PullDetail{},
+		issueDetails:    map[string]*data.IssueDetail{},
+		actionDetails:   map[string]*data.ActionRunDetail{},
+		pullEnrichErr:   map[string]error{},
+		issueEnrichErr:  map[string]error{},
+		actionEnrichErr: map[string]error{},
 	}
 	// Build only the starting view's sections; the other slice stays nil until
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
@@ -195,6 +199,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.issue != nil {
 				delete(m.issueEnrichErr, msg.key)
 				m.issueDetails[msg.key] = msg.issue
+			}
+			if msg.action != nil {
+				delete(m.actionEnrichErr, msg.key)
+				m.actionDetails[msg.key] = msg.action
 			}
 		}
 		m.syncSidebar()
@@ -399,7 +407,9 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 	if key == "" {
 		return nil
 	}
+	sectionType := ""
 	if s := m.getCurrSection(); s != nil {
+		sectionType = s.GetType()
 		switch s.GetType() {
 		case pullsection.SectionType:
 			if _, ok := m.pullDetails[key]; ok {
@@ -407,6 +417,10 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 			}
 		case issuesection.SectionType:
 			if _, ok := m.issueDetails[key]; ok {
+				return nil
+			}
+		case actionsection.SectionType:
+			if _, ok := m.actionDetails[key]; ok {
 				return nil
 			}
 		default:
@@ -422,30 +436,57 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 	if client == nil {
 		return nil
 	}
-	index := row.GetNumber()
-	isPR := false
-	if s := m.getCurrSection(); s != nil {
-		isPR = s.GetType() == pullsection.SectionType
-	}
-	return func() tea.Msg {
-		if isPR {
+	switch sectionType {
+	case pullsection.SectionType:
+		index := row.GetNumber()
+		return func() tea.Msg {
 			d, err := client.GetPullDetail(owner, name, index)
 			if err != nil {
 				return enrichedMsg{key: key, sectionType: pullsection.SectionType, err: err}
 			}
 			return enrichedMsg{key: key, sectionType: pullsection.SectionType, pull: &d}
 		}
-		d, err := client.GetIssueDetail(owner, name, index)
-		if err != nil {
-			return enrichedMsg{key: key, sectionType: issuesection.SectionType, err: err}
+	case issuesection.SectionType:
+		index := row.GetNumber()
+		return func() tea.Msg {
+			d, err := client.GetIssueDetail(owner, name, index)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: issuesection.SectionType, err: err}
+			}
+			return enrichedMsg{key: key, sectionType: issuesection.SectionType, issue: &d}
 		}
-		return enrichedMsg{key: key, sectionType: issuesection.SectionType, issue: &d}
+	case actionsection.SectionType:
+		run, ok := row.(data.ActionRun)
+		if !ok {
+			return nil
+		}
+		runID := run.ID
+		if runID == 0 {
+			runID = run.GetNumber()
+		}
+		return func() tea.Msg {
+			d, err := client.GetActionRun(stdctx.Background(), owner, name, runID)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: actionsection.SectionType, err: err}
+			}
+			jobs, err := client.ListActionJobs(stdctx.Background(), owner, name, runID)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: actionsection.SectionType, err: err}
+			}
+			return enrichedMsg{
+				key:         key,
+				sectionType: actionsection.SectionType,
+				action:      &data.ActionRunDetail{Run: d, Jobs: jobs},
+			}
+		}
+	default:
+		return nil
 	}
 }
 
 // syncSidebar renders the current row (with its cached detail, if any) into the
-// preview pane. The concrete row type selects the pull vs issue renderer; a
-// missing/other-typed cache entry renders as the "loading" placeholder.
+// preview pane. The concrete row type selects the renderer; a missing cache
+// entry renders that row kind's loading placeholder.
 func (m *Model) syncSidebar() {
 	row := m.getCurrRowData()
 	if row == nil {
@@ -471,7 +512,11 @@ func (m *Model) syncSidebar() {
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
 	case data.ActionRun:
-		rendered = prview.RenderAction(r, w)
+		if err := m.actionEnrichErr[key]; err != nil {
+			m.sidebar.SetContent(m.failedPreview(row, err))
+			return
+		}
+		rendered = prview.RenderAction(r, m.actionDetails[key], w)
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -482,6 +527,8 @@ func (m *Model) setEnrichErr(sectionType, key string, err error) {
 		m.pullEnrichErr[key] = err
 	case issuesection.SectionType:
 		m.issueEnrichErr[key] = err
+	case actionsection.SectionType:
+		m.actionEnrichErr[key] = err
 	default:
 		if s := m.getCurrSection(); s != nil {
 			m.setEnrichErr(s.GetType(), key, err)
@@ -502,6 +549,9 @@ func (m *Model) clearSelectedPreviewCache() {
 		case issuesection.SectionType:
 			delete(m.issueDetails, key)
 			delete(m.issueEnrichErr, key)
+		case actionsection.SectionType:
+			delete(m.actionDetails, key)
+			delete(m.actionEnrichErr, key)
 		}
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,14 +1,20 @@
 package ui
 
 import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
@@ -551,6 +557,87 @@ func TestActionsPreviewRendersStaticSummary(t *testing.T) {
 	}
 }
 
+func TestActionsPreviewFetchesAndCachesRunDetail(t *testing.T) {
+	var runCalls, jobCalls int
+	srv := actionDetailServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/actions/runs/101", func(w http.ResponseWriter, _ *http.Request) {
+			runCalls++
+			fmt.Fprint(w, `{
+				"id": 101,
+				"run_number": 77,
+				"display_title": "CI passed",
+				"name": "CI",
+				"status": "completed",
+				"conclusion": "success",
+				"head_branch": "main",
+				"head_sha": "abc123"
+			}`)
+		})
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/actions/runs/101/jobs", func(w http.ResponseWriter, _ *http.Request) {
+			jobCalls++
+			fmt.Fprint(w, `{
+				"jobs": [{
+					"id": 201,
+					"run_id": 101,
+					"name": "build",
+					"status": "completed",
+					"conclusion": "success",
+					"runner_name": "ubuntu-latest",
+					"steps": [{
+						"number": 1,
+						"name": "checkout",
+						"status": "completed",
+						"conclusion": "success"
+					}]
+				}]
+			}`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	next, cmd := m.Update(actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Status: "completed", Conclusion: "success",
+	}}))
+	m = next.(Model)
+	msg := runEnrichedCommand(t, cmd)
+	if msg.err != nil {
+		t.Fatalf("action detail fetch returned error: %v", msg.err)
+	}
+	if msg.sectionType != actionsection.SectionType || msg.action == nil {
+		t.Fatalf("enrichedMsg = %+v, want action detail for action section", msg)
+	}
+
+	m = update(t, m, msg)
+	key := m.selKey()
+	if _, ok := m.actionDetails[key]; !ok {
+		t.Fatalf("actionDetails should contain %q after enrichedMsg", key)
+	}
+	view := m.View().Content
+	for _, want := range []string{"Jobs:", "build", "ubuntu-latest", "checkout"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("action detail preview missing %q:\n%s", want, view)
+		}
+	}
+	if runCalls != 1 || jobCalls != 1 {
+		t.Fatalf("detail endpoints called run=%d jobs=%d, want once each", runCalls, jobCalls)
+	}
+	if cmd := m.enrichCurrRow(); cmd != nil {
+		t.Fatal("cached action detail should suppress another lazy fetch")
+	}
+}
+
 // TestPreviewStartsOpenAndToggles verifies the preview pane is visible by
 // default: the initial window size gives it dimensions and the composed View()
 // renders the sidebar region. 'p' still toggles it closed and open again.
@@ -816,6 +903,46 @@ func isQuitCmd(cmd tea.Cmd) bool {
 	}
 	_, ok := cmd().(tea.QuitMsg)
 	return ok
+}
+
+func runEnrichedCommand(t *testing.T, cmd tea.Cmd) enrichedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected an enrichment command, got nil")
+	}
+	msg := cmd()
+	if enriched, ok := msg.(enrichedMsg); ok {
+		return enriched
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("enrichment command returned %T, want enrichedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		if nested == nil {
+			continue
+		}
+		if enriched, ok := nested().(enrichedMsg); ok {
+			return enriched
+		}
+	}
+	t.Fatal("enrichment batch did not contain an enrichedMsg")
+	return enrichedMsg{}
+}
+
+func actionDetailServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 var errBoom = errBoomType("boom")

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -30,8 +30,10 @@ const (
 // maxChecks / maxComments cap how many per-check and per-comment lines render
 // before a "…and N more" summary line.
 const (
-	maxChecks   = 8
-	maxComments = 10
+	maxChecks      = 8
+	maxComments    = 10
+	maxActionJobs  = 12
+	maxActionSteps = 12
 )
 
 var (
@@ -122,43 +124,53 @@ func RenderNotification(row data.Notification, width int) string {
 	return compose(header, body, false, width, true, nil)
 }
 
-// RenderAction renders a repo-scoped Actions workflow run into the preview. It
-// is intentionally static: opening the run in Gitea is the path to jobs/logs.
-func RenderAction(row data.ActionRun, width int) string {
-	header := []string{
-		locator(row.RepoNameWithOwner, row.GetNumber()),
-		titleLine(row.GetTitle(), width),
+// RenderAction renders a repo-scoped Actions workflow run into the preview.
+// When detail is present it appends the loaded job and step statuses.
+func RenderAction(row data.ActionRun, detail *data.ActionRunDetail, width int) string {
+	run := row
+	if detail != nil {
+		run = mergeActionRun(row, detail.Run)
 	}
-	if status := actionRunStatus(row); status != "" {
-		header = append(header, pill(strings.ToUpper(status), actionRunColor(row)))
+	header := []string{
+		locator(run.RepoNameWithOwner, run.GetNumber()),
+		titleLine(run.GetTitle(), width),
+	}
+	if status := actionRunStatus(run); status != "" {
+		header = append(header, pill(strings.ToUpper(status), actionRunColor(run)))
 	}
 
 	var body []string
-	if row.WorkflowName != "" {
-		body = append(body, "Workflow: "+row.WorkflowName)
+	if run.WorkflowName != "" {
+		body = append(body, "Workflow: "+run.WorkflowName)
 	}
-	if status := actionRunStatus(row); status != "" {
+	if status := actionRunStatus(run); status != "" {
 		body = append(body, "Status: "+status)
 	}
-	if row.Event != "" {
-		body = append(body, "Event: "+row.Event)
+	if run.Event != "" {
+		body = append(body, "Event: "+run.Event)
 	}
-	if row.Actor != "" {
-		body = append(body, "Actor: @"+row.Actor)
+	if run.Actor != "" {
+		body = append(body, "Actor: @"+run.Actor)
 	}
-	if row.HeadBranch != "" {
-		body = append(body, "Branch: "+row.HeadBranch)
+	if run.HeadBranch != "" {
+		body = append(body, "Branch: "+run.HeadBranch)
 	}
-	if row.HeadSHA != "" {
-		body = append(body, "SHA: "+shortSHA(row.HeadSHA))
+	if run.HeadSHA != "" {
+		body = append(body, "SHA: "+shortSHA(run.HeadSHA))
 	}
-	if rel := section.HumanizeTime(row.GetUpdatedAt()); rel != "" {
+	if rel := section.HumanizeTime(run.GetUpdatedAt()); rel != "" {
 		body = append(body, "Updated: "+rel)
 	}
 	if len(body) == 0 {
 		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
 	}
-	return compose(header, strings.Join(body, "\n"), false, width, true, nil)
+	var extras []string
+	if detail == nil {
+		body = append(body, "", "Jobs: Loading...")
+	} else {
+		extras = []string{renderActionJobs(detail.Jobs, width)}
+	}
+	return compose(header, strings.Join(body, "\n"), false, width, true, extras)
 }
 
 // compose joins the header block with the rendered body, then appends any
@@ -291,6 +303,145 @@ func actionRunColor(row data.ActionRun) string {
 		return "#d29922"
 	default:
 		return "#1f6feb"
+	}
+}
+
+func mergeActionRun(base, detail data.ActionRun) data.ActionRun {
+	if detail.ID == 0 {
+		return base
+	}
+	if detail.RunNumber == 0 {
+		detail.RunNumber = base.RunNumber
+	}
+	if detail.RunAttempt == 0 {
+		detail.RunAttempt = base.RunAttempt
+	}
+	if detail.DisplayTitle == "" {
+		detail.DisplayTitle = base.DisplayTitle
+	}
+	if detail.WorkflowName == "" {
+		detail.WorkflowName = base.WorkflowName
+	}
+	if detail.Event == "" {
+		detail.Event = base.Event
+	}
+	if detail.Status == "" {
+		detail.Status = base.Status
+	}
+	if detail.Conclusion == "" {
+		detail.Conclusion = base.Conclusion
+	}
+	if detail.HeadBranch == "" {
+		detail.HeadBranch = base.HeadBranch
+	}
+	if detail.HeadSHA == "" {
+		detail.HeadSHA = base.HeadSHA
+	}
+	if detail.Actor == "" {
+		detail.Actor = base.Actor
+	}
+	if detail.RepoNameWithOwner == "" {
+		detail.RepoNameWithOwner = base.RepoNameWithOwner
+	}
+	if detail.HTMLURL == "" {
+		detail.HTMLURL = base.HTMLURL
+	}
+	if detail.CreatedAt.IsZero() {
+		detail.CreatedAt = base.CreatedAt
+	}
+	if detail.UpdatedAt.IsZero() {
+		detail.UpdatedAt = base.UpdatedAt
+	}
+	if detail.StartedAt.IsZero() {
+		detail.StartedAt = base.StartedAt
+	}
+	return detail
+}
+
+func renderActionJobs(jobs []data.ActionJob, width int) string {
+	lines := []string{titleStyle.Render("Jobs:")}
+	if len(jobs) == 0 {
+		return strings.Join(append(lines, dimStyle.Render("No jobs reported.")), "\n")
+	}
+
+	shown := jobs
+	extra := 0
+	if len(shown) > maxActionJobs {
+		extra = len(shown) - maxActionJobs
+		shown = shown[:maxActionJobs]
+	}
+	for _, job := range shown {
+		lines = append(lines, actionJobLine(job, width))
+		steps := job.Steps
+		stepExtra := 0
+		if len(steps) > maxActionSteps {
+			stepExtra = len(steps) - maxActionSteps
+			steps = steps[:maxActionSteps]
+		}
+		for _, step := range steps {
+			lines = append(lines, actionStepLine(step, width))
+		}
+		if stepExtra > 0 {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("  …and %d more steps", stepExtra)))
+		}
+	}
+	if extra > 0 {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("…and %d more jobs", extra)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func actionJobLine(job data.ActionJob, width int) string {
+	icon, st := actionStatusIcon(job.Status, job.Conclusion)
+	text := job.Name
+	if status := actionItemStatus(job.Status, job.Conclusion); status != "" {
+		text += " · " + status
+	}
+	if job.RunnerName != "" {
+		text += " · " + job.RunnerName
+	}
+	return st.Render(icon) + " " + truncateText(text, width-2)
+}
+
+func actionStepLine(step data.ActionStep, width int) string {
+	icon, st := actionStatusIcon(step.Status, step.Conclusion)
+	text := step.Name
+	if step.Number != 0 {
+		text = fmt.Sprintf("%d. %s", step.Number, text)
+	}
+	if status := actionItemStatus(step.Status, step.Conclusion); status != "" {
+		text += " · " + status
+	}
+	return "  " + st.Render(icon) + " " + truncateText(text, width-4)
+}
+
+func actionItemStatus(status, conclusion string) string {
+	switch {
+	case status != "" && conclusion != "":
+		return status + "/" + conclusion
+	case conclusion != "":
+		return conclusion
+	default:
+		return status
+	}
+}
+
+func actionStatusIcon(status, conclusion string) (string, lipgloss.Style) {
+	switch strings.ToLower(conclusion) {
+	case "success":
+		return "✓", greenStyle
+	case "failure", "cancelled", "timed_out":
+		return "✗", redStyle
+	case "skipped":
+		return "•", dimStyle
+	}
+	switch strings.ToLower(status) {
+	case "completed":
+		return "•", dimStyle
+	case "queued", "waiting", "in_progress", "requested":
+		return "•", yellowStyle
+	default:
+		return "•", yellowStyle
 	}
 }
 

--- a/internal/ui/components/prview/prview_test.go
+++ b/internal/ui/components/prview/prview_test.go
@@ -184,6 +184,57 @@ func TestRenderIssueSingleComment(t *testing.T) {
 	}
 }
 
+func TestRenderActionWithDetailShowsJobsAndSteps(t *testing.T) {
+	row := data.ActionRun{
+		ID:                101,
+		RunNumber:         77,
+		DisplayTitle:      "CI passed",
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "gbarany/tea-dash",
+		Status:            "completed",
+		Conclusion:        "success",
+	}
+	detail := &data.ActionRunDetail{
+		Run: row,
+		Jobs: []data.ActionJob{{
+			ID:         201,
+			RunID:      101,
+			Name:       "build",
+			Status:     "completed",
+			Conclusion: "success",
+			RunnerName: "ubuntu-latest",
+			Steps: []data.ActionStep{{
+				Number:     1,
+				Name:       "checkout",
+				Status:     "completed",
+				Conclusion: "success",
+			}, {
+				Number:     2,
+				Name:       "go test",
+				Status:     "completed",
+				Conclusion: "failure",
+			}},
+		}},
+	}
+
+	out := RenderAction(row, detail, 80)
+	for _, want := range []string{
+		"gbarany/tea-dash · #77",
+		"CI passed",
+		"Jobs:",
+		"build",
+		"ubuntu-latest",
+		"checkout",
+		"go test",
+		"completed/success",
+		"completed/failure",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("action detail preview missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // TestRenderNilDetailNoComments verifies a nil detail keeps the Loading
 // placeholder and renders no comments/CI sections.
 func TestRenderNilDetailNoComments(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds lazy Actions run detail to the preview pane.

- fetches run detail and jobs/steps for the selected Actions run
- caches detail per run and shows an in-pane error if enrichment fails
- renders jobs, runners, steps, statuses, and conclusions in the Actions preview
- keeps the slice read-only: no rerun/cancel controls and no job log streaming yet

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
