### PR TITLE
Add read-only branches view

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ A terminal dashboard for [Gitea](https://about.gitea.com/) (and Forgejo /
 Codeberg), in the spirit of [`gh-dash`](https://github.com/dlvhdr/gh-dash) — but
 for Gitea instead of GitHub.
 
-tea-dash is a keyboard-driven TUI for triaging pull requests, issues and
-notifications across one or more Gitea instances, without leaving the terminal.
+tea-dash is a keyboard-driven TUI for triaging pull requests, issues,
+notifications, and local branches across one or more Gitea instances, without
+leaving the terminal.
 
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
-> pull requests, issues, and unread notifications across all your repos (fetched
-> via the Gitea API (Go SDK + REST)), with view switching (`s`), configurable
-> sections you page through with `h`/`l`, preview pane support, and live keyword
-> search (`/`). PR actions are in progress. See
+> pull requests, issues, unread notifications across all your repos (fetched via
+> the Gitea API (Go SDK + REST)), and read-only local branch status for
+> configured git checkouts, with view switching (`s`), configurable sections you
+> page through with `h`/`l`, preview pane support, and live keyword search (`/`).
+> PR actions are in progress. See
 > [`docs/architecture.md`](docs/architecture.md) for the design.
 
 ## Why
@@ -72,7 +74,7 @@ tea-dash --help
 | Key             | Action                  |
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
-| `s`             | switch view (PRs/issues/notifications)|
+| `s`             | switch view (PRs/issues/notifications/branches)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
 | `p`             | toggle preview pane     |
@@ -100,10 +102,15 @@ instance:
   # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
 
 defaults:
-  view: prs              # startup view: "prs", "issues", or "notifications"
+  view: prs              # startup view: "prs", "issues", "notifications", or "branches"
   prsLimit: 50           # rows fetched per PR section (0 -> 50)
   issuesLimit: 50        # rows fetched per issue section (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
+  branchesLimit: 0       # local branches shown (0 -> all)
+
+localRepos:
+  - name: tea-dash
+    path: /Users/gaborbarany/dev/sandbox/tea-dash
 
 # Each section becomes a tab you page through with h/l. Omit prSections to get
 # two "@me"-authored PR defaults: open and closed pull requests. Omit
@@ -133,6 +140,9 @@ issuesSections:
 notificationsSections:
   - title: Unread
     limit: 50
+
+branchSections:
+  - title: Local Branches
 ```
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
@@ -148,7 +158,9 @@ With or without a config file, tea-dash shows the pull requests and issues you
 authored, plus unread notifications, across every repo you can access on your
 Gitea instance. The default PR view has separate open and closed-history tabs;
 sections and filters let you tailor what each tab shows. Notification sections
-currently support title/limit configuration and default to unread threads.
+currently support title/limit configuration and default to unread threads. The
+branches view shells out to local `git` for configured `localRepos` only and is
+read-only; with no `localRepos`, it falls back to the current working directory.
 
 ## Development
 
@@ -166,6 +178,7 @@ Project layout:
 main.go                 entrypoint + flag handling; loads config, starts the TUI
 internal/ui/            Bubble Tea model, table, preview, keybindings, styles
 internal/gitea/         Gitea Go SDK client wrapper + PR/issue/notification APIs
+internal/git/           read-only local git branch status
 internal/auth/          resolves instance URL + token from the tea config
 internal/data/          TUI-agnostic domain models
 internal/config/        ~/.config/tea-dash/config.yml loading

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,14 +17,18 @@ type Config struct {
 	Instance Instance `yaml:"instance"`
 	// Login is a deprecated alias for Instance.Login (tea login profile name).
 	Login string `yaml:"login"`
-	// Repos lists repositories to watch. Unused in M0; per-repo sections
-	// return in M1.
+	// Repos lists remote Gitea repositories to watch. Unused in M0; per-repo
+	// sections return in M1.
 	Repos []string `yaml:"repos"`
-	// PRSections, IssuesSections, and NotificationsSections configure the tabs
-	// for their respective views. Empty falls back to a default section.
+	// LocalRepos lists local git repository paths for read-only branch status.
+	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
+	// PRSections, IssuesSections, NotificationsSections, and BranchSections
+	// configure tabs for their respective views. Empty falls back to a default
+	// section.
 	PRSections            []SectionConfig `yaml:"prSections"`
 	IssuesSections        []SectionConfig `yaml:"issuesSections"`
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
+	BranchSections        []SectionConfig `yaml:"branchSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 }
@@ -37,6 +41,7 @@ type Defaults struct {
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
+	BranchesLimit      int    `yaml:"branchesLimit"`
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -58,6 +63,13 @@ type SectionConfig struct {
 	// (defaults.prsLimit / defaults.issuesLimit), which in turn falls back to 50.
 	// Precedence: section Limit -> per-view default -> 50.
 	Limit int `yaml:"limit"`
+}
+
+// LocalRepoConfig describes one local git checkout to include in the branches
+// view. Name is optional; Path must point at a git repository worktree.
+type LocalRepoConfig struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
 }
 
 // PrIssueFilter is the structured, config-driven filter for one section. Every
@@ -118,10 +130,20 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	for _, s := range c.BranchSections {
+		if err := s.Filter.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, r := range c.LocalRepos {
+		if strings.TrimSpace(r.Path) == "" {
+			return fmt.Errorf("localRepos entry %q: path is required", r.Name)
+		}
+	}
 	switch c.Defaults.View {
-	case "", "prs", "issues", "notifications":
+	case "", "prs", "issues", "notifications", "branches":
 	default:
-		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", or \"notifications\"", c.Defaults.View)
+		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", or \"branches\"", c.Defaults.View)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,7 @@ defaults:
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
+  branchesLimit: 100
 prSections:
   - title: My PRs
     filter:
@@ -85,13 +86,19 @@ issuesSections:
 notificationsSections:
   - title: Inbox
     limit: 15
+branchSections:
+  - title: Local Branches
+    limit: 25
+localRepos:
+  - name: tea-dash
+    path: /Users/gaborbarany/dev/sandbox/tea-dash
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
-		c.Defaults.NotificationsLimit != 30 {
+		c.Defaults.NotificationsLimit != 30 || c.Defaults.BranchesLimit != 100 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -105,6 +112,14 @@ notificationsSections:
 	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
 		c.NotificationsSections[0].Limit != 15 {
 		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
+	}
+	if len(c.BranchSections) != 1 || c.BranchSections[0].Title != "Local Branches" ||
+		c.BranchSections[0].Limit != 25 {
+		t.Fatalf("branchSections = %+v", c.BranchSections)
+	}
+	if len(c.LocalRepos) != 1 || c.LocalRepos[0].Name != "tea-dash" ||
+		c.LocalRepos[0].Path != "/Users/gaborbarany/dev/sandbox/tea-dash" {
+		t.Fatalf("localRepos = %+v", c.LocalRepos)
 	}
 }
 
@@ -121,10 +136,17 @@ func TestConfigValidateBadView(t *testing.T) {
 	if err := (&Config{Defaults: Defaults{View: "nope"}}).Validate(); err == nil {
 		t.Fatal("Validate() should reject an unknown defaults.view")
 	}
-	for _, view := range []string{"", "prs", "issues", "notifications"} {
+	for _, view := range []string{"", "prs", "issues", "notifications", "branches"} {
 		if err := (&Config{Defaults: Defaults{View: view}}).Validate(); err != nil {
 			t.Fatalf("Validate() rejected valid view %q: %v", view, err)
 		}
+	}
+}
+
+func TestConfigValidateRejectsLocalRepoWithoutPath(t *testing.T) {
+	cfg := &Config{LocalRepos: []LocalRepoConfig{{Name: "missing"}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should reject a local repo without a path")
 	}
 }
 

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -1,0 +1,202 @@
+// Package git reads local repository state through the git executable.
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Repository is a local git repository known to tea-dash.
+type Repository struct {
+	Name string
+	Path string
+}
+
+// Label returns the configured display name, falling back to the directory name.
+func (r Repository) Label() string {
+	if strings.TrimSpace(r.Name) != "" {
+		return strings.TrimSpace(r.Name)
+	}
+	return filepath.Base(filepath.Clean(r.Path))
+}
+
+// Branch is one local branch plus its upstream tracking state.
+type Branch struct {
+	Repository     string
+	RepositoryPath string
+	Name           string
+	Current        bool
+	Upstream       string
+	Ahead          int
+	Behind         int
+	UpstreamGone   bool
+	Commit         string
+	Subject        string
+	UpdatedAt      time.Time
+	WorktreePath   string
+}
+
+// Status summarizes the branch's local/upstream state for compact tables.
+func (b Branch) Status() string {
+	parts := make([]string, 0, 3)
+	if b.Current {
+		parts = append(parts, "current")
+	}
+	if b.UpstreamGone {
+		parts = append(parts, "gone")
+	} else if b.Ahead > 0 && b.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("ahead %d, behind %d", b.Ahead, b.Behind))
+	} else if b.Ahead > 0 {
+		parts = append(parts, fmt.Sprintf("ahead %d", b.Ahead))
+	} else if b.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("behind %d", b.Behind))
+	} else if b.Upstream != "" {
+		parts = append(parts, "synced")
+	} else {
+		parts = append(parts, "local")
+	}
+	if !b.Current && b.WorktreePath != "" {
+		parts = append(parts, "checked out")
+	}
+	return strings.Join(parts, " · ")
+}
+
+// RowData projection methods let Branch reuse the existing generic section.
+func (b Branch) GetRepoNameWithOwner() string { return b.Repository }
+func (b Branch) GetTitle() string             { return b.Name }
+func (b Branch) GetNumber() int64             { return 0 }
+func (b Branch) GetURL() string               { return "" }
+func (b Branch) GetUpdatedAt() time.Time      { return b.UpdatedAt }
+
+// ListBranches returns local branches for one repository.
+func ListBranches(ctx context.Context, repo Repository) ([]Branch, error) {
+	if strings.TrimSpace(repo.Path) == "" {
+		return nil, fmt.Errorf("repository path is required")
+	}
+	format := strings.Join([]string{
+		"%(refname:short)",
+		"%(HEAD)",
+		"%(upstream:short)",
+		"%(upstream:track)",
+		"%(objectname:short)",
+		"%(contents:subject)",
+		"%(committerdate:unix)",
+		"%(worktreepath)",
+	}, "%00")
+	cmd := exec.CommandContext(ctx, "git", "-C", repo.Path, "for-each-ref", "--sort=refname", "--format="+format, "refs/heads")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("git for-each-ref %s: %w: %s", repo.Path, err, strings.TrimSpace(string(out)))
+	}
+	return parseForEachRef(repo, string(out))
+}
+
+// ListBranchesForRepositories returns branches for every configured repository.
+func ListBranchesForRepositories(ctx context.Context, repos []Repository) ([]Branch, error) {
+	var out []Branch
+	for _, repo := range repos {
+		branches, err := ListBranches(ctx, repo)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", repo.Label(), err)
+		}
+		out = append(out, branches...)
+	}
+	return out, nil
+}
+
+func parseForEachRef(repo Repository, out string) ([]Branch, error) {
+	out = strings.TrimSuffix(out, "\n")
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	branches := make([]Branch, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Split(line, "\x00")
+		if len(fields) != 8 {
+			return nil, fmt.Errorf("unexpected for-each-ref record with %d fields", len(fields))
+		}
+		track, err := parseTrackStatus(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		updated, err := parseUnixTime(fields[6])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		branches = append(branches, Branch{
+			Repository:     repo.Label(),
+			RepositoryPath: repo.Path,
+			Name:           fields[0],
+			Current:        strings.TrimSpace(fields[1]) == "*",
+			Upstream:       fields[2],
+			Ahead:          track.Ahead,
+			Behind:         track.Behind,
+			UpstreamGone:   track.Gone,
+			Commit:         fields[4],
+			Subject:        fields[5],
+			UpdatedAt:      updated,
+			WorktreePath:   fields[7],
+		})
+	}
+	return branches, nil
+}
+
+type trackStatus struct {
+	Ahead  int
+	Behind int
+	Gone   bool
+}
+
+func parseTrackStatus(raw string) (trackStatus, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return trackStatus{}, nil
+	}
+	if raw == "[gone]" {
+		return trackStatus{Gone: true}, nil
+	}
+	if !strings.HasPrefix(raw, "[") || !strings.HasSuffix(raw, "]") {
+		return trackStatus{}, fmt.Errorf("unexpected upstream track status %q", raw)
+	}
+	raw = strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]")
+	var status trackStatus
+	for _, part := range strings.Split(raw, ", ") {
+		key, val, ok := strings.Cut(part, " ")
+		if !ok {
+			return trackStatus{}, fmt.Errorf("unexpected upstream track status %q", part)
+		}
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return trackStatus{}, fmt.Errorf("unexpected upstream track count %q: %w", val, err)
+		}
+		switch key {
+		case "ahead":
+			status.Ahead = n
+		case "behind":
+			status.Behind = n
+		default:
+			return trackStatus{}, fmt.Errorf("unexpected upstream track key %q", key)
+		}
+	}
+	return status, nil
+}
+
+func parseUnixTime(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	sec, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unexpected commit time %q: %w", raw, err)
+	}
+	return time.Unix(sec, 0), nil
+}

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -1,0 +1,181 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListBranchesReadsLocalBranchesAndUpstreamStatus(t *testing.T) {
+	repoPath := newBranchRepo(t)
+
+	branches, err := ListBranches(context.Background(), Repository{Name: "tea-dash", Path: repoPath})
+	if err != nil {
+		t.Fatalf("ListBranches() error: %v", err)
+	}
+
+	byName := map[string]Branch{}
+	for _, b := range branches {
+		byName[b.Name] = b
+		if b.Repository != "tea-dash" {
+			t.Fatalf("Branch.Repository = %q, want tea-dash", b.Repository)
+		}
+		if b.RepositoryPath != repoPath {
+			t.Fatalf("Branch.RepositoryPath = %q, want %q", b.RepositoryPath, repoPath)
+		}
+	}
+
+	feature, ok := byName["feature"]
+	if !ok {
+		t.Fatalf("branches missing feature: %+v", branches)
+	}
+	if !feature.Current {
+		t.Fatal("feature should be marked current")
+	}
+	if feature.Upstream != "origin/feature" || feature.Ahead != 1 || feature.Behind != 0 {
+		t.Fatalf("feature upstream status = upstream %q ahead %d behind %d, want origin/feature ahead 1 behind 0",
+			feature.Upstream, feature.Ahead, feature.Behind)
+	}
+	if feature.Commit == "" || feature.Subject != "local feature work" {
+		t.Fatalf("feature commit metadata = %q %q, want short commit and subject", feature.Commit, feature.Subject)
+	}
+
+	main, ok := byName["main"]
+	if !ok {
+		t.Fatalf("branches missing main: %+v", branches)
+	}
+	if main.Current {
+		t.Fatal("main should not be marked current")
+	}
+	if main.Upstream != "origin/main" || main.Ahead != 0 || main.Behind != 1 {
+		t.Fatalf("main upstream status = upstream %q ahead %d behind %d, want origin/main ahead 0 behind 1",
+			main.Upstream, main.Ahead, main.Behind)
+	}
+}
+
+func TestListBranchesForRepositoriesAggregatesAndLabelsRepos(t *testing.T) {
+	first := newSingleBranchRepo(t, "first repo")
+	second := newSingleBranchRepo(t, "second repo")
+
+	branches, err := ListBranchesForRepositories(context.Background(), []Repository{
+		{Name: "first", Path: first},
+		{Name: "second", Path: second},
+	})
+	if err != nil {
+		t.Fatalf("ListBranchesForRepositories() error: %v", err)
+	}
+
+	if len(branches) != 2 {
+		t.Fatalf("len(branches) = %d, want 2: %+v", len(branches), branches)
+	}
+	seen := map[string]bool{}
+	for _, b := range branches {
+		seen[b.Repository] = true
+	}
+	if !seen["first"] || !seen["second"] {
+		t.Fatalf("repositories seen = %+v, want first and second", seen)
+	}
+}
+
+func TestParseTrackStatus(t *testing.T) {
+	cases := []struct {
+		in      string
+		ahead   int
+		behind  int
+		gone    bool
+		wantErr bool
+	}{
+		{in: "", ahead: 0, behind: 0},
+		{in: "[ahead 2]", ahead: 2},
+		{in: "[behind 3]", behind: 3},
+		{in: "[ahead 2, behind 3]", ahead: 2, behind: 3},
+		{in: "[gone]", gone: true},
+		{in: "[ahead nope]", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseTrackStatus(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseTrackStatus(%q) expected error, got nil", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTrackStatus(%q) error: %v", tc.in, err)
+			}
+			if got.Ahead != tc.ahead || got.Behind != tc.behind || got.Gone != tc.gone {
+				t.Fatalf("parseTrackStatus(%q) = %+v, want ahead=%d behind=%d gone=%v",
+					tc.in, got, tc.ahead, tc.behind, tc.gone)
+			}
+		})
+	}
+}
+
+func newBranchRepo(t *testing.T) string {
+	t.Helper()
+	repo := newSingleBranchRepo(t, "base")
+
+	runGit(t, repo, "update-ref", "refs/remotes/origin/feature", "HEAD")
+	runGit(t, repo, "branch", "feature")
+	runGit(t, repo, "branch", "--set-upstream-to", "origin/feature", "feature")
+	runGit(t, repo, "checkout", "feature")
+	writeFile(t, repo, "feature.txt", "local feature work\n")
+	runGit(t, repo, "add", "feature.txt")
+	runGit(t, repo, "commit", "-m", "local feature work")
+
+	runGit(t, repo, "checkout", "main")
+	runGit(t, repo, "checkout", "-b", "remote-main")
+	writeFile(t, repo, "remote.txt", "remote main work\n")
+	runGit(t, repo, "add", "remote.txt")
+	runGit(t, repo, "commit", "-m", "remote main work")
+	remoteMain := gitOutput(t, repo, "rev-parse", "HEAD")
+	runGit(t, repo, "checkout", "main")
+	runGit(t, repo, "branch", "-D", "remote-main")
+	runGit(t, repo, "update-ref", "refs/remotes/origin/main", remoteMain)
+	runGit(t, repo, "branch", "--set-upstream-to", "origin/main", "main")
+
+	runGit(t, repo, "checkout", "feature")
+	return repo
+}
+
+func newSingleBranchRepo(t *testing.T, subject string) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "--initial-branch", "main")
+	runGit(t, repo, "config", "user.name", "tea-dash tests")
+	runGit(t, repo, "config", "user.email", "tea-dash@example.invalid")
+	runGit(t, repo, "remote", "add", "origin", "https://example.invalid/repo.git")
+	writeFile(t, repo, "README.md", subject+"\n")
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", subject)
+	runGit(t, repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, repo, "branch", "--set-upstream-to", "origin/main", "main")
+	return repo
+}
+
+func writeFile(t *testing.T, repo, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	_ = gitOutput(t, repo, args...)
+}
+
+func gitOutput(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/branchsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -35,6 +36,7 @@ type Model struct {
 	prs           []section.Section
 	issues        []section.Section
 	notifications []section.Section
+	branches      []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
@@ -86,6 +88,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 			view = context.IssuesView
 		case "notifications":
 			view = context.NotificationsView
+		case "branches":
+			view = context.BranchesView
 		}
 	}
 	ctx := &context.ProgramContext{
@@ -128,6 +132,8 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 			sections[i] = issuesection.NewModel(i, ctx, cfg)
 		case context.NotificationsView:
 			sections[i] = notificationsection.NewModel(i, ctx, cfg)
+		case context.BranchesView:
+			sections[i] = branchsection.NewModel(i, ctx, cfg)
 		default:
 			sections[i] = pullsection.NewModel(i, ctx, cfg)
 		}
@@ -294,6 +300,8 @@ func (m Model) View() tea.View {
 		subtitle = "  my issues"
 	case context.NotificationsView:
 		subtitle = "  notifications"
+	case context.BranchesView:
+		subtitle = "  local branches"
 	}
 	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
@@ -322,6 +330,8 @@ func (m Model) View() tea.View {
 // currentViewSections returns the section slice for the active view.
 func (m *Model) currentViewSections() []section.Section {
 	switch m.ctx.View {
+	case context.BranchesView:
+		return m.branches
 	case context.NotificationsView:
 		return m.notifications
 	case context.IssuesView:
@@ -334,6 +344,8 @@ func (m *Model) currentViewSections() []section.Section {
 // setCurrentViewSections stores s under the active view and rewires the tab bar.
 func (m *Model) setCurrentViewSections(s []section.Section) {
 	switch m.ctx.View {
+	case context.BranchesView:
+		m.branches = s
 	case context.NotificationsView:
 		m.notifications = s
 	case context.IssuesView:
@@ -458,6 +470,9 @@ func (m *Model) syncSidebar() {
 		rendered = prview.RenderIssue(r, m.issueDetails[key], w, m.expanded)
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
+	default:
+		m.sidebar.SetContent("")
+		return
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -492,14 +507,16 @@ func (m *Model) clearSelectedPreviewCache() {
 	}
 }
 
-// switchView cycles pulls -> issues -> notifications, lazily building and
-// fetching the target view's sections on first visit.
+// switchView cycles pulls -> issues -> notifications -> branches, lazily
+// building and fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
 	switch m.ctx.View {
 	case context.PullsView:
 		m.ctx.View = context.IssuesView
 	case context.IssuesView:
 		m.ctx.View = context.NotificationsView
+	case context.NotificationsView:
+		m.ctx.View = context.BranchesView
 	default:
 		m.ctx.View = context.PullsView
 	}
@@ -567,6 +584,10 @@ func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {
 		if id >= 0 && id < len(m.notifications) {
 			m.notifications[id], cmd = m.notifications[id].Update(msg)
 		}
+	case branchsection.SectionType:
+		if id >= 0 && id < len(m.branches) {
+			m.branches[id], cmd = m.branches[id].Update(msg)
+		}
 	}
 	return cmd
 }
@@ -587,6 +608,9 @@ func (m *Model) syncProgramContext() {
 		s.UpdateProgramContext(m.ctx)
 	}
 	for _, s := range m.notifications {
+		s.UpdateProgramContext(m.ctx)
+	}
+	for _, s := range m.branches {
 		s.UpdateProgramContext(m.ctx)
 	}
 	m.tabs.UpdateProgramContext(m.ctx)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/ui/components/branchsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -39,6 +41,17 @@ func notificationFetchedMsg(rows []data.Notification) context.TaskFinishedMsg {
 		TaskId:      "n1",
 		Msg: notificationsection.SectionNotificationsFetchedMsg{
 			Rows: rows, TotalCount: len(rows), TaskId: "n1",
+		},
+	}
+}
+
+func branchFetchedMsg(rows []localgit.Branch) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: branchsection.SectionType,
+		TaskId:      "b1",
+		Msg: branchsection.SectionBranchesFetchedMsg{
+			Rows: rows, TotalCount: len(rows), TaskId: "b1",
 		},
 	}
 }
@@ -178,6 +191,28 @@ func TestSwitchViewCyclesToNotifications(t *testing.T) {
 	}
 }
 
+func TestSwitchViewCyclesToBranches(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // issues
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = next.(Model)
+	if m.ctx.View != context.BranchesView {
+		t.Fatalf("View = %v, want BranchesView", m.ctx.View)
+	}
+	if len(m.branches) == 0 {
+		t.Fatal("expected branch sections to be built lazily on switch")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch command after switching to the branches view")
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("next switch after branches should wrap to pulls: View = %v", m.ctx.View)
+	}
+}
+
 func TestSectionSwitchWithTwoSections(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{
@@ -295,6 +330,19 @@ func TestDefaultsViewStartsNotifications(t *testing.T) {
 	}
 }
 
+func TestDefaultsViewStartsBranches(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	if m.ctx.View != context.BranchesView {
+		t.Fatalf("View = %v, want BranchesView", m.ctx.View)
+	}
+	if len(m.branches) == 0 {
+		t.Fatal("defaults.view=branches should build the branch sections at startup")
+	}
+	if len(m.prs) != 0 || len(m.issues) != 0 || len(m.notifications) != 0 {
+		t.Fatalf("prs=%d issues=%d notifications=%d, want inactive views lazy", len(m.prs), len(m.issues), len(m.notifications))
+	}
+}
+
 // TestCrossViewFetchRoutesToOwnSlice verifies a late PR fetch that lands while
 // the Issues view is active is still routed to the pulls slice by (id, type),
 // not to whatever section is currently on screen.
@@ -316,8 +364,9 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 			TotalCount: 1, TaskId: "t1",
 		},
 	})
-	// Switch through Notifications back to the pulls view; the fetch must have
-	// landed in m.prs rather than whatever view is on screen.
+	// Switch through Notifications and Branches back to the pulls view; the
+	// fetch must have landed in m.prs rather than whatever view is on screen.
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	if m.ctx.View != context.PullsView {
@@ -444,6 +493,24 @@ func TestModelRendersLoadedNotifications(t *testing.T) {
 	for _, want := range []string{"#42", "Review the new dashboard", "gbarany/tea-dash", "pull", "unread", "1 notification"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("notifications view is missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
+func TestModelRendersLoadedBranches(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"}) // close preview for table assertions
+	m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+		Repository: "tea-dash", Name: "m5/repo-branches", Current: true,
+		Upstream: "origin/m4/notifications", Ahead: 1, Commit: "abc1234",
+		Subject: "Add branches view", UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"m5/repo-branches", "tea-dash", "origin/m4/notifications", "current", "ahead 1", "1 branch"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("branches view is missing %q\n---\n%s", want, view)
 		}
 	}
 }
@@ -601,6 +668,7 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 	})
 
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // branches
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // pulls
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p1",

--- a/internal/ui/components/branchsection/branchsection.go
+++ b/internal/ui/components/branchsection/branchsection.go
@@ -1,0 +1,146 @@
+// Package branchsection is the read-only local git branches dashboard section.
+package branchsection
+
+import (
+	stdctx "context"
+	"os"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+// SectionType is the routing type tag for local branch sections.
+const SectionType = "branch"
+
+// Model is the branches section. It wraps the generic section so the branches
+// view can use columns sized for branch/upstream/status data.
+type Model struct {
+	*section.Model[localgit.Branch]
+}
+
+// SectionBranchesFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
+type SectionBranchesFetchedMsg = section.RowsFetchedMsg[localgit.Branch]
+
+// NewModel builds a local branches section.
+func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	m := &Model{Model: section.New(section.Options[localgit.Branch]{
+		Id:           id,
+		Ctx:          ctx,
+		Config:       cfg,
+		Type:         SectionType,
+		FilterKind:   "",
+		LoadingText:  "Loading local branches...",
+		EmptyText:    "No local branches.",
+		EmptyHint:    "Configure localRepos with paths to git checkouts, or start tea-dash inside a repository.",
+		SingularForm: "branch",
+		PluralForm:   "branches",
+		Limit:        func(c *config.Config) int { return c.Defaults.BranchesLimit },
+		Fetch: func(fetchCtx stdctx.Context, _ *gitea.Client, _ config.PrIssueFilter, limit int) ([]localgit.Branch, int, error) {
+			repos, err := repositoriesFromConfig(ctx.Config, os.Getwd)
+			if err != nil {
+				return nil, 0, err
+			}
+			branches, err := localgit.ListBranchesForRepositories(fetchCtx, repos)
+			if err != nil {
+				return nil, 0, err
+			}
+			total := len(branches)
+			if limit > 0 && len(branches) > limit {
+				branches = branches[:limit]
+			}
+			return branches, total, nil
+		},
+		BuildRow: branchBuildRow,
+	})}
+	m.applyColumns(ctx.MainContentWidth)
+	return m
+}
+
+// Update delegates to the generic section and returns the wrapper so branch
+// sections keep their custom column behavior after updates.
+func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
+	next, cmd := m.Model.Update(msg)
+	if typed, ok := next.(*section.Model[localgit.Branch]); ok {
+		m.Model = typed
+	}
+	return m, cmd
+}
+
+// UpdateProgramContext delegates generic resize work, then restores branch
+// columns instead of the PR/issue defaults.
+func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
+	m.Model.UpdateProgramContext(ctx)
+	m.applyColumns(ctx.MainContentWidth)
+}
+
+func (m *Model) applyColumns(width int) {
+	cols := branchColumns(width)
+	m.Columns = cols
+	m.Table.SetColumns(cols)
+}
+
+func repositoriesFromConfig(cfg *config.Config, getwd func() (string, error)) ([]localgit.Repository, error) {
+	if cfg != nil && len(cfg.LocalRepos) > 0 {
+		repos := make([]localgit.Repository, 0, len(cfg.LocalRepos))
+		for _, r := range cfg.LocalRepos {
+			repos = append(repos, localgit.Repository{
+				Name: strings.TrimSpace(r.Name),
+				Path: strings.TrimSpace(r.Path),
+			})
+		}
+		return repos, nil
+	}
+	wd, err := getwd()
+	if err != nil {
+		return nil, err
+	}
+	return []localgit.Repository{{Path: wd}}, nil
+}
+
+func branchBuildRow(branch localgit.Branch) table.Row {
+	current := ""
+	if branch.Current {
+		current = "*"
+	}
+	upstream := branch.Upstream
+	if upstream == "" {
+		upstream = "local"
+	}
+	return table.Row{
+		current,
+		branch.Name,
+		branch.Repository,
+		upstream,
+		branch.Status(),
+		branch.Commit,
+	}
+}
+
+func branchColumns(mainWidth int) []table.Column {
+	const (
+		markW     = 3
+		repoW     = 20
+		upstreamW = 28
+		statusW   = 22
+		commitW   = 8
+	)
+	branchW := mainWidth - (markW + repoW + upstreamW + statusW + commitW) - 6
+	if branchW < 20 {
+		branchW = 20
+	}
+	return []table.Column{
+		{Title: "#", Width: markW},
+		{Title: "Branch", Width: branchW},
+		{Title: "Repo", Width: repoW},
+		{Title: "Upstream", Width: upstreamW},
+		{Title: "Status", Width: statusW},
+		{Title: "Commit", Width: commitW},
+	}
+}

--- a/internal/ui/components/branchsection/branchsection_test.go
+++ b/internal/ui/components/branchsection/branchsection_test.go
@@ -1,0 +1,82 @@
+package branchsection
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	"github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	ctx := &context.ProgramContext{
+		Config:            &config.Config{},
+		Styles:            context.DefaultStyles(),
+		MainContentWidth:  120,
+		MainContentHeight: 20,
+	}
+	return NewModel(0, ctx, config.SectionConfig{Title: "Local Branches"})
+}
+
+func TestImplementsSection(t *testing.T) {
+	var _ section.Section = (*Model)(nil)
+}
+
+func TestFetchedMsgBuildsRows(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("b1")
+	next, _ := m.Update(SectionBranchesFetchedMsg{
+		Rows: []localgit.Branch{{
+			Repository: "tea-dash", Name: "feature/repo-branches", Current: true,
+			Upstream: "origin/feature/repo-branches", Ahead: 2, Behind: 1,
+			Commit: "abc1234", Subject: "Add branch dashboard", UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1,
+		TaskId:     "b1",
+	})
+	m = next.(*Model)
+
+	if m.GetTotalCount() != 1 || m.NumRows() != 1 {
+		t.Fatalf("counts: total=%d rows=%d", m.GetTotalCount(), m.NumRows())
+	}
+	row := m.BuildRows()[0]
+	joined := strings.Join([]string(row), "|")
+	for _, want := range []string{"feature/repo-branches", "tea-dash", "origin/feature/repo-branches", "current", "ahead 2", "behind 1", "abc1234"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("row %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestRepositoriesFromConfigUsesConfiguredLocalRepos(t *testing.T) {
+	cfg := &config.Config{LocalRepos: []config.LocalRepoConfig{
+		{Name: "tea-dash", Path: "/tmp/tea-dash"},
+		{Name: "other", Path: "/tmp/other"},
+	}}
+	repos, err := repositoriesFromConfig(cfg, func() (string, error) {
+		return "/tmp/ignored", nil
+	})
+	if err != nil {
+		t.Fatalf("repositoriesFromConfig() error: %v", err)
+	}
+	if len(repos) != 2 || repos[0].Name != "tea-dash" || repos[0].Path != "/tmp/tea-dash" ||
+		repos[1].Name != "other" || repos[1].Path != "/tmp/other" {
+		t.Fatalf("repositoriesFromConfig() = %+v", repos)
+	}
+}
+
+func TestRepositoriesFromConfigFallsBackToWorkingDirectory(t *testing.T) {
+	repos, err := repositoriesFromConfig(&config.Config{}, func() (string, error) {
+		return "/tmp/current", nil
+	})
+	if err != nil {
+		t.Fatalf("repositoriesFromConfig() error: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Name != "" || repos[0].Path != "/tmp/current" {
+		t.Fatalf("repositoriesFromConfig() = %+v, want cwd fallback", repos)
+	}
+}

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -23,6 +23,7 @@ const (
 	PullsView ViewType = iota
 	IssuesView
 	NotificationsView
+	BranchesView
 )
 
 // TaskState is the lifecycle of an async task.
@@ -74,6 +75,13 @@ type ProgramContext struct {
 // default section.
 func (c *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 	switch c.View {
+	case BranchesView:
+		if c.Config != nil && len(c.Config.BranchSections) > 0 {
+			return c.Config.BranchSections
+		}
+		return []config.SectionConfig{{
+			Title: "Local Branches",
+		}}
 	case NotificationsView:
 		if c.Config != nil && len(c.Config.NotificationsSections) > 0 {
 			return c.Config.NotificationsSections


### PR DESCRIPTION
## Summary

Adds the first read-only Repo/Branches view.

- introduces `internal/git` with context-bound `git -C <path> for-each-ref` branch discovery
- parses current branch, upstream, ahead/behind, and commit metadata with NUL-separated output
- adds `localRepos`, `branchSections`, `defaults.branchesLimit`, and `defaults.view: branches`
- adds a Branches TUI view and section; `s` now cycles PRs -> Issues -> Notifications -> Branches -> PRs
- documents the new config shape in the README

## Notes

This slice is intentionally read-only. Checkout/delete/pull/push actions are left for the next local-git operations pass.

The app still follows the existing Gitea auth/client startup path before showing the TUI, even when starting in the local Branches view.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
