### PR TITLE
Integrate feature stack into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ tea-dash --help
 | `s`             | switch view (PRs/issues/notifications)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
-| `p`             | toggle preview pane     |
-| `e`             | expand preview body     |
-| `ctrl+u/d`      | scroll preview          |
+| `p`             | show / hide preview panel |
+| `e`             | expand / fold preview body |
+| `ctrl+u` / `ctrl+d` | scroll preview       |
 | `o` / `enter`   | open in browser         |
+| `c`             | add comment             |
+| `m`             | merge PR                |
+| `x` / `X`       | close / reopen          |
+| `v`             | submit PR review        |
+| `d`             | open PR diff in external pager |
+| `C`             | checkout PR locally     |
 | `r`             | refresh                 |
 | `q` / `ctrl+c`  | quit                    |
 
@@ -104,6 +110,16 @@ defaults:
   prsLimit: 50           # rows fetched per PR section (0 -> 50)
   issuesLimit: 50        # rows fetched per issue section (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
+
+pager:
+  diff: diffnav     # command that receives PR diff bytes on stdin (falls back to $PAGER, then less -R)
+
+repoPaths:
+  "gbarany/*": "~/dev/sandbox/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
+
+git:
+  remote: origin
+  prBranchTemplate: "pr-{{.PrIndex}}"
 
 # Each section becomes a tab you page through with h/l. Omit prSections to get
 # two "@me"-authored PR defaults: open and closed pull requests. Omit

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ notifications across one or more Gitea instances, without leaving the terminal.
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
 > pull requests, issues, and unread notifications across all your repos (fetched
 > via the Gitea API (Go SDK + REST)), with view switching (`s`), configurable
-> sections you page through with `h`/`l`, preview pane support, and live keyword
-> search (`/`). PR actions are in progress. See
+> sections you page through with `h`/`l`, live keyword search (`/`),
+> default-open preview, and PR / issue actions. See
 > [`docs/architecture.md`](docs/architecture.md) for the design.
 
 ## Why
@@ -72,6 +72,7 @@ tea-dash --help
 | Key             | Action                  |
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
+| `g` / `G`       | first / last row        |
 | `s`             | switch view (PRs/issues/notifications)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
@@ -79,13 +80,15 @@ tea-dash --help
 | `e`             | expand / fold preview body |
 | `ctrl+u` / `ctrl+d` | scroll preview       |
 | `o` / `enter`   | open in browser         |
+| `y` / `Y`       | copy row number / URL   |
 | `c`             | add comment             |
 | `m`             | merge PR                |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
-| `d`             | open PR diff in external pager |
-| `C`             | checkout PR locally     |
-| `r`             | refresh                 |
+| `d` / `ctrl+t`  | open PR diff in external pager |
+| `C` / `space`   | checkout PR locally     |
+| `r` / `R`       | refresh section / all sections |
+| `?`             | show / hide full help   |
 | `q` / `ctrl+c`  | quit                    |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A terminal dashboard for [Gitea](https://about.gitea.com/) (and Forgejo /
 Codeberg), in the spirit of [`gh-dash`](https://github.com/dlvhdr/gh-dash) — but
 for Gitea instead of GitHub.
 
-tea-dash is a keyboard-driven TUI for triaging pull requests, issues and
-notifications across one or more Gitea instances, without leaving the terminal.
+tea-dash is a keyboard-driven TUI for triaging pull requests, issues,
+notifications, and local branches across one or more Gitea instances, without
+leaving the terminal.
 
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
-> pull requests, issues, and unread notifications across all your repos (fetched
-> via the Gitea API (Go SDK + REST)), with view switching (`s`), configurable
-> sections you page through with `h`/`l`, live keyword search (`/`),
-> default-open preview, and PR / issue actions. See
+> pull requests, issues, unread notifications, Actions runs, and read-only local
+> branch status (fetched via the Gitea API (Go SDK + REST) and local `git`),
+> with view switching (`s`), configurable sections you page through with `h`/`l`,
+> live keyword search (`/`), a default-open preview, and PR / issue actions. See
 > [`docs/architecture.md`](docs/architecture.md) for the design.
 
 ## Why
@@ -73,7 +74,7 @@ tea-dash --help
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
 | `g` / `G`       | first / last row        |
-| `s`             | switch view (PRs/issues/notifications)|
+| `s`             | switch view (PRs/issues/notifications/actions/branches)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
 | `p`             | show / hide preview panel |
@@ -109,10 +110,16 @@ instance:
   # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
 
 defaults:
-  view: prs              # startup view: "prs", "issues", or "notifications"
+  view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
   prsLimit: 50           # rows fetched per PR section (0 -> 50)
   issuesLimit: 50        # rows fetched per issue section (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
+  actionsLimit: 50       # rows fetched per Actions section (0 -> 50)
+  branchesLimit: 0       # local branches shown (0 -> all)
+
+localRepos:
+  - name: tea-dash
+    path: /Users/gaborbarany/dev/sandbox/tea-dash
 
 pager:
   diff: diffnav     # command that receives PR diff bytes on stdin (falls back to $PAGER, then less -R)
@@ -152,6 +159,9 @@ issuesSections:
 notificationsSections:
   - title: Unread
     limit: 50
+
+branchSections:
+  - title: Local Branches
 ```
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
@@ -167,7 +177,9 @@ With or without a config file, tea-dash shows the pull requests and issues you
 authored, plus unread notifications, across every repo you can access on your
 Gitea instance. The default PR view has separate open and closed-history tabs;
 sections and filters let you tailor what each tab shows. Notification sections
-currently support title/limit configuration and default to unread threads.
+currently support title/limit configuration and default to unread threads. The
+branches view shells out to local `git` for configured `localRepos` only and is
+read-only; with no `localRepos`, it falls back to the current working directory.
 
 ## Development
 
@@ -185,6 +197,7 @@ Project layout:
 main.go                 entrypoint + flag handling; loads config, starts the TUI
 internal/ui/            Bubble Tea model, table, preview, keybindings, styles
 internal/gitea/         Gitea Go SDK client wrapper + PR/issue/notification APIs
+internal/git/           read-only local git branch status
 internal/auth/          resolves instance URL + token from the tea config
 internal/data/          TUI-agnostic domain models
 internal/config/        ~/.config/tea-dash/config.yml loading

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -128,7 +128,11 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		return fmt.Sprintf("Reopened %s#%d.", intent.Target.Repo, index), nil
 
 	case uiactions.KindMerge:
-		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: data.MergeStyleMerge})
+		style, err := mergeStyle(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: style})
 		if err != nil {
 			return "", err
 		}
@@ -213,6 +217,23 @@ func reviewEvent(value string) (data.PullReviewEvent, error) {
 		return data.PullReviewEventRequestChanges, nil
 	default:
 		return "", fmt.Errorf("unsupported review action %q", value)
+	}
+}
+
+func mergeStyle(value string) (data.MergeStyle, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", string(data.MergeStyleMerge), "confirm":
+		return data.MergeStyleMerge, nil
+	case string(data.MergeStyleSquash):
+		return data.MergeStyleSquash, nil
+	case string(data.MergeStyleRebase):
+		return data.MergeStyleRebase, nil
+	case string(data.MergeStyleRebaseMerge):
+		return data.MergeStyleRebaseMerge, nil
+	case string(data.MergeStyleFastForwardOnly), "ff-only":
+		return data.MergeStyleFastForwardOnly, nil
+	default:
+		return "", fmt.Errorf("unsupported merge strategy %q", value)
 	}
 }
 

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -1,0 +1,238 @@
+// Package actionrunner executes UI action intents against Gitea, local git, and
+// configured shell commands.
+package actionrunner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/shell"
+	uiactions "github.com/gbarany/tea-dash/internal/ui/actions"
+)
+
+const actionTimeout = 2 * time.Minute
+
+// Client is the subset of the Gitea client used by action dispatch.
+type Client interface {
+	AddComment(owner, repo string, index int64, body string) (data.Comment, error)
+	SetIssueState(owner, repo string, index int64, state data.ItemState) error
+	SetPullState(owner, repo string, index int64, state data.ItemState) error
+	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
+	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
+	GetPullDiff(owner, repo string, index int64) ([]byte, error)
+}
+
+// CheckoutFunc runs or fakes a local PR checkout.
+type CheckoutFunc func(context.Context, localgit.CheckoutOptions) (localgit.CheckoutPlan, error)
+
+// Options configures a Runner.
+type Options struct {
+	Client      Client
+	Config      *config.Config
+	InstanceURL string
+	CWD         string
+	ShellRunner shell.Runner
+	GitRunner   localgit.Runner
+	Checkout    CheckoutFunc
+}
+
+// Runner executes actions and returns ResultMsg values for the UI.
+type Runner struct {
+	client      Client
+	cfg         *config.Config
+	instanceURL string
+	cwd         string
+	shellRunner shell.Runner
+	gitRunner   localgit.Runner
+	checkout    CheckoutFunc
+}
+
+// New constructs a Runner with production defaults for omitted runners.
+func New(opts Options) Runner {
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	shellRunner := opts.ShellRunner
+	if shellRunner == nil {
+		shellRunner = shell.ExecRunner{}
+	}
+	checkout := opts.Checkout
+	if checkout == nil {
+		checkout = localgit.RunCheckout
+	}
+	return Runner{
+		client:      opts.Client,
+		cfg:         cfg,
+		instanceURL: opts.InstanceURL,
+		cwd:         opts.CWD,
+		shellRunner: shellRunner,
+		gitRunner:   opts.GitRunner,
+		checkout:    checkout,
+	}
+}
+
+// Dispatch returns a Bubble Tea command that executes intent off the update
+// path and reports the result back as actions.ResultMsg.
+func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+
+		message, err := r.run(ctx, intent)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultSucceeded, Message: message}
+	}
+}
+
+func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error) {
+	if r.client == nil {
+		return "", fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))
+	}
+	owner, repo, err := splitRepo(intent.Target.Repo)
+	if err != nil {
+		return "", err
+	}
+	index := intent.Target.Number
+
+	switch intent.Kind {
+	case uiactions.KindComment:
+		body := strings.TrimSpace(intent.Prompt.Value)
+		if body == "" {
+			return "", fmt.Errorf("comment body cannot be empty")
+		}
+		if _, err := r.client.AddComment(owner, repo, index, body); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Commented on %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindClose:
+		if err := r.setState(owner, repo, index, intent.Target.RowKind, data.ItemStateClosed); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Closed %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindReopen:
+		if err := r.setState(owner, repo, index, intent.Target.RowKind, data.ItemStateOpen); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Reopened %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindMerge:
+		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: data.MergeStyleMerge})
+		if err != nil {
+			return "", err
+		}
+		if !merged {
+			return fmt.Sprintf("Merge requested for %s#%d.", intent.Target.Repo, index), nil
+		}
+		return fmt.Sprintf("Merged %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindReview:
+		event, err := reviewEvent(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		if _, err := r.client.SubmitPullReview(owner, repo, index, data.PullReviewOptions{Event: event}); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Submitted review for %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindExternalDiff:
+		diff, err := r.client.GetPullDiff(owner, repo, index)
+		if err != nil {
+			return "", err
+		}
+		command := r.cfg.Pager.DiffCommand()
+		cmd := shell.BuildCommand(command, diff, r.cwd)
+		out, err := r.shellRunner.Run(ctx, cmd)
+		if err != nil {
+			msg := strings.TrimSpace(string(out))
+			if msg != "" {
+				return "", fmt.Errorf("run diff pager %q: %w: %s", command, err, msg)
+			}
+			return "", fmt.Errorf("run diff pager %q: %w", command, err)
+		}
+		return fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindCheckout:
+		plan, err := r.checkout(ctx, localgit.CheckoutOptions{
+			RepoName:       intent.Target.Repo,
+			CWD:            r.cwd,
+			InstanceURL:    r.instanceURL,
+			RepoPaths:      r.cfg.RepoPaths,
+			Remote:         r.cfg.Git.Remote,
+			BranchTemplate: r.cfg.Git.PRBranchTemplate,
+			PrIndex:        index,
+			Runner:         r.gitRunner,
+		})
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Checked out %s in %s.", plan.Branch, plan.RepoPath), nil
+	default:
+		return "", fmt.Errorf("unsupported action %q", intent.Kind)
+	}
+}
+
+func (r Runner) setState(owner, repo string, index int64, kind uiactions.RowKind, state data.ItemState) error {
+	switch kind {
+	case uiactions.RowKindPullRequest:
+		return r.client.SetPullState(owner, repo, index, state)
+	case uiactions.RowKindIssue:
+		return r.client.SetIssueState(owner, repo, index, state)
+	default:
+		return fmt.Errorf("unsupported row kind %q", kind)
+	}
+}
+
+func splitRepo(repoName string) (string, string, error) {
+	owner, repo, ok := data.SplitOwnerRepo(repoName)
+	if !ok {
+		return "", "", fmt.Errorf("invalid repository %q", repoName)
+	}
+	return owner, repo, nil
+}
+
+func reviewEvent(value string) (data.PullReviewEvent, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "comment":
+		return data.PullReviewEventComment, nil
+	case "approve", "approved":
+		return data.PullReviewEventApprove, nil
+	case "request_changes", "request-changes", "changes_requested":
+		return data.PullReviewEventRequestChanges, nil
+	default:
+		return "", fmt.Errorf("unsupported review action %q", value)
+	}
+}
+
+func actionLabel(kind uiactions.Kind) string {
+	switch kind {
+	case uiactions.KindComment:
+		return "comment"
+	case uiactions.KindMerge:
+		return "merge"
+	case uiactions.KindClose:
+		return "close"
+	case uiactions.KindReopen:
+		return "reopen"
+	case uiactions.KindReview:
+		return "review"
+	case uiactions.KindExternalDiff:
+		return "external diff"
+	case uiactions.KindCheckout:
+		return "checkout"
+	default:
+		return string(kind)
+	}
+}

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -91,6 +91,16 @@ func TestDispatchMergeAndReview(t *testing.T) {
 		t.Fatalf("merge style = %q, want merge", client.merge.Style)
 	}
 
+	squash := pullIntent(uiactions.KindMerge)
+	squash.Prompt.Value = "squash"
+	got = runDispatch(t, r, squash)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("squash merge result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleSquash {
+		t.Fatalf("merge style = %q, want squash", client.merge.Style)
+	}
+
 	review := pullIntent(uiactions.KindReview)
 	review.Prompt.Value = "request_changes"
 	got = runDispatch(t, r, review)

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -1,0 +1,211 @@
+package actionrunner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/shell"
+	uiactions "github.com/gbarany/tea-dash/internal/ui/actions"
+)
+
+func runDispatch(t *testing.T, r Runner, intent uiactions.Intent) uiactions.ResultMsg {
+	t.Helper()
+	cmd := r.Dispatch(intent)
+	if cmd == nil {
+		t.Fatal("Dispatch returned nil")
+	}
+	msg := cmd()
+	got, ok := msg.(uiactions.ResultMsg)
+	if !ok {
+		t.Fatalf("Dispatch msg = %T, want actions.ResultMsg", msg)
+	}
+	return got
+}
+
+func pullIntent(kind uiactions.Kind) uiactions.Intent {
+	return uiactions.Intent{
+		Kind: kind,
+		Target: uiactions.Target{
+			RowKind: uiactions.RowKindPullRequest,
+			Repo:    "acme/widgets",
+			Number:  7,
+			Title:   "PR title",
+		},
+	}
+}
+
+func issueIntent(kind uiactions.Kind) uiactions.Intent {
+	in := pullIntent(kind)
+	in.Target.RowKind = uiactions.RowKindIssue
+	return in
+}
+
+func TestDispatchCommentAndClose(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	comment := pullIntent(uiactions.KindComment)
+	comment.Prompt.Value = "hello"
+	got := runDispatch(t, r, comment)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("comment result = %+v", got)
+	}
+	if client.commentBody != "hello" {
+		t.Fatalf("commentBody = %q, want hello", client.commentBody)
+	}
+
+	got = runDispatch(t, r, issueIntent(uiactions.KindClose))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("close issue result = %+v", got)
+	}
+	if client.issueState != data.ItemStateClosed {
+		t.Fatalf("issueState = %q, want closed", client.issueState)
+	}
+
+	got = runDispatch(t, r, pullIntent(uiactions.KindReopen))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("reopen pull result = %+v", got)
+	}
+	if client.pullState != data.ItemStateOpen {
+		t.Fatalf("pullState = %q, want open", client.pullState)
+	}
+}
+
+func TestDispatchMergeAndReview(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("merge result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleMerge {
+		t.Fatalf("merge style = %q, want merge", client.merge.Style)
+	}
+
+	review := pullIntent(uiactions.KindReview)
+	review.Prompt.Value = "request_changes"
+	got = runDispatch(t, r, review)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("review result = %+v", got)
+	}
+	if client.review.Event != data.PullReviewEventRequestChanges {
+		t.Fatalf("review event = %q, want request-changes", client.review.Event)
+	}
+}
+
+func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
+	client := &fakeClient{diff: []byte("diff --git a/a b/a\n+hello\n")}
+	shellRunner := &fakeShellRunner{}
+	r := New(Options{
+		Client:      client,
+		Config:      &config.Config{Pager: config.Pager{Diff: "diffnav"}},
+		CWD:         "/tmp/repo",
+		ShellRunner: shellRunner,
+	})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindExternalDiff))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("diff result = %+v", got)
+	}
+	if shellRunner.command.Name == "" {
+		t.Fatal("shell runner was not called")
+	}
+	if !reflect.DeepEqual(shellRunner.command.Args, []string{"-c", "diffnav"}) {
+		t.Fatalf("shell args = %#v, want shell -c diffnav", shellRunner.command.Args)
+	}
+	if string(shellRunner.command.Stdin) != string(client.diff) || shellRunner.command.Dir != "/tmp/repo" {
+		t.Fatalf("shell command = %+v", shellRunner.command)
+	}
+}
+
+func TestDispatchCheckoutPassesConfig(t *testing.T) {
+	var gotOpts localgit.CheckoutOptions
+	r := New(Options{
+		Client:      &fakeClient{},
+		Config:      &config.Config{RepoPaths: map[string]string{"acme/widgets": "/src/widgets"}, Git: config.Git{Remote: "upstream", PRBranchTemplate: "review-{{.PrIndex}}"}},
+		InstanceURL: "https://git.example",
+		CWD:         "/cwd",
+		Checkout: func(_ context.Context, opts localgit.CheckoutOptions) (localgit.CheckoutPlan, error) {
+			gotOpts = opts
+			return localgit.CheckoutPlan{RepoPath: "/src/widgets", Branch: "review-7"}, nil
+		},
+	})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindCheckout))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("checkout result = %+v", got)
+	}
+	if gotOpts.RepoName != "acme/widgets" || gotOpts.PrIndex != 7 || gotOpts.CWD != "/cwd" ||
+		gotOpts.InstanceURL != "https://git.example" || gotOpts.Remote != "upstream" ||
+		gotOpts.BranchTemplate != "review-{{.PrIndex}}" {
+		t.Fatalf("checkout opts = %+v", gotOpts)
+	}
+}
+
+func TestDispatchReturnsErrorResult(t *testing.T) {
+	client := &fakeClient{err: errors.New("boom")}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultErrored || got.Err == nil || !strings.Contains(got.Err.Error(), "boom") {
+		t.Fatalf("error result = %+v", got)
+	}
+}
+
+type fakeClient struct {
+	err         error
+	commentBody string
+	issueState  data.ItemState
+	pullState   data.ItemState
+	merge       data.MergeOptions
+	review      data.PullReviewOptions
+	diff        []byte
+}
+
+func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
+	f.commentBody = body
+	return data.Comment{Body: body}, f.err
+}
+
+func (f *fakeClient) SetIssueState(_, _ string, _ int64, state data.ItemState) error {
+	f.issueState = state
+	return f.err
+}
+
+func (f *fakeClient) SetPullState(_, _ string, _ int64, state data.ItemState) error {
+	f.pullState = state
+	return f.err
+}
+
+func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOptions) (bool, error) {
+	f.merge = opt
+	return f.err == nil, f.err
+}
+
+func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewOptions) (data.Review, error) {
+	f.review = opt
+	return data.Review{State: data.ReviewState(opt.Event)}, f.err
+}
+
+func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {
+	return f.diff, f.err
+}
+
+type fakeShellRunner struct {
+	command shell.Command
+	err     error
+}
+
+func (f *fakeShellRunner) Run(_ context.Context, cmd shell.Command) ([]byte, error) {
+	f.command = cmd
+	return nil, f.err
+}
+
+var _ tea.Cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,11 +24,13 @@ type Config struct {
 	// Repos lists repositories to watch. Unused in M0; per-repo sections
 	// return in M1.
 	Repos []string `yaml:"repos"`
-	// PRSections, IssuesSections, and NotificationsSections configure the tabs
-	// for their respective views. Empty falls back to a default section.
+	// PRSections, IssuesSections, NotificationsSections, and ActionsSections
+	// configure the tabs for their respective views. Empty falls back to a
+	// default section.
 	PRSections            []SectionConfig `yaml:"prSections"`
 	IssuesSections        []SectionConfig `yaml:"issuesSections"`
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
+	ActionsSections       []SectionConfig `yaml:"actionsSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 	// Pager configures external pager commands.
@@ -40,14 +42,15 @@ type Config struct {
 	Git Git `yaml:"git"`
 }
 
-// Defaults holds startup and limit defaults. PRsLimit and IssuesLimit set the
-// per-view row-fetch cap used when a section omits its own Limit. Precedence:
-// section Limit -> per-view default -> 50.
+// Defaults holds startup and limit defaults. Per-view limits set the row-fetch
+// cap used when a section omits its own Limit. Precedence: section Limit ->
+// per-view default -> 50.
 type Defaults struct {
-	View               string `yaml:"view"` // "prs" | "issues" | "notifications"
+	View               string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions"
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
+	ActionsLimit       int    `yaml:"actionsLimit"`
 }
 
 // Pager configures external pager commands.
@@ -103,9 +106,10 @@ type Instance struct {
 // SectionConfig describes one dashboard section (a tab).
 type SectionConfig struct {
 	Title  string        `yaml:"title"`
+	Repo   string        `yaml:"repo"`
 	Filter PrIssueFilter `yaml:"filter"`
 	// Limit caps this section's row fetch. 0 falls back to the per-view default
-	// (defaults.prsLimit / defaults.issuesLimit), which in turn falls back to 50.
+	// (defaults.prsLimit / defaults.issuesLimit / etc.), which in turn falls back to 50.
 	// Precedence: section Limit -> per-view default -> 50.
 	Limit int `yaml:"limit"`
 }
@@ -128,6 +132,14 @@ type PrIssueFilter struct {
 	Since           string `yaml:"since"`           // RFC3339 lower bound on updatedAt
 	Sort            string `yaml:"sort"`            // e.g. recentupdate
 	Q               string `yaml:"-"`               // live keyword (set by "/", never persisted)
+
+	// Repo-scoped Actions filters. These are ignored by PR/issue search and are
+	// mapped to Gitea's actions/runs query params by the Actions view.
+	Status  string `yaml:"status"`
+	Branch  string `yaml:"branch"`
+	Event   string `yaml:"event"`
+	HeadSHA string `yaml:"headSha"`
+	Actor   string `yaml:"actor"`
 }
 
 // Validate rejects unsupported me-scoped author values. The cross-repo search
@@ -168,10 +180,18 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	for _, s := range c.ActionsSections {
+		if strings.TrimSpace(s.Repo) == "" {
+			continue
+		}
+		if _, err := ParseRepo(s.Repo); err != nil {
+			return fmt.Errorf("actionsSections.repo: %w", err)
+		}
+	}
 	switch c.Defaults.View {
-	case "", "prs", "issues", "notifications":
+	case "", "prs", "issues", "notifications", "actions":
 	default:
-		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", or \"notifications\"", c.Defaults.View)
+		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", or \"actions\"", c.Defaults.View)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,15 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 	"strings"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
@@ -27,6 +31,13 @@ type Config struct {
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
+	// Pager configures external pager commands.
+	Pager Pager `yaml:"pager"`
+	// RepoPaths maps repo names or wildcard patterns (for example "fcmb/*")
+	// to local checkout paths.
+	RepoPaths map[string]string `yaml:"repoPaths"`
+	// Git configures local git checkout behavior.
+	Git Git `yaml:"git"`
 }
 
 // Defaults holds startup and limit defaults. PRsLimit and IssuesLimit set the
@@ -37,6 +48,45 @@ type Defaults struct {
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
+}
+
+// Pager configures external pager commands.
+type Pager struct {
+	Diff string `yaml:"diff"`
+}
+
+// DiffCommand returns the configured diff pager command, then $PAGER, then the
+// less fallback that preserves ANSI color.
+func (p Pager) DiffCommand() string {
+	if diff := strings.TrimSpace(p.Diff); diff != "" {
+		return diff
+	}
+	if pager := strings.TrimSpace(os.Getenv("PAGER")); pager != "" {
+		return pager
+	}
+	return "less -R"
+}
+
+// Git configures local git checkout behavior.
+type Git struct {
+	Remote           string `yaml:"remote"`
+	PRBranchTemplate string `yaml:"prBranchTemplate"`
+}
+
+// RemoteName returns the configured remote name or the origin default.
+func (g Git) RemoteName() string {
+	if remote := strings.TrimSpace(g.Remote); remote != "" {
+		return remote
+	}
+	return "origin"
+}
+
+// BranchTemplate returns the configured PR branch template or the default.
+func (g Git) BranchTemplate() string {
+	if tmpl := strings.TrimSpace(g.PRBranchTemplate); tmpl != "" {
+		return tmpl
+	}
+	return "pr-{{.PrIndex}}"
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -153,6 +203,85 @@ func ParseRepo(s string) (Repo, error) {
 		return Repo{}, fmt.Errorf("invalid repo %q, want \"owner/name\"", s)
 	}
 	return Repo{Owner: owner, Name: name}, nil
+}
+
+// ExpandPath expands a leading "~" or "~/" to the current user's home
+// directory. Other paths are returned unchanged.
+func ExpandPath(p string) (string, error) {
+	switch {
+	case p == "~":
+		return os.UserHomeDir()
+	case strings.HasPrefix(p, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, p[2:]), nil
+	default:
+		return p, nil
+	}
+}
+
+// MatchRepoPath returns the path mapped for repoName, preferring an exact key
+// before evaluating wildcard patterns such as "fcmb/*". Mapped paths may use
+// {{.Owner}}, {{.Repo}}, and {{.RepoName}} template variables, and are expanded
+// through ExpandPath before being returned.
+func MatchRepoPath(repoName string, repoPaths map[string]string) (string, bool, error) {
+	repoName = strings.TrimSpace(repoName)
+	if repoName == "" || len(repoPaths) == 0 {
+		return "", false, nil
+	}
+	if p, ok := repoPaths[repoName]; ok {
+		expanded, err := expandRepoPathMapping(p, repoName)
+		return expanded, true, err
+	}
+
+	patterns := make([]string, 0, len(repoPaths))
+	for pattern := range repoPaths {
+		if strings.ContainsAny(pattern, "*?[") {
+			patterns = append(patterns, pattern)
+		}
+	}
+	sort.Strings(patterns)
+	for _, pattern := range patterns {
+		ok, err := path.Match(pattern, repoName)
+		if err != nil {
+			return "", false, fmt.Errorf("repoPaths pattern %q: %w", pattern, err)
+		}
+		if !ok {
+			continue
+		}
+		expanded, err := expandRepoPathMapping(repoPaths[pattern], repoName)
+		return expanded, true, err
+	}
+	return "", false, nil
+}
+
+func expandRepoPathMapping(p, repoName string) (string, error) {
+	if strings.Contains(p, "{{") {
+		r, err := ParseRepo(repoName)
+		if err != nil {
+			return "", err
+		}
+		tmpl, err := template.New("repoPath").Option("missingkey=error").Parse(p)
+		if err != nil {
+			return "", fmt.Errorf("repoPaths template %q: %w", p, err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, struct {
+			Owner    string
+			Repo     string
+			RepoName string
+		}{
+			Owner:    r.Owner,
+			Repo:     r.Name,
+			RepoName: repoName,
+		}); err != nil {
+			return "", fmt.Errorf("repoPaths template %q: %w", p, err)
+		}
+		p = buf.String()
+	}
+	return ExpandPath(p)
 }
 
 // ParsedRepos returns the configured repos parsed into Repo values.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,16 +21,19 @@ type Config struct {
 	Instance Instance `yaml:"instance"`
 	// Login is a deprecated alias for Instance.Login (tea login profile name).
 	Login string `yaml:"login"`
-	// Repos lists repositories to watch. Unused in M0; per-repo sections
-	// return in M1.
+	// Repos lists remote Gitea repositories to watch. Unused in M0; per-repo
+	// sections return in M1.
 	Repos []string `yaml:"repos"`
-	// PRSections, IssuesSections, NotificationsSections, and ActionsSections
-	// configure the tabs for their respective views. Empty falls back to a
-	// default section.
+	// LocalRepos lists local git repository paths for read-only branch status.
+	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
+	// PRSections, IssuesSections, NotificationsSections, ActionsSections, and BranchSections
+	// configure tabs for their respective views. Empty falls back to a default
+	// section.
 	PRSections            []SectionConfig `yaml:"prSections"`
 	IssuesSections        []SectionConfig `yaml:"issuesSections"`
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
 	ActionsSections       []SectionConfig `yaml:"actionsSections"`
+	BranchSections        []SectionConfig `yaml:"branchSections"`
 	// Defaults sets the startup view and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 	// Pager configures external pager commands.
@@ -46,11 +49,12 @@ type Config struct {
 // cap used when a section omits its own Limit. Precedence: section Limit ->
 // per-view default -> 50.
 type Defaults struct {
-	View               string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions"
+	View               string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
 	PRsLimit           int    `yaml:"prsLimit"`
 	IssuesLimit        int    `yaml:"issuesLimit"`
 	NotificationsLimit int    `yaml:"notificationsLimit"`
 	ActionsLimit       int    `yaml:"actionsLimit"`
+	BranchesLimit      int    `yaml:"branchesLimit"`
 }
 
 // Pager configures external pager commands.
@@ -112,6 +116,13 @@ type SectionConfig struct {
 	// (defaults.prsLimit / defaults.issuesLimit / etc.), which in turn falls back to 50.
 	// Precedence: section Limit -> per-view default -> 50.
 	Limit int `yaml:"limit"`
+}
+
+// LocalRepoConfig describes one local git checkout to include in the branches
+// view. Name is optional; Path must point at a git repository worktree.
+type LocalRepoConfig struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
 }
 
 // PrIssueFilter is the structured, config-driven filter for one section. Every
@@ -188,10 +199,20 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("actionsSections.repo: %w", err)
 		}
 	}
+	for _, s := range c.BranchSections {
+		if err := s.Filter.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, r := range c.LocalRepos {
+		if strings.TrimSpace(r.Path) == "" {
+			return fmt.Errorf("localRepos entry %q: path is required", r.Name)
+		}
+	}
 	switch c.Defaults.View {
-	case "", "prs", "issues", "notifications", "actions":
+	case "", "prs", "issues", "notifications", "actions", "branches":
 	default:
-		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", or \"actions\"", c.Defaults.View)
+		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", \"actions\", or \"branches\"", c.Defaults.View)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,7 @@ defaults:
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
+  actionsLimit: 20
 prSections:
   - title: My PRs
     filter:
@@ -86,13 +87,23 @@ issuesSections:
 notificationsSections:
   - title: Inbox
     limit: 15
+actionsSections:
+  - title: CI
+    repo: acme/widgets
+    limit: 10
+    filter:
+      status: in_progress
+      branch: main
+      event: push
+      headSha: abc123
+      actor: octo
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
-		c.Defaults.NotificationsLimit != 30 {
+		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -106,6 +117,15 @@ notificationsSections:
 	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
 		c.NotificationsSections[0].Limit != 15 {
 		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
+	}
+	if len(c.ActionsSections) != 1 || c.ActionsSections[0].Title != "CI" ||
+		c.ActionsSections[0].Repo != "acme/widgets" || c.ActionsSections[0].Limit != 10 {
+		t.Fatalf("actionsSections = %+v", c.ActionsSections)
+	}
+	filter := c.ActionsSections[0].Filter
+	if filter.Status != "in_progress" || filter.Branch != "main" || filter.Event != "push" ||
+		filter.HeadSHA != "abc123" || filter.Actor != "octo" {
+		t.Fatalf("actions filter = %+v", filter)
 	}
 }
 
@@ -216,7 +236,7 @@ func TestConfigValidateBadView(t *testing.T) {
 	if err := (&Config{Defaults: Defaults{View: "nope"}}).Validate(); err == nil {
 		t.Fatal("Validate() should reject an unknown defaults.view")
 	}
-	for _, view := range []string{"", "prs", "issues", "notifications"} {
+	for _, view := range []string{"", "prs", "issues", "notifications", "actions"} {
 		if err := (&Config{Defaults: Defaults{View: view}}).Validate(); err != nil {
 			t.Fatalf("Validate() rejected valid view %q: %v", view, err)
 		}
@@ -231,6 +251,20 @@ func TestConfigValidateRejectsBadSectionFilter(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() should reject a section with a non-@me author filter")
+	}
+}
+
+func TestConfigValidateRejectsBadActionRepo(t *testing.T) {
+	if err := (&Config{ActionsSections: []SectionConfig{{
+		Title: "Actions",
+		Repo:  "owner/repo/extra",
+	}}}).Validate(); err == nil {
+		t.Fatal("Validate() should reject malformed actionsSections.repo")
+	}
+	if err := (&Config{ActionsSections: []SectionConfig{{
+		Title: "Actions",
+	}}}).Validate(); err != nil {
+		t.Fatalf("Validate() should allow a blank actions repo for the empty state: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,7 @@ defaults:
   issuesLimit: 40
   notificationsLimit: 30
   actionsLimit: 20
+  branchesLimit: 100
 prSections:
   - title: My PRs
     filter:
@@ -97,13 +98,19 @@ actionsSections:
       event: push
       headSha: abc123
       actor: octo
+branchSections:
+  - title: Local Branches
+    limit: 25
+localRepos:
+  - name: tea-dash
+    path: /Users/gaborbarany/dev/sandbox/tea-dash
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
-		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 {
+		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 || c.Defaults.BranchesLimit != 100 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -126,6 +133,14 @@ actionsSections:
 	if filter.Status != "in_progress" || filter.Branch != "main" || filter.Event != "push" ||
 		filter.HeadSHA != "abc123" || filter.Actor != "octo" {
 		t.Fatalf("actions filter = %+v", filter)
+	}
+	if len(c.BranchSections) != 1 || c.BranchSections[0].Title != "Local Branches" ||
+		c.BranchSections[0].Limit != 25 {
+		t.Fatalf("branchSections = %+v", c.BranchSections)
+	}
+	if len(c.LocalRepos) != 1 || c.LocalRepos[0].Name != "tea-dash" ||
+		c.LocalRepos[0].Path != "/Users/gaborbarany/dev/sandbox/tea-dash" {
+		t.Fatalf("localRepos = %+v", c.LocalRepos)
 	}
 }
 
@@ -236,10 +251,17 @@ func TestConfigValidateBadView(t *testing.T) {
 	if err := (&Config{Defaults: Defaults{View: "nope"}}).Validate(); err == nil {
 		t.Fatal("Validate() should reject an unknown defaults.view")
 	}
-	for _, view := range []string{"", "prs", "issues", "notifications", "actions"} {
+	for _, view := range []string{"", "prs", "issues", "notifications", "actions", "branches"} {
 		if err := (&Config{Defaults: Defaults{View: view}}).Validate(); err != nil {
 			t.Fatalf("Validate() rejected valid view %q: %v", view, err)
 		}
+	}
+}
+
+func TestConfigValidateRejectsLocalRepoWithoutPath(t *testing.T) {
+	cfg := &Config{LocalRepos: []LocalRepoConfig{{Name: "missing"}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should reject a local repo without a path")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -105,6 +106,100 @@ notificationsSections:
 	if len(c.NotificationsSections) != 1 || c.NotificationsSections[0].Title != "Inbox" ||
 		c.NotificationsSections[0].Limit != 15 {
 		t.Fatalf("notificationsSections = %+v", c.NotificationsSections)
+	}
+}
+
+func TestUnmarshalPagerRepoPathsAndGit(t *testing.T) {
+	const y = `
+pager:
+  diff: delta --paging=always
+repoPaths:
+  fcmb/api: ~/src/fcmb-api
+  fcmb/*: ~/src/fcmb/{{.Repo}}
+git:
+  remote: upstream
+  prBranchTemplate: review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Pager.Diff != "delta --paging=always" {
+		t.Fatalf("pager.diff = %q", c.Pager.Diff)
+	}
+	if c.RepoPaths["fcmb/api"] != "~/src/fcmb-api" || c.RepoPaths["fcmb/*"] != "~/src/fcmb/{{.Repo}}" {
+		t.Fatalf("repoPaths = %+v", c.RepoPaths)
+	}
+	if c.Git.Remote != "upstream" || c.Git.PRBranchTemplate != "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}" {
+		t.Fatalf("git = %+v", c.Git)
+	}
+}
+
+func TestPagerDiffCommandDefaults(t *testing.T) {
+	t.Setenv("PAGER", "bat --plain")
+	if got := (Pager{}).DiffCommand(); got != "bat --plain" {
+		t.Fatalf("DiffCommand() = %q, want env pager", got)
+	}
+	t.Setenv("PAGER", "")
+	if got := (Pager{}).DiffCommand(); got != "less -R" {
+		t.Fatalf("DiffCommand() = %q, want less -R fallback", got)
+	}
+	if got := (Pager{Diff: "delta"}).DiffCommand(); got != "delta" {
+		t.Fatalf("DiffCommand() = %q, want configured command", got)
+	}
+}
+
+func TestGitDefaults(t *testing.T) {
+	var g Git
+	if got := g.RemoteName(); got != "origin" {
+		t.Fatalf("RemoteName() = %q, want origin", got)
+	}
+	if got := g.BranchTemplate(); got != "pr-{{.PrIndex}}" {
+		t.Fatalf("BranchTemplate() = %q, want default template", got)
+	}
+	g = Git{Remote: "upstream", PRBranchTemplate: "review/{{.PrIndex}}"}
+	if got := g.RemoteName(); got != "upstream" {
+		t.Fatalf("RemoteName() = %q, want upstream", got)
+	}
+	if got := g.BranchTemplate(); got != "review/{{.PrIndex}}" {
+		t.Fatalf("BranchTemplate() = %q, want configured template", got)
+	}
+}
+
+func TestMatchRepoPathExactBeforeWildcardAndExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths := map[string]string{
+		"fcmb/*":   "~/src/fcmb/{{.Repo}}",
+		"fcmb/api": "~/src/exact",
+	}
+	got, ok, err := MatchRepoPath("fcmb/api", paths)
+	if err != nil {
+		t.Fatalf("MatchRepoPath exact: %v", err)
+	}
+	if !ok {
+		t.Fatal("MatchRepoPath exact did not match")
+	}
+	if want := filepath.Join(home, "src", "exact"); got != want {
+		t.Fatalf("MatchRepoPath exact = %q, want %q", got, want)
+	}
+
+	got, ok, err = MatchRepoPath("fcmb/web", paths)
+	if err != nil {
+		t.Fatalf("MatchRepoPath wildcard: %v", err)
+	}
+	if !ok {
+		t.Fatal("MatchRepoPath wildcard did not match")
+	}
+	if want := filepath.Join(home, "src", "fcmb", "web"); got != want {
+		t.Fatalf("MatchRepoPath wildcard = %q, want %q", got, want)
+	}
+}
+
+func TestMatchRepoPathRejectsBadWildcard(t *testing.T) {
+	_, _, err := MatchRepoPath("fcmb/api", map[string]string{"fcmb/[": "/tmp/repo"})
+	if err == nil || !strings.Contains(err.Error(), "fcmb/[") {
+		t.Fatalf("MatchRepoPath bad wildcard error = %v", err)
 	}
 }
 

--- a/internal/data/actions.go
+++ b/internal/data/actions.go
@@ -49,6 +49,12 @@ type ActionStep struct {
 	CompletedAt time.Time
 }
 
+// ActionRunDetail is the preview detail payload for one Actions workflow run.
+type ActionRunDetail struct {
+	Run  ActionRun
+	Jobs []ActionJob
+}
+
 func (r ActionRun) GetRepoNameWithOwner() string { return r.RepoNameWithOwner }
 
 func (r ActionRun) GetTitle() string {

--- a/internal/data/actions.go
+++ b/internal/data/actions.go
@@ -1,0 +1,75 @@
+package data
+
+import "time"
+
+// ActionRun is the domain view of one Gitea Actions workflow run for a repo.
+// It is denormalized with RepoNameWithOwner so a future Actions section can use
+// the same generic row model as pulls, issues, and notifications.
+type ActionRun struct {
+	ID                int64
+	RunNumber         int64
+	RunAttempt        int64
+	DisplayTitle      string
+	WorkflowName      string
+	Event             string
+	Status            string
+	Conclusion        string
+	HeadBranch        string
+	HeadSHA           string
+	Actor             string
+	RepoNameWithOwner string
+	HTMLURL           string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	StartedAt         time.Time
+}
+
+// ActionJob is the domain view of one job within an Actions workflow run.
+type ActionJob struct {
+	ID                int64
+	RunID             int64
+	Name              string
+	Status            string
+	Conclusion        string
+	RunnerName        string
+	RepoNameWithOwner string
+	HTMLURL           string
+	StartedAt         time.Time
+	CompletedAt       time.Time
+	Steps             []ActionStep
+}
+
+// ActionStep is one step within an Actions job.
+type ActionStep struct {
+	Number      int64
+	Name        string
+	Status      string
+	Conclusion  string
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+func (r ActionRun) GetRepoNameWithOwner() string { return r.RepoNameWithOwner }
+
+func (r ActionRun) GetTitle() string {
+	if r.DisplayTitle != "" {
+		return r.DisplayTitle
+	}
+	return r.WorkflowName
+}
+
+func (r ActionRun) GetNumber() int64 {
+	if r.RunNumber != 0 {
+		return r.RunNumber
+	}
+	return r.ID
+}
+
+func (r ActionRun) GetURL() string { return r.HTMLURL }
+
+func (r ActionRun) GetUpdatedAt() time.Time {
+	if !r.UpdatedAt.IsZero() {
+		return r.UpdatedAt
+	}
+	return r.StartedAt
+}

--- a/internal/data/actions_test.go
+++ b/internal/data/actions_test.go
@@ -1,0 +1,80 @@
+package data
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActionRunSatisfiesRowData(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 7, 2, 8, 5, 0, 0, time.UTC)
+	run := ActionRun{
+		ID:                101,
+		RunNumber:         12,
+		DisplayTitle:      "Fix checkout flakes",
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "acme/widgets",
+		HTMLURL:           "https://git.example/acme/widgets/actions/runs/101",
+		StartedAt:         started,
+		UpdatedAt:         updated,
+	}
+
+	var row RowData = run
+	if row.GetRepoNameWithOwner() != "acme/widgets" || row.GetTitle() != "Fix checkout flakes" ||
+		row.GetNumber() != 12 || row.GetURL() != run.HTMLURL || !row.GetUpdatedAt().Equal(updated) {
+		t.Fatalf("RowData projection mismatch: %+v", row)
+	}
+}
+
+func TestActionRunRowDataFallbacks(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+	run := ActionRun{
+		ID:                101,
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "acme/widgets",
+		StartedAt:         started,
+	}
+
+	var row RowData = run
+	if row.GetTitle() != "CI" {
+		t.Fatalf("GetTitle() = %q, want workflow name fallback", row.GetTitle())
+	}
+	if row.GetNumber() != 101 {
+		t.Fatalf("GetNumber() = %d, want ID fallback", row.GetNumber())
+	}
+	if !row.GetUpdatedAt().Equal(started) {
+		t.Fatalf("GetUpdatedAt() = %s, want StartedAt fallback %s", row.GetUpdatedAt(), started)
+	}
+}
+
+func TestActionJobCarriesSteps(t *testing.T) {
+	started := time.Date(2026, 7, 2, 8, 1, 0, 0, time.UTC)
+	completed := time.Date(2026, 7, 2, 8, 4, 0, 0, time.UTC)
+	job := ActionJob{
+		ID:          201,
+		RunID:       101,
+		Name:        "build",
+		Status:      "success",
+		Conclusion:  "success",
+		RunnerName:  "ubuntu-latest",
+		StartedAt:   started,
+		CompletedAt: completed,
+		Steps: []ActionStep{
+			{
+				Number:      1,
+				Name:        "checkout",
+				Status:      "success",
+				Conclusion:  "success",
+				StartedAt:   started,
+				CompletedAt: completed,
+			},
+		},
+	}
+
+	if job.ID != 201 || job.RunID != 101 || len(job.Steps) != 1 {
+		t.Fatalf("job fields mismatch: %+v", job)
+	}
+	if job.Steps[0].Number != 1 || job.Steps[0].Name != "checkout" {
+		t.Fatalf("step fields mismatch: %+v", job.Steps[0])
+	}
+}

--- a/internal/data/mutation.go
+++ b/internal/data/mutation.go
@@ -1,0 +1,68 @@
+package data
+
+// ItemKind identifies whether a repo item is a pull request or an issue.
+type ItemKind string
+
+const (
+	ItemKindPull  ItemKind = "pull"
+	ItemKindIssue ItemKind = "issue"
+)
+
+// ItemRef identifies one mutable repo item.
+type ItemRef struct {
+	Owner  string
+	Repo   string
+	Number int64
+	Kind   ItemKind
+}
+
+// ItemState is the mutable open/closed state shared by issues and pulls.
+type ItemState string
+
+const (
+	ItemStateOpen   ItemState = "open"
+	ItemStateClosed ItemState = "closed"
+)
+
+// MergeStyle is the server-supported pull-request merge strategy.
+type MergeStyle string
+
+const (
+	MergeStyleMerge           MergeStyle = "merge"
+	MergeStyleRebase          MergeStyle = "rebase"
+	MergeStyleRebaseMerge     MergeStyle = "rebase-merge"
+	MergeStyleSquash          MergeStyle = "squash"
+	MergeStyleFastForwardOnly MergeStyle = "fast-forward-only"
+)
+
+// MergeOptions carries the editable fields for merging a pull request.
+type MergeOptions struct {
+	Style        MergeStyle
+	Title        string
+	Message      string
+	DeleteBranch bool
+	ForceMerge   bool
+	HeadCommitID string
+}
+
+// PullReviewEvent is the user's review action. The transport maps these event
+// names onto Gitea's submitted review states.
+type PullReviewEvent string
+
+const (
+	PullReviewEventApprove        PullReviewEvent = "approve"
+	PullReviewEventRequestChanges PullReviewEvent = "request-changes"
+	PullReviewEventComment        PullReviewEvent = "comment"
+)
+
+const (
+	PullReviewStateApproved       ReviewState = ReviewStateApproved
+	PullReviewStateRequestChanges ReviewState = ReviewStateRequestChanges
+	PullReviewStateComment        ReviewState = ReviewStateComment
+)
+
+// PullReviewOptions carries the submitted review action and body.
+type PullReviewOptions struct {
+	Event PullReviewEvent
+	Body  string
+}

--- a/internal/data/mutation_test.go
+++ b/internal/data/mutation_test.go
@@ -1,0 +1,24 @@
+package data
+
+import "testing"
+
+func TestMutationDomainConstants(t *testing.T) {
+	if ItemKindPull != "pull" || ItemKindIssue != "issue" {
+		t.Fatalf("item kinds = %q/%q, want pull/issue", ItemKindPull, ItemKindIssue)
+	}
+	if ItemStateOpen != "open" || ItemStateClosed != "closed" {
+		t.Fatalf("item states = %q/%q, want open/closed", ItemStateOpen, ItemStateClosed)
+	}
+	if MergeStyleMerge != "merge" ||
+		MergeStyleRebase != "rebase" ||
+		MergeStyleRebaseMerge != "rebase-merge" ||
+		MergeStyleSquash != "squash" ||
+		MergeStyleFastForwardOnly != "fast-forward-only" {
+		t.Fatalf("merge style constants changed")
+	}
+	if PullReviewEventApprove != "approve" ||
+		PullReviewEventRequestChanges != "request-changes" ||
+		PullReviewEventComment != "comment" {
+		t.Fatalf("review event constants changed")
+	}
+}

--- a/internal/data/utils.go
+++ b/internal/data/utils.go
@@ -30,9 +30,10 @@ func (n Notification) GetNumber() int64             { return n.Number }
 func (n Notification) GetURL() string               { return n.HTMLURL }
 func (n Notification) GetUpdatedAt() time.Time      { return n.UpdatedAt }
 
-// Compile-time assertions that both domain row types satisfy RowData.
+// Compile-time assertions that domain row types satisfy RowData.
 var (
 	_ RowData = PullRequest{}
 	_ RowData = Issue{}
 	_ RowData = Notification{}
+	_ RowData = ActionRun{}
 )

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -1,0 +1,202 @@
+// Package git reads local repository state through the git executable.
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Repository is a local git repository known to tea-dash.
+type Repository struct {
+	Name string
+	Path string
+}
+
+// Label returns the configured display name, falling back to the directory name.
+func (r Repository) Label() string {
+	if strings.TrimSpace(r.Name) != "" {
+		return strings.TrimSpace(r.Name)
+	}
+	return filepath.Base(filepath.Clean(r.Path))
+}
+
+// Branch is one local branch plus its upstream tracking state.
+type Branch struct {
+	Repository     string
+	RepositoryPath string
+	Name           string
+	Current        bool
+	Upstream       string
+	Ahead          int
+	Behind         int
+	UpstreamGone   bool
+	Commit         string
+	Subject        string
+	UpdatedAt      time.Time
+	WorktreePath   string
+}
+
+// Status summarizes the branch's local/upstream state for compact tables.
+func (b Branch) Status() string {
+	parts := make([]string, 0, 3)
+	if b.Current {
+		parts = append(parts, "current")
+	}
+	if b.UpstreamGone {
+		parts = append(parts, "gone")
+	} else if b.Ahead > 0 && b.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("ahead %d, behind %d", b.Ahead, b.Behind))
+	} else if b.Ahead > 0 {
+		parts = append(parts, fmt.Sprintf("ahead %d", b.Ahead))
+	} else if b.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("behind %d", b.Behind))
+	} else if b.Upstream != "" {
+		parts = append(parts, "synced")
+	} else {
+		parts = append(parts, "local")
+	}
+	if !b.Current && b.WorktreePath != "" {
+		parts = append(parts, "checked out")
+	}
+	return strings.Join(parts, " · ")
+}
+
+// RowData projection methods let Branch reuse the existing generic section.
+func (b Branch) GetRepoNameWithOwner() string { return b.Repository }
+func (b Branch) GetTitle() string             { return b.Name }
+func (b Branch) GetNumber() int64             { return 0 }
+func (b Branch) GetURL() string               { return "" }
+func (b Branch) GetUpdatedAt() time.Time      { return b.UpdatedAt }
+
+// ListBranches returns local branches for one repository.
+func ListBranches(ctx context.Context, repo Repository) ([]Branch, error) {
+	if strings.TrimSpace(repo.Path) == "" {
+		return nil, fmt.Errorf("repository path is required")
+	}
+	format := strings.Join([]string{
+		"%(refname:short)",
+		"%(HEAD)",
+		"%(upstream:short)",
+		"%(upstream:track)",
+		"%(objectname:short)",
+		"%(contents:subject)",
+		"%(committerdate:unix)",
+		"%(worktreepath)",
+	}, "%00")
+	cmd := exec.CommandContext(ctx, "git", "-C", repo.Path, "for-each-ref", "--sort=refname", "--format="+format, "refs/heads")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("git for-each-ref %s: %w: %s", repo.Path, err, strings.TrimSpace(string(out)))
+	}
+	return parseForEachRef(repo, string(out))
+}
+
+// ListBranchesForRepositories returns branches for every configured repository.
+func ListBranchesForRepositories(ctx context.Context, repos []Repository) ([]Branch, error) {
+	var out []Branch
+	for _, repo := range repos {
+		branches, err := ListBranches(ctx, repo)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", repo.Label(), err)
+		}
+		out = append(out, branches...)
+	}
+	return out, nil
+}
+
+func parseForEachRef(repo Repository, out string) ([]Branch, error) {
+	out = strings.TrimSuffix(out, "\n")
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	branches := make([]Branch, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Split(line, "\x00")
+		if len(fields) != 8 {
+			return nil, fmt.Errorf("unexpected for-each-ref record with %d fields", len(fields))
+		}
+		track, err := parseTrackStatus(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		updated, err := parseUnixTime(fields[6])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", fields[0], err)
+		}
+		branches = append(branches, Branch{
+			Repository:     repo.Label(),
+			RepositoryPath: repo.Path,
+			Name:           fields[0],
+			Current:        strings.TrimSpace(fields[1]) == "*",
+			Upstream:       fields[2],
+			Ahead:          track.Ahead,
+			Behind:         track.Behind,
+			UpstreamGone:   track.Gone,
+			Commit:         fields[4],
+			Subject:        fields[5],
+			UpdatedAt:      updated,
+			WorktreePath:   fields[7],
+		})
+	}
+	return branches, nil
+}
+
+type trackStatus struct {
+	Ahead  int
+	Behind int
+	Gone   bool
+}
+
+func parseTrackStatus(raw string) (trackStatus, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return trackStatus{}, nil
+	}
+	if raw == "[gone]" {
+		return trackStatus{Gone: true}, nil
+	}
+	if !strings.HasPrefix(raw, "[") || !strings.HasSuffix(raw, "]") {
+		return trackStatus{}, fmt.Errorf("unexpected upstream track status %q", raw)
+	}
+	raw = strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]")
+	var status trackStatus
+	for _, part := range strings.Split(raw, ", ") {
+		key, val, ok := strings.Cut(part, " ")
+		if !ok {
+			return trackStatus{}, fmt.Errorf("unexpected upstream track status %q", part)
+		}
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return trackStatus{}, fmt.Errorf("unexpected upstream track count %q: %w", val, err)
+		}
+		switch key {
+		case "ahead":
+			status.Ahead = n
+		case "behind":
+			status.Behind = n
+		default:
+			return trackStatus{}, fmt.Errorf("unexpected upstream track key %q", key)
+		}
+	}
+	return status, nil
+}
+
+func parseUnixTime(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	sec, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unexpected commit time %q: %w", raw, err)
+	}
+	return time.Unix(sec, 0), nil
+}

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -1,0 +1,181 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListBranchesReadsLocalBranchesAndUpstreamStatus(t *testing.T) {
+	repoPath := newBranchRepo(t)
+
+	branches, err := ListBranches(context.Background(), Repository{Name: "tea-dash", Path: repoPath})
+	if err != nil {
+		t.Fatalf("ListBranches() error: %v", err)
+	}
+
+	byName := map[string]Branch{}
+	for _, b := range branches {
+		byName[b.Name] = b
+		if b.Repository != "tea-dash" {
+			t.Fatalf("Branch.Repository = %q, want tea-dash", b.Repository)
+		}
+		if b.RepositoryPath != repoPath {
+			t.Fatalf("Branch.RepositoryPath = %q, want %q", b.RepositoryPath, repoPath)
+		}
+	}
+
+	feature, ok := byName["feature"]
+	if !ok {
+		t.Fatalf("branches missing feature: %+v", branches)
+	}
+	if !feature.Current {
+		t.Fatal("feature should be marked current")
+	}
+	if feature.Upstream != "origin/feature" || feature.Ahead != 1 || feature.Behind != 0 {
+		t.Fatalf("feature upstream status = upstream %q ahead %d behind %d, want origin/feature ahead 1 behind 0",
+			feature.Upstream, feature.Ahead, feature.Behind)
+	}
+	if feature.Commit == "" || feature.Subject != "local feature work" {
+		t.Fatalf("feature commit metadata = %q %q, want short commit and subject", feature.Commit, feature.Subject)
+	}
+
+	main, ok := byName["main"]
+	if !ok {
+		t.Fatalf("branches missing main: %+v", branches)
+	}
+	if main.Current {
+		t.Fatal("main should not be marked current")
+	}
+	if main.Upstream != "origin/main" || main.Ahead != 0 || main.Behind != 1 {
+		t.Fatalf("main upstream status = upstream %q ahead %d behind %d, want origin/main ahead 0 behind 1",
+			main.Upstream, main.Ahead, main.Behind)
+	}
+}
+
+func TestListBranchesForRepositoriesAggregatesAndLabelsRepos(t *testing.T) {
+	first := newSingleBranchRepo(t, "first repo")
+	second := newSingleBranchRepo(t, "second repo")
+
+	branches, err := ListBranchesForRepositories(context.Background(), []Repository{
+		{Name: "first", Path: first},
+		{Name: "second", Path: second},
+	})
+	if err != nil {
+		t.Fatalf("ListBranchesForRepositories() error: %v", err)
+	}
+
+	if len(branches) != 2 {
+		t.Fatalf("len(branches) = %d, want 2: %+v", len(branches), branches)
+	}
+	seen := map[string]bool{}
+	for _, b := range branches {
+		seen[b.Repository] = true
+	}
+	if !seen["first"] || !seen["second"] {
+		t.Fatalf("repositories seen = %+v, want first and second", seen)
+	}
+}
+
+func TestParseTrackStatus(t *testing.T) {
+	cases := []struct {
+		in      string
+		ahead   int
+		behind  int
+		gone    bool
+		wantErr bool
+	}{
+		{in: "", ahead: 0, behind: 0},
+		{in: "[ahead 2]", ahead: 2},
+		{in: "[behind 3]", behind: 3},
+		{in: "[ahead 2, behind 3]", ahead: 2, behind: 3},
+		{in: "[gone]", gone: true},
+		{in: "[ahead nope]", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseTrackStatus(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseTrackStatus(%q) expected error, got nil", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTrackStatus(%q) error: %v", tc.in, err)
+			}
+			if got.Ahead != tc.ahead || got.Behind != tc.behind || got.Gone != tc.gone {
+				t.Fatalf("parseTrackStatus(%q) = %+v, want ahead=%d behind=%d gone=%v",
+					tc.in, got, tc.ahead, tc.behind, tc.gone)
+			}
+		})
+	}
+}
+
+func newBranchRepo(t *testing.T) string {
+	t.Helper()
+	repo := newSingleBranchRepo(t, "base")
+
+	runTestGit(t, repo, "update-ref", "refs/remotes/origin/feature", "HEAD")
+	runTestGit(t, repo, "branch", "feature")
+	runTestGit(t, repo, "branch", "--set-upstream-to", "origin/feature", "feature")
+	runTestGit(t, repo, "checkout", "feature")
+	writeFile(t, repo, "feature.txt", "local feature work\n")
+	runTestGit(t, repo, "add", "feature.txt")
+	runTestGit(t, repo, "commit", "-m", "local feature work")
+
+	runTestGit(t, repo, "checkout", "main")
+	runTestGit(t, repo, "checkout", "-b", "remote-main")
+	writeFile(t, repo, "remote.txt", "remote main work\n")
+	runTestGit(t, repo, "add", "remote.txt")
+	runTestGit(t, repo, "commit", "-m", "remote main work")
+	remoteMain := gitOutput(t, repo, "rev-parse", "HEAD")
+	runTestGit(t, repo, "checkout", "main")
+	runTestGit(t, repo, "branch", "-D", "remote-main")
+	runTestGit(t, repo, "update-ref", "refs/remotes/origin/main", remoteMain)
+	runTestGit(t, repo, "branch", "--set-upstream-to", "origin/main", "main")
+
+	runTestGit(t, repo, "checkout", "feature")
+	return repo
+}
+
+func newSingleBranchRepo(t *testing.T, subject string) string {
+	t.Helper()
+	repo := t.TempDir()
+	runTestGit(t, repo, "init", "--initial-branch", "main")
+	runTestGit(t, repo, "config", "user.name", "tea-dash tests")
+	runTestGit(t, repo, "config", "user.email", "tea-dash@example.invalid")
+	runTestGit(t, repo, "remote", "add", "origin", "https://example.invalid/repo.git")
+	writeFile(t, repo, "README.md", subject+"\n")
+	runTestGit(t, repo, "add", "README.md")
+	runTestGit(t, repo, "commit", "-m", subject)
+	runTestGit(t, repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runTestGit(t, repo, "branch", "--set-upstream-to", "origin/main", "main")
+	return repo
+}
+
+func writeFile(t *testing.T, repo, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runTestGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	_ = gitOutput(t, repo, args...)
+}
+
+func gitOutput(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,384 @@
+// Package git contains local checkout helpers for pull requests.
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/gbarany/tea-dash/internal/config"
+)
+
+// RemoteRef is the parsed owner/repo identity from a git remote URL.
+type RemoteRef struct {
+	Host  string
+	Owner string
+	Repo  string
+}
+
+// FullName returns "owner/repo".
+func (r RemoteRef) FullName() string {
+	if r.Owner == "" || r.Repo == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Repo
+}
+
+// MatchesInstanceURL reports whether this remote points at the configured
+// Gitea/Forgejo instance host.
+func (r RemoteRef) MatchesInstanceURL(instanceURL string) bool {
+	want := normalizeRemoteHost(instanceURLHost(instanceURL))
+	if want == "" {
+		return false
+	}
+	return normalizeRemoteHost(r.Host) == want
+}
+
+// ParseRemoteURL parses common HTTPS and SSH git remote URL forms.
+func ParseRemoteURL(raw string) (RemoteRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return RemoteRef{}, errors.New("empty remote URL")
+	}
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return RemoteRef{}, err
+		}
+		owner, repo, err := parseRemotePath(u.Path)
+		if err != nil {
+			return RemoteRef{}, err
+		}
+		return RemoteRef{Host: normalizeRemoteHost(u.Host), Owner: owner, Repo: repo}, nil
+	}
+
+	hostPart, remotePath, ok := strings.Cut(raw, ":")
+	if !ok || hostPart == "" || remotePath == "" {
+		return RemoteRef{}, fmt.Errorf("unsupported remote URL %q", raw)
+	}
+	if at := strings.LastIndex(hostPart, "@"); at >= 0 {
+		hostPart = hostPart[at+1:]
+	}
+	owner, repo, err := parseRemotePath(remotePath)
+	if err != nil {
+		return RemoteRef{}, err
+	}
+	return RemoteRef{Host: normalizeRemoteHost(hostPart), Owner: owner, Repo: repo}, nil
+}
+
+func parseRemotePath(rawPath string) (string, string, error) {
+	p := strings.Trim(rawPath, "/")
+	p = strings.TrimSuffix(p, ".git")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("remote path %q does not contain owner/repo", rawPath)
+	}
+	owner := parts[len(parts)-2]
+	repo := parts[len(parts)-1]
+	if owner == "" || repo == "" {
+		return "", "", fmt.Errorf("remote path %q does not contain owner/repo", rawPath)
+	}
+	return owner, repo, nil
+}
+
+func instanceURLHost(instanceURL string) string {
+	instanceURL = strings.TrimSpace(instanceURL)
+	if instanceURL == "" {
+		return ""
+	}
+	u, err := url.Parse(instanceURL)
+	if err != nil || u.Host == "" {
+		return instanceURL
+	}
+	return u.Host
+}
+
+func normalizeRemoteHost(host string) string {
+	return strings.ToLower(strings.TrimSpace(host))
+}
+
+// ResolveRepoPath resolves repoName to a local checkout path from configured
+// repoPaths first, then from cwd when cwd's origin remote matches repoName and
+// instanceURL.
+func ResolveRepoPath(repoName, cwd, instanceURL string, repoPaths map[string]string) (string, error) {
+	if p, ok, err := config.MatchRepoPath(repoName, repoPaths); err != nil {
+		return "", err
+	} else if ok {
+		return p, nil
+	}
+
+	if cwd != "" {
+		if remoteURL, err := originRemoteURL(cwd); err == nil {
+			if remote, err := ParseRemoteURL(remoteURL); err == nil &&
+				remote.FullName() == strings.TrimSpace(repoName) &&
+				(instanceURL == "" || remote.MatchesInstanceURL(instanceURL)) {
+				return cwd, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no local checkout for %s; configure repoPaths", repoName)
+}
+
+func originRemoteURL(cwd string) (string, error) {
+	configPath, err := gitConfigPath(cwd)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	inOrigin := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") {
+			inOrigin = strings.Contains(line, `remote "origin"`) || strings.Contains(line, `remote 'origin'`)
+			continue
+		}
+		if !inOrigin {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(key) == "url" {
+			return strings.TrimSpace(val), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("origin remote URL not found")
+}
+
+func gitConfigPath(cwd string) (string, error) {
+	gitPath := filepath.Join(cwd, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return filepath.Join(gitPath, "config"), nil
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("%s is not a gitdir file", gitPath)
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(cwd, gitDir)
+	}
+	return filepath.Join(gitDir, "config"), nil
+}
+
+// BranchNameFromTemplate renders a local branch name for a pull request.
+func BranchNameFromTemplate(tmpl, repoName string, prIndex int64) (string, error) {
+	r, err := config.ParseRepo(repoName)
+	if err != nil {
+		return "", err
+	}
+	tmpl = (config.Git{PRBranchTemplate: tmpl}).BranchTemplate()
+	t, err := template.New("branch").Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, struct {
+		Owner    string
+		Repo     string
+		RepoName string
+		PrIndex  int64
+	}{
+		Owner:    r.Owner,
+		Repo:     r.Name,
+		RepoName: repoName,
+		PrIndex:  prIndex,
+	}); err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(buf.String())
+	if branch == "" {
+		return "", errors.New("branch template rendered an empty branch name")
+	}
+	return branch, nil
+}
+
+// Command is a git command invocation.
+type Command struct {
+	Dir  string
+	Name string
+	Args []string
+}
+
+// Result is a completed command result. Non-zero ExitCode means the process ran
+// and failed; a non-nil Runner error means it could not be started or observed.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Runner runs git commands.
+type Runner interface {
+	Run(context.Context, Command) (Result, error)
+}
+
+// ExecRunner runs git commands with os/exec.
+type ExecRunner struct{}
+
+// Run executes cmd and captures stdout/stderr.
+func (ExecRunner) Run(ctx context.Context, cmd Command) (Result, error) {
+	c := exec.CommandContext(ctx, cmd.Name, cmd.Args...)
+	c.Dir = cmd.Dir
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	res := Result{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: 0}
+	if err == nil {
+		return res, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		res.ExitCode = exitErr.ExitCode()
+		return res, nil
+	}
+	return Result{}, err
+}
+
+// CheckoutOptions configures pull-request checkout.
+type CheckoutOptions struct {
+	RepoName       string
+	CWD            string
+	InstanceURL    string
+	RepoPaths      map[string]string
+	Remote         string
+	BranchTemplate string
+	PrIndex        int64
+	Runner         Runner
+}
+
+// CheckoutPlan is the resolved local checkout plan.
+type CheckoutPlan struct {
+	RepoPath     string
+	Remote       string
+	Branch       string
+	FetchRefspec string
+	RemoteRef    string
+}
+
+// PlanCheckout resolves paths, branch names, and refspecs without running git.
+func PlanCheckout(opts CheckoutOptions) (CheckoutPlan, error) {
+	if opts.PrIndex <= 0 {
+		return CheckoutPlan{}, fmt.Errorf("invalid PR index %d", opts.PrIndex)
+	}
+	repoPath, err := ResolveRepoPath(opts.RepoName, opts.CWD, opts.InstanceURL, opts.RepoPaths)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	remote := (config.Git{Remote: opts.Remote}).RemoteName()
+	branch, err := BranchNameFromTemplate(opts.BranchTemplate, opts.RepoName, opts.PrIndex)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	remoteRef := fmt.Sprintf("refs/remotes/%s/pull/%d/head", remote, opts.PrIndex)
+	return CheckoutPlan{
+		RepoPath:     repoPath,
+		Remote:       remote,
+		Branch:       branch,
+		FetchRefspec: fmt.Sprintf("+refs/pull/%d/head:%s", opts.PrIndex, remoteRef),
+		RemoteRef:    remoteRef,
+	}, nil
+}
+
+// RunCheckout fetches and checks out a pull request branch. It refuses dirty
+// worktrees. Existing local branches are advanced only through --ff-only.
+func RunCheckout(ctx context.Context, opts CheckoutOptions) (CheckoutPlan, error) {
+	plan, err := PlanCheckout(opts)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	status, err := runGit(ctx, runner, plan.RepoPath, "status", "--porcelain")
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	if strings.TrimSpace(status.Stdout) != "" {
+		return CheckoutPlan{}, fmt.Errorf("refusing checkout in dirty worktree %s", plan.RepoPath)
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "fetch", plan.Remote, plan.FetchRefspec); err != nil {
+		return CheckoutPlan{}, err
+	}
+
+	exists, err := branchExists(ctx, runner, plan.RepoPath, plan.Branch)
+	if err != nil {
+		return CheckoutPlan{}, err
+	}
+	if !exists {
+		if _, err := runGit(ctx, runner, plan.RepoPath, "switch", "-c", plan.Branch, plan.RemoteRef); err != nil {
+			return CheckoutPlan{}, err
+		}
+		return plan, nil
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "switch", plan.Branch); err != nil {
+		return CheckoutPlan{}, err
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "merge", "--ff-only", plan.RemoteRef); err != nil {
+		return CheckoutPlan{}, fmt.Errorf("fast-forward existing branch %s: %w", plan.Branch, err)
+	}
+	return plan, nil
+}
+
+func branchExists(ctx context.Context, runner Runner, dir, branch string) (bool, error) {
+	res, err := runner.Run(ctx, Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}})
+	if err != nil {
+		return false, err
+	}
+	switch res.ExitCode {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, commandError(Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}}, res)
+	}
+}
+
+func runGit(ctx context.Context, runner Runner, dir string, args ...string) (Result, error) {
+	cmd := Command{Dir: dir, Name: "git", Args: args}
+	res, err := runner.Run(ctx, cmd)
+	if err != nil {
+		return Result{}, err
+	}
+	if res.ExitCode != 0 {
+		return res, commandError(cmd, res)
+	}
+	return res, nil
+}
+
+func commandError(cmd Command, res Result) error {
+	msg := strings.TrimSpace(res.Stderr)
+	if msg == "" {
+		msg = strings.TrimSpace(res.Stdout)
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("exit %d", res.ExitCode)
+	}
+	return fmt.Errorf("%s %s failed: %s", cmd.Name, strings.Join(cmd.Args, " "), msg)
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,295 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		host   string
+		owner  string
+		repo   string
+		remote string
+	}{
+		{
+			name:   "https with git suffix",
+			raw:    "https://git.example.com/acme/widgets.git",
+			host:   "git.example.com",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "https with port",
+			raw:    "http://git.example.com:3000/acme/widgets",
+			host:   "git.example.com:3000",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "ssh URL with port",
+			raw:    "ssh://git@git.example.com:2222/acme/widgets.git",
+			host:   "git.example.com:2222",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "ssh URL preserves explicit port 443",
+			raw:    "ssh://git@git.example.com:443/acme/widgets.git",
+			host:   "git.example.com:443",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+		{
+			name:   "scp SSH",
+			raw:    "git@git.example.com:acme/widgets.git",
+			host:   "git.example.com",
+			owner:  "acme",
+			repo:   "widgets",
+			remote: "acme/widgets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRemoteURL(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseRemoteURL: %v", err)
+			}
+			if got.Host != tt.host || got.Owner != tt.owner || got.Repo != tt.repo || got.FullName() != tt.remote {
+				t.Fatalf("ParseRemoteURL = %+v, FullName=%q", got, got.FullName())
+			}
+		})
+	}
+}
+
+func TestRemoteMatchesInstanceURL(t *testing.T) {
+	remote, err := ParseRemoteURL("git@gitea.example.com:fcmb/api.git")
+	if err != nil {
+		t.Fatalf("ParseRemoteURL: %v", err)
+	}
+	if !remote.MatchesInstanceURL("https://gitea.example.com") {
+		t.Fatal("remote should match same instance host")
+	}
+	if remote.MatchesInstanceURL("https://other.example.com") {
+		t.Fatal("remote should not match a different instance host")
+	}
+
+	withPort, err := ParseRemoteURL("ssh://git@gitea.example.com:2222/fcmb/api.git")
+	if err != nil {
+		t.Fatalf("ParseRemoteURL with port: %v", err)
+	}
+	if !withPort.MatchesInstanceURL("https://gitea.example.com:2222") {
+		t.Fatal("remote with port should match same instance host and port")
+	}
+	if withPort.MatchesInstanceURL("https://gitea.example.com") {
+		t.Fatal("remote with port should not match instance without that port")
+	}
+}
+
+func TestResolveRepoPathExactWildcardAndCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths := map[string]string{
+		"fcmb/*":   "~/work/fcmb/{{.Repo}}",
+		"fcmb/api": "~/work/exact-api",
+	}
+
+	got, err := ResolveRepoPath("fcmb/api", "/not/used", "https://gitea.example.com", paths)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath exact: %v", err)
+	}
+	if want := filepath.Join(home, "work", "exact-api"); got != want {
+		t.Fatalf("ResolveRepoPath exact = %q, want %q", got, want)
+	}
+
+	got, err = ResolveRepoPath("fcmb/web", "/not/used", "https://gitea.example.com", paths)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath wildcard: %v", err)
+	}
+	if want := filepath.Join(home, "work", "fcmb", "web"); got != want {
+		t.Fatalf("ResolveRepoPath wildcard = %q, want %q", got, want)
+	}
+
+	cwd := makeGitDir(t, "https://gitea.example.com/fcmb/api.git")
+	got, err = ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	if err != nil {
+		t.Fatalf("ResolveRepoPath cwd: %v", err)
+	}
+	if got != cwd {
+		t.Fatalf("ResolveRepoPath cwd = %q, want %q", got, cwd)
+	}
+}
+
+func TestResolveRepoPathRejectsCWDHostMismatch(t *testing.T) {
+	cwd := makeGitDir(t, "https://other.example.com/fcmb/api.git")
+	_, err := ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	if err == nil || !strings.Contains(err.Error(), "no local checkout") {
+		t.Fatalf("ResolveRepoPath host mismatch error = %v", err)
+	}
+}
+
+func TestBranchNameFromTemplate(t *testing.T) {
+	got, err := BranchNameFromTemplate("review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}", "fcmb/api", 42)
+	if err != nil {
+		t.Fatalf("BranchNameFromTemplate: %v", err)
+	}
+	if got != "review/fcmb-api-42" {
+		t.Fatalf("BranchNameFromTemplate = %q", got)
+	}
+
+	got, err = BranchNameFromTemplate("", "fcmb/api", 42)
+	if err != nil {
+		t.Fatalf("BranchNameFromTemplate default: %v", err)
+	}
+	if got != "pr-42" {
+		t.Fatalf("BranchNameFromTemplate default = %q", got)
+	}
+}
+
+func TestRunCheckoutDirtyTreeRefusal(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{Stdout: " M file.txt\n", ExitCode: 0}}}
+
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:  "fcmb/api",
+		RepoPaths: map[string]string{"fcmb/api": repo},
+		PrIndex:   42,
+		Runner:    runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("RunCheckout dirty error = %v", err)
+	}
+	if len(runner.commands) != 1 || !reflect.DeepEqual(runner.commands[0].Args, []string{"status", "--porcelain"}) {
+		t.Fatalf("commands = %#v", runner.commands)
+	}
+}
+
+func TestRunCheckoutFetchesAndCreatesMissingBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 0}, // fetch
+		{ExitCode: 1}, // show-ref missing branch
+		{ExitCode: 0}, // switch -c
+	}}
+
+	plan, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:       "fcmb/api",
+		RepoPaths:      map[string]string{"fcmb/api": repo},
+		Remote:         "upstream",
+		BranchTemplate: "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}",
+		PrIndex:        42,
+		Runner:         runner,
+	})
+	if err != nil {
+		t.Fatalf("RunCheckout: %v", err)
+	}
+	if plan.Branch != "review/fcmb-api-42" {
+		t.Fatalf("Branch = %q", plan.Branch)
+	}
+	if plan.FetchRefspec != "+refs/pull/42/head:refs/remotes/upstream/pull/42/head" {
+		t.Fatalf("FetchRefspec = %q", plan.FetchRefspec)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"fetch", "upstream", "+refs/pull/42/head:refs/remotes/upstream/pull/42/head"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/review/fcmb-api-42"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "-c", "review/fcmb-api-42", "refs/remotes/upstream/pull/42/head"}},
+	})
+}
+
+func TestRunCheckoutExistingBranchFastForwardOnly(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 0}, // fetch
+		{ExitCode: 0}, // show-ref existing branch
+		{ExitCode: 0}, // switch branch
+		{ExitCode: 0}, // merge --ff-only
+	}}
+
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:  "fcmb/api",
+		RepoPaths: map[string]string{"fcmb/api": repo},
+		PrIndex:   7,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("RunCheckout: %v", err)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"fetch", "origin", "+refs/pull/7/head:refs/remotes/origin/pull/7/head"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/pr-7"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "pr-7"}},
+		{Dir: repo, Name: "git", Args: []string{"merge", "--ff-only", "refs/remotes/origin/pull/7/head"}},
+	})
+}
+
+func TestRunCheckoutMissingRepoPath(t *testing.T) {
+	runner := &fakeRunner{}
+	_, err := RunCheckout(context.Background(), CheckoutOptions{
+		RepoName:    "fcmb/api",
+		CWD:         t.TempDir(),
+		InstanceURL: "https://gitea.example.com",
+		PrIndex:     7,
+		Runner:      runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no local checkout") {
+		t.Fatalf("RunCheckout missing repo error = %v", err)
+	}
+	if len(runner.commands) != 0 {
+		t.Fatalf("runner should not be called, commands = %#v", runner.commands)
+	}
+}
+
+func makeGitDir(t *testing.T, remoteURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := "[remote \"origin\"]\n\turl = " + remoteURL + "\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+type fakeRunner struct {
+	results  []Result
+	err      error
+	commands []Command
+}
+
+func (f *fakeRunner) Run(_ context.Context, cmd Command) (Result, error) {
+	f.commands = append(f.commands, cmd)
+	if f.err != nil {
+		return Result{}, f.err
+	}
+	if len(f.results) == 0 {
+		return Result{}, errors.New("unexpected command: " + strings.Join(cmd.Args, " "))
+	}
+	res := f.results[0]
+	f.results = f.results[1:]
+	return res, nil
+}
+
+func assertCommands(t *testing.T, got, want []Command) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands:\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/internal/gitea/actions.go
+++ b/internal/gitea/actions.go
@@ -1,0 +1,315 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+// ActionRunListOptions are the optional filters supported by Gitea's
+// repo-scoped Actions runs endpoint.
+type ActionRunListOptions struct {
+	Event   string
+	Branch  string
+	Status  string
+	Actor   string
+	HeadSHA string
+	Limit   int
+}
+
+type rawActionRun struct {
+	ID           int64     `json:"id"`
+	RunNumber    int64     `json:"run_number"`
+	RunAttempt   int64     `json:"run_attempt"`
+	Name         string    `json:"name"`
+	WorkflowName string    `json:"workflow_name"`
+	DisplayTitle string    `json:"display_title"`
+	Event        string    `json:"event"`
+	Status       string    `json:"status"`
+	Conclusion   string    `json:"conclusion"`
+	HeadBranch   string    `json:"head_branch"`
+	HeadSHA      string    `json:"head_sha"`
+	HTMLURL      string    `json:"html_url"`
+	URL          string    `json:"url"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	RunStartedAt time.Time `json:"run_started_at"`
+	StartedAt    time.Time `json:"started_at"`
+	Actor        *struct {
+		Login string `json:"login"`
+	} `json:"actor"`
+	Repository *struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type rawActionJob struct {
+	ID          int64           `json:"id"`
+	RunID       int64           `json:"run_id"`
+	Name        string          `json:"name"`
+	Status      string          `json:"status"`
+	Conclusion  string          `json:"conclusion"`
+	RunnerName  string          `json:"runner_name"`
+	HTMLURL     string          `json:"html_url"`
+	URL         string          `json:"url"`
+	StartedAt   time.Time       `json:"started_at"`
+	CompletedAt time.Time       `json:"completed_at"`
+	Steps       []rawActionStep `json:"steps"`
+}
+
+type rawActionStep struct {
+	Number      int64     `json:"number"`
+	StepNumber  int64     `json:"step_number"`
+	Name        string    `json:"name"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+type actionRunsEnvelope struct {
+	TotalCount   int            `json:"total_count"`
+	WorkflowRuns []rawActionRun `json:"workflow_runs"`
+	Runs         []rawActionRun `json:"runs"`
+	ActionRuns   []rawActionRun `json:"action_runs"`
+	Data         []rawActionRun `json:"data"`
+}
+
+type actionJobsEnvelope struct {
+	TotalCount int            `json:"total_count"`
+	Jobs       []rawActionJob `json:"jobs"`
+	ActionJobs []rawActionJob `json:"action_jobs"`
+	Data       []rawActionJob `json:"data"`
+}
+
+// ListActionRuns returns one page of repo-scoped Actions workflow runs plus the
+// server's total count when the payload exposes it. Decoding accepts both the
+// documented wrapped shape and bare arrays seen on some Forgejo/Gitea variants.
+func (c *Client) ListActionRuns(ctx context.Context, owner, repo string, opts ActionRunListOptions) ([]data.ActionRun, int, error) {
+	path := actionRunsPath(owner, repo)
+	if q := buildActionRunParams(opts); len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var raw json.RawMessage
+	if _, err := c.rawGet(ctx, path, &raw); err != nil {
+		return nil, 0, err
+	}
+	rows, total, err := decodeActionRuns(raw)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decoding actions runs: %w", err)
+	}
+
+	repoName := owner + "/" + repo
+	runs := make([]data.ActionRun, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, mapActionRun(row, repoName))
+	}
+	return runs, total, nil
+}
+
+// GetActionRun fetches one repo-scoped Actions workflow run.
+func (c *Client) GetActionRun(ctx context.Context, owner, repo string, runID int64) (data.ActionRun, error) {
+	var raw rawActionRun
+	if _, err := c.rawGet(ctx, actionRunPath(owner, repo, runID), &raw); err != nil {
+		return data.ActionRun{}, err
+	}
+	return mapActionRun(raw, owner+"/"+repo), nil
+}
+
+// ListActionJobs returns the jobs attached to one repo-scoped Actions workflow
+// run. Decoding accepts both the documented wrapped shape and bare arrays.
+func (c *Client) ListActionJobs(ctx context.Context, owner, repo string, runID int64) ([]data.ActionJob, error) {
+	var raw json.RawMessage
+	if _, err := c.rawGet(ctx, actionJobsPath(owner, repo, runID), &raw); err != nil {
+		return nil, err
+	}
+	rows, err := decodeActionJobs(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decoding actions jobs: %w", err)
+	}
+
+	repoName := owner + "/" + repo
+	jobs := make([]data.ActionJob, 0, len(rows))
+	for _, row := range rows {
+		jobs = append(jobs, mapActionJob(row, repoName, runID))
+	}
+	return jobs, nil
+}
+
+func buildActionRunParams(opts ActionRunListOptions) url.Values {
+	q := url.Values{}
+	if opts.Event != "" {
+		q.Set("event", opts.Event)
+	}
+	if opts.Branch != "" {
+		q.Set("branch", opts.Branch)
+	}
+	if opts.Status != "" {
+		q.Set("status", opts.Status)
+	}
+	if opts.Actor != "" {
+		q.Set("actor", opts.Actor)
+	}
+	if opts.HeadSHA != "" {
+		q.Set("head_sha", opts.HeadSHA)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	return q
+}
+
+func decodeActionRuns(raw json.RawMessage) ([]rawActionRun, int, error) {
+	var rows []rawActionRun
+	if err := json.Unmarshal(raw, &rows); err == nil {
+		return rows, len(rows), nil
+	}
+
+	var env actionRunsEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, 0, err
+	}
+	switch {
+	case env.WorkflowRuns != nil:
+		rows = env.WorkflowRuns
+	case env.Runs != nil:
+		rows = env.Runs
+	case env.ActionRuns != nil:
+		rows = env.ActionRuns
+	case env.Data != nil:
+		rows = env.Data
+	default:
+		rows = nil
+	}
+	total := env.TotalCount
+	if total == 0 {
+		total = len(rows)
+	}
+	return rows, total, nil
+}
+
+func decodeActionJobs(raw json.RawMessage) ([]rawActionJob, error) {
+	var rows []rawActionJob
+	if err := json.Unmarshal(raw, &rows); err == nil {
+		return rows, nil
+	}
+
+	var env actionJobsEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, err
+	}
+	switch {
+	case env.Jobs != nil:
+		return env.Jobs, nil
+	case env.ActionJobs != nil:
+		return env.ActionJobs, nil
+	case env.Data != nil:
+		return env.Data, nil
+	default:
+		return nil, nil
+	}
+}
+
+func mapActionRun(row rawActionRun, fallbackRepo string) data.ActionRun {
+	workflowName := row.WorkflowName
+	if workflowName == "" {
+		workflowName = row.Name
+	}
+	htmlURL := row.HTMLURL
+	if htmlURL == "" {
+		htmlURL = row.URL
+	}
+	startedAt := row.RunStartedAt
+	if startedAt.IsZero() {
+		startedAt = row.StartedAt
+	}
+	repoName := fallbackRepo
+	if row.Repository != nil && row.Repository.FullName != "" {
+		repoName = row.Repository.FullName
+	}
+
+	run := data.ActionRun{
+		ID:                row.ID,
+		RunNumber:         row.RunNumber,
+		RunAttempt:        row.RunAttempt,
+		DisplayTitle:      row.DisplayTitle,
+		WorkflowName:      workflowName,
+		Event:             row.Event,
+		Status:            row.Status,
+		Conclusion:        row.Conclusion,
+		HeadBranch:        row.HeadBranch,
+		HeadSHA:           row.HeadSHA,
+		RepoNameWithOwner: repoName,
+		HTMLURL:           htmlURL,
+		CreatedAt:         row.CreatedAt,
+		UpdatedAt:         row.UpdatedAt,
+		StartedAt:         startedAt,
+	}
+	if row.Actor != nil {
+		run.Actor = row.Actor.Login
+	}
+	return run
+}
+
+func mapActionJob(row rawActionJob, repoName string, fallbackRunID int64) data.ActionJob {
+	runID := row.RunID
+	if runID == 0 {
+		runID = fallbackRunID
+	}
+	htmlURL := row.HTMLURL
+	if htmlURL == "" {
+		htmlURL = row.URL
+	}
+	job := data.ActionJob{
+		ID:                row.ID,
+		RunID:             runID,
+		Name:              row.Name,
+		Status:            row.Status,
+		Conclusion:        row.Conclusion,
+		RunnerName:        row.RunnerName,
+		RepoNameWithOwner: repoName,
+		HTMLURL:           htmlURL,
+		StartedAt:         row.StartedAt,
+		CompletedAt:       row.CompletedAt,
+	}
+	if len(row.Steps) > 0 {
+		job.Steps = make([]data.ActionStep, 0, len(row.Steps))
+		for _, step := range row.Steps {
+			job.Steps = append(job.Steps, mapActionStep(step))
+		}
+	}
+	return job
+}
+
+func mapActionStep(row rawActionStep) data.ActionStep {
+	number := row.Number
+	if number == 0 {
+		number = row.StepNumber
+	}
+	return data.ActionStep{
+		Number:      number,
+		Name:        row.Name,
+		Status:      row.Status,
+		Conclusion:  row.Conclusion,
+		StartedAt:   row.StartedAt,
+		CompletedAt: row.CompletedAt,
+	}
+}
+
+func actionRunsPath(owner, repo string) string {
+	return "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/actions/runs"
+}
+
+func actionRunPath(owner, repo string, runID int64) string {
+	return actionRunsPath(owner, repo) + "/" + strconv.FormatInt(runID, 10)
+}
+
+func actionJobsPath(owner, repo string, runID int64) string {
+	return actionRunPath(owner, repo, runID) + "/jobs"
+}

--- a/internal/gitea/actions_test.go
+++ b/internal/gitea/actions_test.go
@@ -1,0 +1,227 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+)
+
+const actionRunsJSON = `{
+  "total_count": 12,
+  "workflow_runs": [
+    {
+      "id": 101,
+      "run_number": 12,
+      "run_attempt": 2,
+      "name": "CI",
+      "display_title": "Fix checkout flakes",
+      "event": "push",
+      "status": "in_progress",
+      "conclusion": "",
+      "head_branch": "main",
+      "head_sha": "abc123",
+      "html_url": "https://git.example/acme/widgets/actions/runs/101",
+      "actor": {"login": "octo"},
+      "created_at": "2026-07-02T08:00:00Z",
+      "updated_at": "2026-07-02T08:05:00Z",
+      "run_started_at": "2026-07-02T08:01:00Z"
+    }
+  ]
+}`
+
+func TestListActionRunsMapsWrappedResponseAndFilters(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			if r.Header.Get("Authorization") != "token t" {
+				t.Fatalf("Authorization header = %q, want token auth", r.Header.Get("Authorization"))
+			}
+			fmt.Fprint(w, actionRunsJSON)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	runs, total, err := c.ListActionRuns(context.Background(), "acme", "widgets", ActionRunListOptions{
+		Event:   "push",
+		Branch:  "main",
+		Status:  "in_progress",
+		Actor:   "octo",
+		HeadSHA: "abc123",
+		Limit:   25,
+	})
+	if err != nil {
+		t.Fatalf("ListActionRuns: %v", err)
+	}
+	if total != 12 || len(runs) != 1 {
+		t.Fatalf("got total=%d len=%d, want total 12 and one run", total, len(runs))
+	}
+	run := runs[0]
+	if run.ID != 101 || run.RunNumber != 12 || run.RunAttempt != 2 ||
+		run.DisplayTitle != "Fix checkout flakes" || run.WorkflowName != "CI" ||
+		run.Event != "push" || run.Status != "in_progress" || run.Conclusion != "" ||
+		run.HeadBranch != "main" || run.HeadSHA != "abc123" || run.Actor != "octo" ||
+		run.RepoNameWithOwner != "acme/widgets" || run.HTMLURL != "https://git.example/acme/widgets/actions/runs/101" {
+		t.Fatalf("mapped run = %+v", run)
+	}
+	wantStarted := time.Date(2026, 7, 2, 8, 1, 0, 0, time.UTC)
+	wantUpdated := time.Date(2026, 7, 2, 8, 5, 0, 0, time.UTC)
+	if !run.StartedAt.Equal(wantStarted) || !run.UpdatedAt.Equal(wantUpdated) {
+		t.Fatalf("run times = started %s updated %s", run.StartedAt, run.UpdatedAt)
+	}
+	for _, want := range []string{
+		"event=push",
+		"branch=main",
+		"status=in_progress",
+		"actor=octo",
+		"head_sha=abc123",
+		"limit=25",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+func TestListActionRunsMapsArrayResponse(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `[
+			  {
+			    "id": 102,
+			    "name": "Nightly",
+			    "status": "success",
+			    "repository": {"full_name": "acme/widgets"},
+			    "html_url": "https://git.example/acme/widgets/actions/runs/102"
+			  }
+			]`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	runs, total, err := c.ListActionRuns(context.Background(), "acme", "widgets", ActionRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListActionRuns: %v", err)
+	}
+	if total != 1 || len(runs) != 1 {
+		t.Fatalf("got total=%d len=%d, want one array-decoded run", total, len(runs))
+	}
+	if runs[0].ID != 102 || runs[0].WorkflowName != "Nightly" || runs[0].Status != "success" {
+		t.Fatalf("mapped run = %+v", runs[0])
+	}
+}
+
+func TestGetActionRunMapsSingleRun(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{
+			  "id": 101,
+			  "run_number": 12,
+			  "name": "CI",
+			  "status": "failure",
+			  "conclusion": "failure",
+			  "html_url": "https://git.example/acme/widgets/actions/runs/101"
+			}`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	run, err := c.GetActionRun(context.Background(), "acme", "widgets", 101)
+	if err != nil {
+		t.Fatalf("GetActionRun: %v", err)
+	}
+	if run.ID != 101 || run.RunNumber != 12 || run.WorkflowName != "CI" ||
+		run.Status != "failure" || run.Conclusion != "failure" || run.RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("mapped run = %+v", run)
+	}
+}
+
+func TestListActionJobsMapsWrappedResponse(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101/jobs", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{
+			  "total_count": 1,
+			  "jobs": [
+			    {
+			      "id": 201,
+			      "run_id": 101,
+			      "name": "build",
+			      "status": "success",
+			      "conclusion": "success",
+			      "runner_name": "ubuntu-latest",
+			      "html_url": "https://git.example/acme/widgets/actions/runs/101/jobs/201",
+			      "started_at": "2026-07-02T08:01:00Z",
+			      "completed_at": "2026-07-02T08:04:00Z",
+			      "steps": [
+			        {
+			          "number": 1,
+			          "name": "checkout",
+			          "status": "success",
+			          "conclusion": "success",
+			          "started_at": "2026-07-02T08:01:00Z",
+			          "completed_at": "2026-07-02T08:02:00Z"
+			        }
+			      ]
+			    }
+			  ]
+			}`)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	jobs, err := c.ListActionJobs(context.Background(), "acme", "widgets", 101)
+	if err != nil {
+		t.Fatalf("ListActionJobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	job := jobs[0]
+	if job.ID != 201 || job.RunID != 101 || job.Name != "build" ||
+		job.Status != "success" || job.Conclusion != "success" ||
+		job.RunnerName != "ubuntu-latest" || job.RepoNameWithOwner != "acme/widgets" ||
+		job.HTMLURL != "https://git.example/acme/widgets/actions/runs/101/jobs/201" {
+		t.Fatalf("mapped job = %+v", job)
+	}
+	if len(job.Steps) != 1 || job.Steps[0].Number != 1 || job.Steps[0].Name != "checkout" ||
+		job.Steps[0].Status != "success" || job.Steps[0].Conclusion != "success" {
+		t.Fatalf("mapped steps = %+v", job.Steps)
+	}
+}
+
+func actionServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/gitea/diff.go
+++ b/internal/gitea/diff.go
@@ -1,0 +1,21 @@
+package gitea
+
+import (
+	"fmt"
+
+	sdk "code.gitea.io/sdk/gitea"
+)
+
+// GetPullDiff fetches the raw unified diff bytes for a pull request.
+func (c *Client) GetPullDiff(owner, repo string, index int64) ([]byte, error) {
+	var diff []byte
+	err := c.call(func() error {
+		var e error
+		diff, _, e = c.sdk.GetPullRequestDiff(owner, repo, index, sdk.PullRequestDiffOptions{Binary: true})
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get pull diff %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return diff, nil
+}

--- a/internal/gitea/diff_test.go
+++ b/internal/gitea/diff_test.go
@@ -1,0 +1,67 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+)
+
+func TestGetPullDiffReturnsBytes(t *testing.T) {
+	const want = "diff --git a/file.txt b/file.txt\n+hello\n"
+	c := newDiffTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/7.diff" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "token t" {
+			t.Fatalf("Authorization = %q, want token t", got)
+		}
+		fmt.Fprint(w, want)
+	}))
+
+	got, err := c.GetPullDiff("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetPullDiff: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("GetPullDiff = %q, want %q", string(got), want)
+	}
+}
+
+func TestGetPullDiffWrapsErrors(t *testing.T) {
+	c := newDiffTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+
+	_, err := c.GetPullDiff("acme", "widgets", 7)
+	if err == nil {
+		t.Fatal("GetPullDiff expected an error")
+	}
+	if !strings.Contains(err.Error(), "get pull diff acme/widgets#7") {
+		t.Fatalf("GetPullDiff error = %v, want wrapped pull context", err)
+	}
+}
+
+func newDiffTestClient(t *testing.T, diffHandler http.Handler) *Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me","full_name":"Me"}`)
+	})
+	mux.Handle("/api/v1/repos/acme/widgets/pulls/7.diff", diffHandler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -1,0 +1,118 @@
+package gitea
+
+import (
+	"fmt"
+
+	sdk "code.gitea.io/sdk/gitea"
+
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+// AddComment creates an issue/PR comment and maps the returned comment into the
+// domain shape used by detail views.
+func (c *Client) AddComment(owner, repo string, index int64, body string) (data.Comment, error) {
+	var comment *sdk.Comment
+	err := c.call(func() error {
+		var e error
+		comment, _, e = c.sdk.CreateIssueComment(owner, repo, index, sdk.CreateIssueCommentOption{
+			Body: body,
+		})
+		return e
+	})
+	if err != nil {
+		return data.Comment{}, fmt.Errorf("add comment %s/%s#%d: %w", owner, repo, index, err)
+	}
+	mapped := mapComments([]*sdk.Comment{comment})
+	if len(mapped) == 0 {
+		return data.Comment{}, nil
+	}
+	return mapped[0], nil
+}
+
+// SetIssueState opens or closes an issue.
+func (c *Client) SetIssueState(owner, repo string, index int64, state data.ItemState) error {
+	s := sdk.StateType(state)
+	err := c.call(func() error {
+		_, _, e := c.sdk.EditIssue(owner, repo, index, sdk.EditIssueOption{State: &s})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("set issue state %s/%s#%d to %s: %w", owner, repo, index, state, err)
+	}
+	return nil
+}
+
+// SetPullState opens or closes a pull request.
+func (c *Client) SetPullState(owner, repo string, index int64, state data.ItemState) error {
+	s := sdk.StateType(state)
+	err := c.call(func() error {
+		_, _, e := c.sdk.EditPullRequest(owner, repo, index, sdk.EditPullRequestOption{State: &s})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("set pull state %s/%s#%d to %s: %w", owner, repo, index, state, err)
+	}
+	return nil
+}
+
+// MergePullRequest merges a pull request with the requested strategy and
+// optional server-side controls.
+func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {
+	deleteBranch := opt.DeleteBranch
+	var merged bool
+	err := c.call(func() error {
+		var e error
+		merged, _, e = c.sdk.MergePullRequest(owner, repo, index, sdk.MergePullRequestOption{
+			Style:                  sdk.MergeStyle(opt.Style),
+			Title:                  opt.Title,
+			Message:                opt.Message,
+			DeleteBranchAfterMerge: &deleteBranch,
+			ForceMerge:             opt.ForceMerge,
+			HeadCommitId:           opt.HeadCommitID,
+		})
+		return e
+	})
+	if err != nil {
+		return false, fmt.Errorf("merge pull %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return merged, nil
+}
+
+// SubmitPullReview creates a submitted pull-request review.
+func (c *Client) SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error) {
+	event, err := mapPullReviewEvent(opt.Event)
+	if err != nil {
+		return data.Review{}, fmt.Errorf("submit pull review %s/%s#%d: %w", owner, repo, index, err)
+	}
+
+	var review *sdk.PullReview
+	err = c.call(func() error {
+		var e error
+		review, _, e = c.sdk.CreatePullReview(owner, repo, index, sdk.CreatePullReviewOptions{
+			State: event,
+			Body:  opt.Body,
+		})
+		return e
+	})
+	if err != nil {
+		return data.Review{}, fmt.Errorf("submit pull review %s/%s#%d: %w", owner, repo, index, err)
+	}
+	mapped := mapReviews([]*sdk.PullReview{review})
+	if len(mapped) == 0 {
+		return data.Review{}, nil
+	}
+	return mapped[0], nil
+}
+
+func mapPullReviewEvent(event data.PullReviewEvent) (sdk.ReviewStateType, error) {
+	switch event {
+	case data.PullReviewEventApprove:
+		return sdk.ReviewStateApproved, nil
+	case data.PullReviewEventRequestChanges:
+		return sdk.ReviewStateRequestChanges, nil
+	case data.PullReviewEventComment:
+		return sdk.ReviewStateComment, nil
+	default:
+		return "", fmt.Errorf("unsupported pull review event %q", event)
+	}
+}

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -1,0 +1,209 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+	"github.com/gbarany/tea-dash/internal/data"
+)
+
+func mutationClient(t *testing.T, mutate http.HandlerFunc) *Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me","full_name":"Me"}`)
+	})
+	mux.HandleFunc("/", mutate)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func decodeMutationBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	return body
+}
+
+func TestAddCommentPostsBodyAndMapsResponse(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/7/comments" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		if body["body"] != "hello world" {
+			t.Fatalf("body = %#v", body)
+		}
+		fmt.Fprint(w, `{"id":10,"body":"hello world","created_at":"2026-07-01T10:00:00Z","user":{"login":"alice"}}`)
+	})
+
+	got, err := c.AddComment("acme", "widgets", 7, "hello world")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	wantCreated := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if got.Author != "alice" || got.Body != "hello world" || !got.CreatedAt.Equal(wantCreated) {
+		t.Fatalf("comment = %+v", got)
+	}
+}
+
+func TestSetIssueStatePatchesState(t *testing.T) {
+	var states []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/42" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		state, _ := body["state"].(string)
+		states = append(states, state)
+		fmt.Fprintf(w, `{"number":42,"state":%q}`, state)
+	})
+
+	if err := c.SetIssueState("acme", "widgets", 42, data.ItemStateClosed); err != nil {
+		t.Fatalf("close issue: %v", err)
+	}
+	if err := c.SetIssueState("acme", "widgets", 42, data.ItemStateOpen); err != nil {
+		t.Fatalf("reopen issue: %v", err)
+	}
+	if len(states) != 2 || states[0] != "closed" || states[1] != "open" {
+		t.Fatalf("states = %v, want [closed open]", states)
+	}
+}
+
+func TestSetPullStatePatchesPullState(t *testing.T) {
+	var states []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/43" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		state, _ := body["state"].(string)
+		states = append(states, state)
+		fmt.Fprintf(w, `{"number":43,"state":%q}`, state)
+	})
+
+	if err := c.SetPullState("acme", "widgets", 43, data.ItemStateClosed); err != nil {
+		t.Fatalf("close pull: %v", err)
+	}
+	if err := c.SetPullState("acme", "widgets", 43, data.ItemStateOpen); err != nil {
+		t.Fatalf("reopen pull: %v", err)
+	}
+	if len(states) != 2 || states[0] != "closed" || states[1] != "open" {
+		t.Fatalf("states = %v, want [closed open]", states)
+	}
+}
+
+func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44/merge" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		checks := map[string]any{
+			"Do":                        "squash",
+			"MergeTitleField":           "merge title",
+			"MergeMessageField":         "merge message",
+			"delete_branch_after_merge": true,
+			"force_merge":               true,
+			"head_commit_id":            "abc123",
+		}
+		for key, want := range checks {
+			if body[key] != want {
+				t.Fatalf("%s = %#v, want %#v in body %#v", key, body[key], want, body)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	merged, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{
+		Style:        data.MergeStyleSquash,
+		Title:        "merge title",
+		Message:      "merge message",
+		DeleteBranch: true,
+		ForceMerge:   true,
+		HeadCommitID: "abc123",
+	})
+	if err != nil {
+		t.Fatalf("MergePullRequest: %v", err)
+	}
+	if !merged {
+		t.Fatal("merged = false, want true")
+	}
+}
+
+func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/45/reviews" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		if body["event"] != "REQUEST_CHANGES" || body["body"] != "needs work" {
+			t.Fatalf("body = %#v", body)
+		}
+		fmt.Fprint(w, `{"id":2,"state":"REQUEST_CHANGES","body":"needs work","submitted_at":"2026-07-01T11:00:00Z","user":{"login":"reviewer"}}`)
+	})
+
+	got, err := c.SubmitPullReview("acme", "widgets", 45, data.PullReviewOptions{
+		Event: data.PullReviewEventRequestChanges,
+		Body:  "needs work",
+	})
+	if err != nil {
+		t.Fatalf("SubmitPullReview: %v", err)
+	}
+	wantSubmitted := time.Date(2026, 7, 1, 11, 0, 0, 0, time.UTC)
+	if got.Author != "reviewer" || got.State != data.ReviewStateRequestChanges || got.Body != "needs work" || !got.SubmittedAt.Equal(wantSubmitted) {
+		t.Fatalf("review = %+v", got)
+	}
+}
+
+func TestAddCommentWrapsServerError(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/7/comments" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	_, err := c.AddComment("acme", "widgets", 7, "hello")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "add comment acme/widgets#7") || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %q", err)
+	}
+}

--- a/internal/gitea/notifications.go
+++ b/internal/gitea/notifications.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -35,6 +36,42 @@ func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notific
 		rows = append(rows, mapNotificationThread(thread))
 	}
 	return rows, len(rows), nil
+}
+
+// MarkNotificationRead marks one notification thread as read.
+func (c *Client) MarkNotificationRead(_ context.Context, threadID int64) error {
+	return c.markNotification(threadID, sdk.NotifyStatusRead, "read")
+}
+
+// MarkNotificationUnread marks one notification thread as unread.
+func (c *Client) MarkNotificationUnread(_ context.Context, threadID int64) error {
+	return c.markNotification(threadID, sdk.NotifyStatusUnread, "unread")
+}
+
+// MarkAllNotificationsRead marks all unread notification threads as read.
+func (c *Client) MarkAllNotificationsRead(_ context.Context) error {
+	err := c.call(func() error {
+		_, _, e := c.sdk.ReadNotifications(sdk.MarkNotificationOptions{
+			Status:   []sdk.NotifyStatus{sdk.NotifyStatusUnread},
+			ToStatus: sdk.NotifyStatusRead,
+		})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("marking all unread notifications read: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) markNotification(threadID int64, status sdk.NotifyStatus, label string) error {
+	err := c.call(func() error {
+		_, _, e := c.sdk.ReadNotification(threadID, status)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("marking notification %d %s: %w", threadID, label, err)
+	}
+	return nil
 }
 
 func mapNotificationThread(thread *sdk.NotificationThread) data.Notification {

--- a/internal/gitea/notifications_test.go
+++ b/internal/gitea/notifications_test.go
@@ -3,6 +3,7 @@ package gitea
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -69,7 +70,150 @@ func TestListNotificationsMapsThreads(t *testing.T) {
 	}
 }
 
-func notificationServer(t *testing.T, notifications http.HandlerFunc) *httptest.Server {
+func TestMarkNotificationReadUsesThreadEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"unread":false}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkNotificationRead(context.Background(), 12); err != nil {
+		t.Fatalf("MarkNotificationRead: %v", err)
+	}
+	if !hit {
+		t.Fatal("notification thread endpoint was not called")
+	}
+}
+
+func TestMarkNotificationUnreadUsesThreadEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "unread" {
+				t.Fatalf("to-status = %q, want unread", got)
+			}
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"unread":true}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkNotificationUnread(context.Background(), 12); err != nil {
+		t.Fatalf("MarkNotificationUnread: %v", err)
+	}
+	if !hit {
+		t.Fatal("notification thread endpoint was not called")
+	}
+}
+
+func TestMarkAllNotificationsReadUsesNotificationsEndpoint(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		q := r.URL.Query()
+		if got := q.Get("to-status"); got != "read" {
+			t.Fatalf("to-status = %q, want read", got)
+		}
+		if got := q["status-types"]; len(got) != 1 || got[0] != "unread" {
+			t.Fatalf("status-types = %v, want [unread]", got)
+		}
+		assertEmptyBody(t, r)
+		fmt.Fprint(w, `[]`)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.MarkAllNotificationsRead(context.Background()); err != nil {
+		t.Fatalf("MarkAllNotificationsRead: %v", err)
+	}
+	if !hit {
+		t.Fatal("notifications endpoint was not called")
+	}
+}
+
+func TestMarkNotificationReadReturnsActionableError(t *testing.T) {
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "patch denied", http.StatusInternalServerError)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = c.MarkNotificationRead(context.Background(), 12)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "marking notification 12 read") ||
+		!strings.Contains(msg, "500") ||
+		!strings.Contains(msg, "patch denied") {
+		t.Fatalf("error %q should include operation, status, and server body", msg)
+	}
+}
+
+func TestMarkAllNotificationsReadReturnsActionableError(t *testing.T) {
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bulk denied", http.StatusBadGateway)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = c.MarkAllNotificationsRead(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "marking all unread notifications read") ||
+		!strings.Contains(msg, "502") ||
+		!strings.Contains(msg, "bulk denied") {
+		t.Fatalf("error %q should include operation, status, and server body", msg)
+	}
+}
+
+type notificationRoute struct {
+	pattern string
+	handler http.HandlerFunc
+}
+
+func notificationServer(t *testing.T, notifications http.HandlerFunc, routes ...notificationRoute) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
@@ -78,8 +222,24 @@ func notificationServer(t *testing.T, notifications http.HandlerFunc) *httptest.
 	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"id":1,"login":"me"}`)
 	})
-	mux.HandleFunc("/api/v1/notifications", notifications)
+	if notifications != nil {
+		mux.HandleFunc("/api/v1/notifications", notifications)
+	}
+	for _, route := range routes {
+		mux.HandleFunc(route.pattern, route.handler)
+	}
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func assertEmptyBody(t *testing.T, r *http.Request) {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("reading request body: %v", err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("body = %q, want empty", body)
+	}
 }

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,50 @@
+// Package shell builds and runs user shell commands through the user's shell.
+package shell
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// Command is an executable shell command plus execution context.
+type Command struct {
+	Name  string
+	Args  []string
+	Stdin []byte
+	Dir   string
+}
+
+// BuildCommand builds a command that runs command through "$SHELL -c", falling
+// back to /bin/sh when SHELL is unset. It does not execute the command.
+func BuildCommand(command string, stdin []byte, dir string) Command {
+	name := os.Getenv("SHELL")
+	if name == "" {
+		name = "/bin/sh"
+	}
+	return Command{
+		Name:  name,
+		Args:  []string{"-c", command},
+		Stdin: stdin,
+		Dir:   dir,
+	}
+}
+
+// Runner runs shell commands.
+type Runner interface {
+	Run(context.Context, Command) ([]byte, error)
+}
+
+// ExecRunner runs commands through os/exec.
+type ExecRunner struct{}
+
+// Run executes cmd and returns combined stdout/stderr.
+func (ExecRunner) Run(ctx context.Context, cmd Command) ([]byte, error) {
+	c := exec.CommandContext(ctx, cmd.Name, cmd.Args...)
+	c.Dir = cmd.Dir
+	if cmd.Stdin != nil {
+		c.Stdin = bytes.NewReader(cmd.Stdin)
+	}
+	return c.CombinedOutput()
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,39 @@
+package shell
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestBuildCommandUsesShellCWithStdinAndDir(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+
+	cmd := BuildCommand("delta --paging=always", []byte("diff"), "/tmp/repo")
+
+	if cmd.Name != "/bin/zsh" {
+		t.Fatalf("Name = %q, want /bin/zsh", cmd.Name)
+	}
+	if want := []string{"-c", "delta --paging=always"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
+	}
+	if !bytes.Equal(cmd.Stdin, []byte("diff")) {
+		t.Fatalf("Stdin = %q, want diff bytes", string(cmd.Stdin))
+	}
+	if cmd.Dir != "/tmp/repo" {
+		t.Fatalf("Dir = %q, want /tmp/repo", cmd.Dir)
+	}
+}
+
+func TestBuildCommandDefaultsToBinSh(t *testing.T) {
+	t.Setenv("SHELL", "")
+
+	cmd := BuildCommand("less -R", nil, "")
+
+	if cmd.Name != "/bin/sh" {
+		t.Fatalf("Name = %q, want /bin/sh", cmd.Name)
+	}
+	if want := []string{"-c", "less -R"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
+	}
+}

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -1,0 +1,77 @@
+// Package actions defines UI-level action intents. It deliberately carries no
+// transport or local-git behavior; callers provide a dispatcher seam.
+package actions
+
+// Kind identifies the action the user requested.
+type Kind string
+
+const (
+	KindComment      Kind = "comment"
+	KindMerge        Kind = "merge"
+	KindClose        Kind = "close"
+	KindReopen       Kind = "reopen"
+	KindReview       Kind = "review"
+	KindExternalDiff Kind = "external_diff"
+	KindCheckout     Kind = "checkout"
+)
+
+// RowKind identifies the selected row's domain type.
+type RowKind string
+
+const (
+	RowKindPullRequest RowKind = "pull_request"
+	RowKindIssue       RowKind = "issue"
+)
+
+// PromptMode records which kind of prompt produced a submitted value.
+type PromptMode string
+
+const (
+	PromptConfirm PromptMode = "confirm"
+	PromptText    PromptMode = "text"
+	PromptPicker  PromptMode = "picker"
+)
+
+// Target is the immutable row/section context for an action.
+type Target struct {
+	SectionID   int
+	SectionType string
+	RowKind     RowKind
+	Repo        string
+	Number      int64
+	Title       string
+	URL         string
+}
+
+// Prompt carries the prompt payload that was submitted with the intent.
+type Prompt struct {
+	Mode  PromptMode
+	Value string
+	Label string
+}
+
+// Intent is the value passed through the app-level dispatcher seam.
+type Intent struct {
+	Kind   Kind
+	Target Target
+	Prompt Prompt
+}
+
+// ResultStatus describes feedback returned by a dispatcher command.
+type ResultStatus string
+
+const (
+	ResultStarted   ResultStatus = "start"
+	ResultSucceeded ResultStatus = "success"
+	ResultErrored   ResultStatus = "error"
+	ResultCanceled  ResultStatus = "cancel"
+)
+
+// ResultMsg is an optional Bubble Tea message a dispatcher can return so the UI
+// can show action feedback without knowing how the action was executed.
+type ResultMsg struct {
+	Intent  Intent
+	Status  ResultStatus
+	Message string
+	Err     error
+}

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -1,0 +1,39 @@
+package actions
+
+import "testing"
+
+func TestKindConstants(t *testing.T) {
+	tests := map[Kind]string{
+		KindComment:      "comment",
+		KindMerge:        "merge",
+		KindClose:        "close",
+		KindReopen:       "reopen",
+		KindReview:       "review",
+		KindExternalDiff: "external_diff",
+		KindCheckout:     "checkout",
+	}
+	for got, want := range tests {
+		if string(got) != want {
+			t.Fatalf("kind constant = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestIntentCarriesTargetAndPrompt(t *testing.T) {
+	intent := Intent{
+		Kind: KindComment,
+		Target: Target{
+			SectionID:   2,
+			SectionType: "pr",
+			RowKind:     RowKindPullRequest,
+			Repo:        "gbarany/tea-dash",
+			Number:      42,
+			Title:       "Add action UI",
+			URL:         "https://example.test/pr/42",
+		},
+		Prompt: Prompt{Mode: PromptText, Value: "ship it"},
+	}
+	if intent.Kind != KindComment || intent.Target.Repo != "gbarany/tea-dash" || intent.Prompt.Value != "ship it" {
+		t.Fatalf("intent did not retain values: %+v", intent)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -197,6 +197,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case actions.ResultMsg:
 		m.notice = ""
 		m.actionFeedback = m.actionFeedback.Set(feedbackFromActionResult(msg))
+		if msg.Status == actions.ResultSucceeded {
+			m.clearPreviewCacheForAction(msg.Intent.Target)
+			if s := m.getCurrSection(); s != nil &&
+				s.GetId() == msg.Intent.Target.SectionID &&
+				s.GetType() == msg.Intent.Target.SectionType {
+				if m.ctx.PreviewOpen {
+					m.syncSidebar()
+				}
+				return m, tea.Batch(s.FetchRows(), m.enrichCurrRow())
+			}
+		}
 		return m, nil
 
 	case enrichedMsg:
@@ -355,7 +366,7 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x close · q quit"))
+		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x/X close/reopen · v review · d diff · C checkout · q quit"))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
@@ -531,6 +542,21 @@ func (m *Model) clearSelectedPreviewCache() {
 			delete(m.issueDetails, key)
 			delete(m.issueEnrichErr, key)
 		}
+	}
+}
+
+func (m *Model) clearPreviewCacheForAction(target actions.Target) {
+	if target.Repo == "" || target.Number <= 0 {
+		return
+	}
+	key := fmt.Sprintf("%s#%d", target.Repo, target.Number)
+	switch target.RowKind {
+	case actions.RowKindPullRequest:
+		delete(m.pullDetails, key)
+		delete(m.pullEnrichErr, key)
+	case actions.RowKindIssue:
+		delete(m.issueDetails, key)
+		delete(m.issueEnrichErr, key)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/ui/components/actionfeedback"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionprompt"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
+	"github.com/gbarany/tea-dash/internal/ui/components/branchsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -42,6 +43,7 @@ type Model struct {
 	issues        []section.Section
 	notifications []section.Section
 	actions       []section.Section
+	branches      []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
 	actionDispatcher func(actions.Intent) tea.Cmd
@@ -114,6 +116,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 			view = context.NotificationsView
 		case "actions":
 			view = context.ActionsView
+		case "branches":
+			view = context.BranchesView
 		}
 	}
 	ctx := &context.ProgramContext{
@@ -169,6 +173,8 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 			sections[i] = notificationsection.NewModel(i, ctx, cfg)
 		case context.ActionsView:
 			sections[i] = actionsection.NewModel(i, ctx, cfg)
+		case context.BranchesView:
+			sections[i] = branchsection.NewModel(i, ctx, cfg)
 		default:
 			sections[i] = pullsection.NewModel(i, ctx, cfg)
 		}
@@ -398,6 +404,8 @@ func (m Model) View() tea.View {
 		subtitle = "  notifications"
 	case context.ActionsView:
 		subtitle = "  actions"
+	case context.BranchesView:
+		subtitle = "  local branches"
 	}
 	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
@@ -451,6 +459,8 @@ func (m *Model) currentViewSections() []section.Section {
 	switch m.ctx.View {
 	case context.ActionsView:
 		return m.actions
+	case context.BranchesView:
+		return m.branches
 	case context.NotificationsView:
 		return m.notifications
 	case context.IssuesView:
@@ -465,6 +475,8 @@ func (m *Model) setCurrentViewSections(s []section.Section) {
 	switch m.ctx.View {
 	case context.ActionsView:
 		m.actions = s
+	case context.BranchesView:
+		m.branches = s
 	case context.NotificationsView:
 		m.notifications = s
 	case context.IssuesView:
@@ -628,6 +640,9 @@ func (m *Model) syncSidebar() {
 			return
 		}
 		rendered = prview.RenderAction(r, m.actionDetails[key], w)
+	default:
+		m.sidebar.SetContent("")
+		return
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -682,8 +697,8 @@ func (m *Model) clearPreviewCacheForAction(target actions.Target) {
 	}
 }
 
-// switchView cycles pulls -> issues -> notifications -> actions, lazily building and
-// fetching the target view's sections on first visit.
+// switchView cycles pulls -> issues -> notifications -> actions -> branches, lazily
+// building and fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
 	switch m.ctx.View {
 	case context.PullsView:
@@ -692,6 +707,8 @@ func (m *Model) switchView() tea.Cmd {
 		m.ctx.View = context.NotificationsView
 	case context.NotificationsView:
 		m.ctx.View = context.ActionsView
+	case context.ActionsView:
+		m.ctx.View = context.BranchesView
 	default:
 		m.ctx.View = context.PullsView
 	}
@@ -1064,6 +1081,10 @@ func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {
 		if id >= 0 && id < len(m.actions) {
 			m.actions[id], cmd = m.actions[id].Update(msg)
 		}
+	case branchsection.SectionType:
+		if id >= 0 && id < len(m.branches) {
+			m.branches[id], cmd = m.branches[id].Update(msg)
+		}
 	}
 	return cmd
 }
@@ -1087,6 +1108,9 @@ func (m *Model) syncProgramContext() {
 		s.UpdateProgramContext(m.ctx)
 	}
 	for _, s := range m.actions {
+		s.UpdateProgramContext(m.ctx)
+	}
+	for _, s := range m.branches {
 		s.UpdateProgramContext(m.ctx)
 	}
 	m.tabs.UpdateProgramContext(m.ctx)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,9 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/actions"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionfeedback"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionprompt"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -36,6 +39,11 @@ type Model struct {
 	issues        []section.Section
 	notifications []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
+
+	actionDispatcher func(actions.Intent) tea.Cmd
+	actionPrompt     actionprompt.Model
+	pendingAction    actions.Intent
+	actionFeedback   actionfeedback.Model
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
 	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
@@ -107,6 +115,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		tabs:           tabs.New(ctx),
 		sidebar:        sidebar.New(ctx),
 		tasks:          tasks,
+		actionPrompt:   actionprompt.New(),
+		actionFeedback: actionfeedback.New(),
 		pullDetails:    map[string]*data.PullDetail{},
 		issueDetails:   map[string]*data.IssueDetail{},
 		pullEnrichErr:  map[string]error{},
@@ -116,6 +126,12 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
 	m.setCurrentViewSections(buildSections(view, ctx))
 	return m
+}
+
+// SetActionDispatcher wires the frontend action-intent seam. The dispatcher is
+// responsible for all backend or local-git side effects.
+func (m *Model) SetActionDispatcher(dispatcher func(actions.Intent) tea.Cmd) {
+	m.actionDispatcher = dispatcher
 }
 
 // buildSections constructs the section models for a view from its config list.
@@ -146,6 +162,9 @@ func (m Model) Init() tea.Cmd {
 
 // Update routes messages: layout, async results, keys, then generic fallthrough.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(tea.KeyPressMsg); ok && m.actionPrompt.Active() {
+		return m, m.updateActionPrompt(msg)
+	}
 	// While the current section's search bar is focused, route key presses
 	// straight to it so typing isn't eaten by nav/quit keys. Resize and async
 	// messages still flow through the normal switch below.
@@ -173,6 +192,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case openFailedMsg:
 		m.notice = fmt.Sprintf("Couldn't open browser: %v — copy: %s", msg.err, msg.url)
+		return m, nil
+
+	case actions.ResultMsg:
+		m.notice = ""
+		m.actionFeedback = m.actionFeedback.Set(feedbackFromActionResult(msg))
 		return m, nil
 
 	case enrichedMsg:
@@ -209,6 +233,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m.notice = "" // any key dismisses a transient notice
 		switch {
+		case key.Matches(msg, m.keys.Comment):
+			return m, m.startAction(actions.KindComment)
+		case key.Matches(msg, m.keys.Merge):
+			return m, m.startAction(actions.KindMerge)
+		case key.Matches(msg, m.keys.Close):
+			return m, m.startAction(actions.KindClose)
+		case key.Matches(msg, m.keys.Reopen):
+			return m, m.startAction(actions.KindReopen)
+		case key.Matches(msg, m.keys.Review):
+			return m, m.startAction(actions.KindReview)
+		case key.Matches(msg, m.keys.ExternalDiff):
+			return m, m.startAction(actions.KindExternalDiff)
+		case key.Matches(msg, m.keys.Checkout):
+			return m, m.startAction(actions.KindCheckout)
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.Refresh):
@@ -302,8 +340,12 @@ func (m Model) View() tea.View {
 		parts = append(parts, tv)
 	}
 	status := m.statusLine()
-	if m.notice != "" {
+	if m.actionPrompt.Active() {
+		status = m.actionPrompt.View(m.ctx.ScreenWidth - 4)
+	} else if m.notice != "" {
 		status = m.ctx.Styles.ErrorText.Render(m.notice)
+	} else if !m.actionFeedback.Empty() {
+		status = m.actionFeedback.View(m.ctx.ScreenWidth - 4)
 	}
 	body := ""
 	if s := m.getCurrSection(); s != nil {
@@ -313,7 +355,7 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · e expand · r refresh · o open · q quit"))
+		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x close · q quit"))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
@@ -549,6 +591,177 @@ func (m Model) openSelected() tea.Cmd {
 			return openFailedMsg{url: url, err: err}
 		}
 		return nil
+	}
+}
+
+func (m *Model) startAction(kind actions.Kind) tea.Cmd {
+	target, ok := m.selectedActionTarget()
+	if !ok {
+		m.notice = "Select a row before running an action."
+		return nil
+	}
+	if actionRequiresPullRequest(kind) && target.RowKind != actions.RowKindPullRequest {
+		m.notice = fmt.Sprintf("%s is only available for pull requests.", actionLabel(kind))
+		return nil
+	}
+	intent := actions.Intent{
+		Kind:   kind,
+		Target: target,
+		Prompt: actions.Prompt{Mode: promptModeForAction(kind)},
+	}
+	m.pendingAction = intent
+	m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(kind, target))
+	return nil
+}
+
+func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
+	var result actionprompt.Result
+	var cmd tea.Cmd
+	m.actionPrompt, result, cmd = m.actionPrompt.Update(msg)
+	if result.Canceled {
+		m.pendingAction = actions.Intent{}
+		m.actionFeedback = m.actionFeedback.Set(actionfeedback.Cancel("Action cancelled."))
+		return cmd
+	}
+	if !result.Submitted {
+		return cmd
+	}
+	intent := m.pendingAction
+	intent.Prompt.Value = result.Value
+	intent.Prompt.Label = result.Label
+	m.pendingAction = actions.Intent{}
+	if m.actionDispatcher == nil {
+		m.notice = "Action not wired yet."
+		return cmd
+	}
+	m.actionFeedback = m.actionFeedback.Set(actionfeedback.Start(actionStartText(intent)))
+	dispatchCmd := m.actionDispatcher(intent)
+	if cmd == nil {
+		return dispatchCmd
+	}
+	if dispatchCmd == nil {
+		return cmd
+	}
+	return tea.Batch(cmd, dispatchCmd)
+}
+
+func (m Model) selectedActionTarget() (actions.Target, bool) {
+	s := m.getCurrSection()
+	row := m.getCurrRowData()
+	if s == nil || row == nil {
+		return actions.Target{}, false
+	}
+	rowKind := actions.RowKind(s.GetType())
+	switch row.(type) {
+	case data.PullRequest:
+		rowKind = actions.RowKindPullRequest
+	case data.Issue:
+		rowKind = actions.RowKindIssue
+	}
+	return actions.Target{
+		SectionID:   s.GetId(),
+		SectionType: s.GetType(),
+		RowKind:     rowKind,
+		Repo:        row.GetRepoNameWithOwner(),
+		Number:      row.GetNumber(),
+		Title:       row.GetTitle(),
+		URL:         row.GetURL(),
+	}, true
+}
+
+func actionRequiresPullRequest(kind actions.Kind) bool {
+	switch kind {
+	case actions.KindMerge, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
+		return true
+	default:
+		return false
+	}
+}
+
+func promptModeForAction(kind actions.Kind) actions.PromptMode {
+	switch kind {
+	case actions.KindComment:
+		return actions.PromptText
+	case actions.KindReview:
+		return actions.PromptPicker
+	default:
+		return actions.PromptConfirm
+	}
+}
+
+func promptConfigForAction(kind actions.Kind, target actions.Target) actionprompt.Config {
+	title := fmt.Sprintf("%s #%d", actionLabel(kind), target.Number)
+	message := fmt.Sprintf("%s - %s", target.Repo, target.Title)
+	switch kind {
+	case actions.KindComment:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Write a comment",
+		}
+	case actions.KindReview:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModePicker,
+			Title:   title,
+			Message: message,
+			Options: []actionprompt.Option{
+				{Label: "Comment", Value: "comment"},
+				{Label: "Approve", Value: "approve"},
+				{Label: "Request changes", Value: "request_changes"},
+			},
+		}
+	default:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModeConfirm,
+			Title:   title,
+			Message: message,
+		}
+	}
+}
+
+func actionLabel(kind actions.Kind) string {
+	switch kind {
+	case actions.KindComment:
+		return "Comment"
+	case actions.KindMerge:
+		return "Merge"
+	case actions.KindClose:
+		return "Close"
+	case actions.KindReopen:
+		return "Reopen"
+	case actions.KindReview:
+		return "Review"
+	case actions.KindExternalDiff:
+		return "External diff"
+	case actions.KindCheckout:
+		return "Checkout"
+	default:
+		return string(kind)
+	}
+}
+
+func actionStartText(intent actions.Intent) string {
+	return fmt.Sprintf("Starting %s for %s#%d.", actionLabel(intent.Kind), intent.Target.Repo, intent.Target.Number)
+}
+
+func feedbackFromActionResult(msg actions.ResultMsg) actionfeedback.Message {
+	text := msg.Message
+	if text == "" && msg.Err != nil {
+		text = msg.Err.Error()
+	}
+	if text == "" {
+		text = actionStartText(msg.Intent)
+	}
+	switch msg.Status {
+	case actions.ResultSucceeded:
+		return actionfeedback.Success(text)
+	case actions.ResultErrored:
+		return actionfeedback.Error(text)
+	case actions.ResultCanceled:
+		return actionfeedback.Cancel(text)
+	default:
+		return actionfeedback.Start(text)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -51,18 +51,18 @@ type Model struct {
 	copyToClipboard  func(string) error
 	showHelp         bool
 
-	// pullDetails and issueDetails memoize fetched detail views keyed by
-	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
-	// syncSidebar reads the right one without any runtime type assertion.
-	pullDetails  map[string]*data.PullDetail
-	issueDetails map[string]*data.IssueDetail
-	// pullEnrichErr and issueEnrichErr record the last failed detail fetch per
-	// key so the preview can show an error block (instead of a perpetual
-	// "Loading…") while keeping the row retryable. They are kept separate, just
-	// like the detail maps, because PRs and issues in the same repo can share a
-	// number ("owner/repo#num").
-	pullEnrichErr  map[string]error
-	issueEnrichErr map[string]error
+	// Detail maps memoize fetched preview detail keyed by "owner/repo#num".
+	// syncSidebar reads the map matching the selected row kind.
+	pullDetails   map[string]*data.PullDetail
+	issueDetails  map[string]*data.IssueDetail
+	actionDetails map[string]*data.ActionRunDetail
+	// Enrich error maps record the last failed detail fetch per key so the
+	// preview can show an error block while keeping the row retryable. They are
+	// kept separate, just like the detail maps, because row kinds can share a
+	// number in the same repo ("owner/repo#num").
+	pullEnrichErr   map[string]error
+	issueEnrichErr  map[string]error
+	actionEnrichErr map[string]error
 	// expanded controls whether the preview shows the full body or the folded
 	// (read-more) form. Reset to false each time the preview is (re)opened.
 	expanded bool
@@ -88,6 +88,7 @@ type enrichedMsg struct {
 	sectionType string
 	pull        *data.PullDetail
 	issue       *data.IssueDetail
+	action      *data.ActionRunDetail
 	err         error
 }
 
@@ -141,6 +142,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		issueDetails:    map[string]*data.IssueDetail{},
 		pullEnrichErr:   map[string]error{},
 		issueEnrichErr:  map[string]error{},
+		actionDetails:   map[string]*data.ActionRunDetail{},
+		actionEnrichErr: map[string]error{},
 	}
 	// Build only the starting view's sections; the other slice stays nil until
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
@@ -254,6 +257,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.issue != nil {
 				delete(m.issueEnrichErr, msg.key)
 				m.issueDetails[msg.key] = msg.issue
+			}
+			if msg.action != nil {
+				delete(m.actionEnrichErr, msg.key)
+				m.actionDetails[msg.key] = msg.action
 			}
 		}
 		m.syncSidebar()
@@ -511,7 +518,9 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 	if key == "" {
 		return nil
 	}
+	sectionType := ""
 	if s := m.getCurrSection(); s != nil {
+		sectionType = s.GetType()
 		switch s.GetType() {
 		case pullsection.SectionType:
 			if _, ok := m.pullDetails[key]; ok {
@@ -519,6 +528,10 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 			}
 		case issuesection.SectionType:
 			if _, ok := m.issueDetails[key]; ok {
+				return nil
+			}
+		case actionsection.SectionType:
+			if _, ok := m.actionDetails[key]; ok {
 				return nil
 			}
 		default:
@@ -534,30 +547,57 @@ func (m *Model) enrichCurrRow() tea.Cmd {
 	if client == nil {
 		return nil
 	}
-	index := row.GetNumber()
-	isPR := false
-	if s := m.getCurrSection(); s != nil {
-		isPR = s.GetType() == pullsection.SectionType
-	}
-	return func() tea.Msg {
-		if isPR {
+	switch sectionType {
+	case pullsection.SectionType:
+		index := row.GetNumber()
+		return func() tea.Msg {
 			d, err := client.GetPullDetail(owner, name, index)
 			if err != nil {
 				return enrichedMsg{key: key, sectionType: pullsection.SectionType, err: err}
 			}
 			return enrichedMsg{key: key, sectionType: pullsection.SectionType, pull: &d}
 		}
-		d, err := client.GetIssueDetail(owner, name, index)
-		if err != nil {
-			return enrichedMsg{key: key, sectionType: issuesection.SectionType, err: err}
+	case issuesection.SectionType:
+		index := row.GetNumber()
+		return func() tea.Msg {
+			d, err := client.GetIssueDetail(owner, name, index)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: issuesection.SectionType, err: err}
+			}
+			return enrichedMsg{key: key, sectionType: issuesection.SectionType, issue: &d}
 		}
-		return enrichedMsg{key: key, sectionType: issuesection.SectionType, issue: &d}
+	case actionsection.SectionType:
+		run, ok := row.(data.ActionRun)
+		if !ok {
+			return nil
+		}
+		runID := run.ID
+		if runID == 0 {
+			runID = run.GetNumber()
+		}
+		return func() tea.Msg {
+			d, err := client.GetActionRun(stdctx.Background(), owner, name, runID)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: actionsection.SectionType, err: err}
+			}
+			jobs, err := client.ListActionJobs(stdctx.Background(), owner, name, runID)
+			if err != nil {
+				return enrichedMsg{key: key, sectionType: actionsection.SectionType, err: err}
+			}
+			return enrichedMsg{
+				key:         key,
+				sectionType: actionsection.SectionType,
+				action:      &data.ActionRunDetail{Run: d, Jobs: jobs},
+			}
+		}
+	default:
+		return nil
 	}
 }
 
 // syncSidebar renders the current row (with its cached detail, if any) into the
-// preview pane. The concrete row type selects the pull vs issue renderer; a
-// missing/other-typed cache entry renders as the "loading" placeholder.
+// preview pane. The concrete row type selects the renderer; a missing cache
+// entry renders that row kind's loading placeholder.
 func (m *Model) syncSidebar() {
 	row := m.getCurrRowData()
 	if row == nil {
@@ -583,7 +623,11 @@ func (m *Model) syncSidebar() {
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
 	case data.ActionRun:
-		rendered = prview.RenderAction(r, w)
+		if err := m.actionEnrichErr[key]; err != nil {
+			m.sidebar.SetContent(m.failedPreview(row, err))
+			return
+		}
+		rendered = prview.RenderAction(r, m.actionDetails[key], w)
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -594,6 +638,8 @@ func (m *Model) setEnrichErr(sectionType, key string, err error) {
 		m.pullEnrichErr[key] = err
 	case issuesection.SectionType:
 		m.issueEnrichErr[key] = err
+	case actionsection.SectionType:
+		m.actionEnrichErr[key] = err
 	default:
 		if s := m.getCurrSection(); s != nil {
 			m.setEnrichErr(s.GetType(), key, err)
@@ -614,6 +660,9 @@ func (m *Model) clearSelectedPreviewCache() {
 		case issuesection.SectionType:
 			delete(m.issueDetails, key)
 			delete(m.issueEnrichErr, key)
+		case actionsection.SectionType:
+			delete(m.actionDetails, key)
+			delete(m.actionEnrichErr, key)
 		}
 	}
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,7 +2,9 @@
 package ui
 
 import (
+	stdctx "context"
 	"fmt"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -85,6 +87,12 @@ type enrichedMsg struct {
 	pull        *data.PullDetail
 	issue       *data.IssueDetail
 	err         error
+}
+
+type notificationActionMsg struct {
+	sectionID int
+	all       bool
+	err       error
 }
 
 // New builds the root model. client may be nil in tests (only FetchRows uses it).
@@ -245,6 +253,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncSidebar()
 		return m, nil
 
+	case notificationActionMsg:
+		return m.handleNotificationAction(msg)
+
 	case spinner.TickMsg:
 		// A tick belongs to whichever section started the spinner, but sibling
 		// sections in the current view share one animation; route it to every one
@@ -260,6 +271,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m.notice = "" // any key dismisses a transient notice
 		switch {
+		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
+			return m.markSelectedNotificationRead()
+		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
+			return m.markAllNotificationsRead()
 		case key.Matches(msg, m.keys.Comment):
 			return m, m.startAction(actions.KindComment)
 		case key.Matches(msg, m.keys.Merge):
@@ -399,9 +414,21 @@ func (m Model) View() tea.View {
 
 func (m Model) helpLine() string {
 	if m.showHelp {
-		return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout · q quit"
+		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
+		if m.ctx.View == context.NotificationsView {
+			text += " · m mark read · M mark all read"
+		} else {
+			text += " · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+		}
+		return text + " · q quit"
 	}
-	return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh · c comment · m merge · d/ctrl+t diff · C/space checkout · ? help · q quit"
+	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
+	if m.ctx.View == context.NotificationsView {
+		text += " · m/M read"
+	} else {
+		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
+	}
+	return text + " · ? help · q quit"
 }
 
 // currentViewSections returns the section slice for the active view.
@@ -879,6 +906,78 @@ func feedbackFromActionResult(msg actions.ResultMsg) actionfeedback.Message {
 	default:
 		return actionfeedback.Start(text)
 	}
+}
+
+func (m Model) markSelectedNotificationRead() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.Notification)
+	if !ok {
+		m.notice = "Select a notification to mark read."
+		return m, nil
+	}
+	if row.ID == 0 {
+		m.notice = "Selected notification has no thread id."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to mark notifications read."
+		return m, nil
+	}
+	return m, markNotificationReadCmd(m.ctx.Client, m.currSectionId, row.ID)
+}
+
+func (m Model) markAllNotificationsRead() (Model, tea.Cmd) {
+	if m.ctx.View != context.NotificationsView {
+		m.notice = "Switch to notifications to mark all read."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to mark notifications read."
+		return m, nil
+	}
+	return m, markAllNotificationsReadCmd(m.ctx.Client, m.currSectionId)
+}
+
+func markNotificationReadCmd(client *gitea.Client, sectionID int, threadID int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			err:       client.MarkNotificationRead(ctx, threadID),
+		}
+	}
+}
+
+func markAllNotificationsReadCmd(client *gitea.Client, sectionID int) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			all:       true,
+			err:       client.MarkAllNotificationsRead(ctx),
+		}
+	}
+}
+
+func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.Cmd) {
+	if msg.err != nil {
+		if msg.all {
+			m.notice = fmt.Sprintf("Couldn't mark all notifications read: %v", msg.err)
+		} else {
+			m.notice = fmt.Sprintf("Couldn't mark notification read: %v", msg.err)
+		}
+		return m, nil
+	}
+	if msg.all {
+		m.notice = "Marked all notifications read."
+	} else {
+		m.notice = "Marked notification read."
+	}
+	if msg.sectionID < 0 || msg.sectionID >= len(m.notifications) {
+		return m, nil
+	}
+	return m, m.notifications[msg.sectionID].FetchRows()
 }
 
 func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -708,7 +708,7 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 	switch kind {
 	case actions.KindComment:
 		return actions.PromptText
-	case actions.KindReview:
+	case actions.KindMerge, actions.KindReview:
 		return actions.PromptPicker
 	default:
 		return actions.PromptConfirm
@@ -735,6 +735,19 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 				{Label: "Comment", Value: "comment"},
 				{Label: "Approve", Value: "approve"},
 				{Label: "Request changes", Value: "request_changes"},
+			},
+		}
+	case actions.KindMerge:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModePicker,
+			Title:   title,
+			Message: message,
+			Options: []actionprompt.Option{
+				{Label: "Merge", Value: string(data.MergeStyleMerge)},
+				{Label: "Squash", Value: string(data.MergeStyleSquash)},
+				{Label: "Rebase", Value: string(data.MergeStyleRebase)},
+				{Label: "Rebase merge", Value: string(data.MergeStyleRebaseMerge)},
+				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
 			},
 		}
 	default:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -44,6 +44,8 @@ type Model struct {
 	actionPrompt     actionprompt.Model
 	pendingAction    actions.Intent
 	actionFeedback   actionfeedback.Model
+	copyToClipboard  func(string) error
+	showHelp         bool
 
 	// pullDetails and issueDetails memoize fetched detail views keyed by
 	// "owner/repo#num". The map is chosen by the row's kind (PR vs issue), so
@@ -67,6 +69,11 @@ type Model struct {
 type openFailedMsg struct {
 	url string
 	err error
+}
+
+type copyResultMsg struct {
+	value string
+	err   error
 }
 
 // enrichedMsg carries the result of a lazy detail fetch back to the root, keyed
@@ -110,17 +117,18 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 	}
 
 	m := Model{
-		ctx:            ctx,
-		keys:           defaultKeyMap(),
-		tabs:           tabs.New(ctx),
-		sidebar:        sidebar.New(ctx),
-		tasks:          tasks,
-		actionPrompt:   actionprompt.New(),
-		actionFeedback: actionfeedback.New(),
-		pullDetails:    map[string]*data.PullDetail{},
-		issueDetails:   map[string]*data.IssueDetail{},
-		pullEnrichErr:  map[string]error{},
-		issueEnrichErr: map[string]error{},
+		ctx:             ctx,
+		keys:            defaultKeyMap(),
+		tabs:            tabs.New(ctx),
+		sidebar:         sidebar.New(ctx),
+		tasks:           tasks,
+		actionPrompt:    actionprompt.New(),
+		actionFeedback:  actionfeedback.New(),
+		copyToClipboard: writeClipboard,
+		pullDetails:     map[string]*data.PullDetail{},
+		issueDetails:    map[string]*data.IssueDetail{},
+		pullEnrichErr:   map[string]error{},
+		issueEnrichErr:  map[string]error{},
 	}
 	// Build only the starting view's sections; the other slice stays nil until
 	// the first switch (lazy build). setCurrentViewSections wires the tab bar.
@@ -192,6 +200,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case openFailedMsg:
 		m.notice = fmt.Sprintf("Couldn't open browser: %v — copy: %s", msg.err, msg.url)
+		return m, nil
+
+	case copyResultMsg:
+		if msg.err != nil {
+			m.notice = fmt.Sprintf("Couldn't copy: %v", msg.err)
+		} else {
+			m.notice = fmt.Sprintf("Copied %s.", msg.value)
+		}
 		return m, nil
 
 	case actions.ResultMsg:
@@ -269,8 +285,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, s.FetchRows()
 			}
 			return m, nil
+		case key.Matches(msg, m.keys.RefreshAll):
+			return m, m.refreshAllSections()
 		case key.Matches(msg, m.keys.Open):
 			return m, m.openSelected()
+		case key.Matches(msg, m.keys.CopyNumber):
+			return m, m.copySelectedNumber()
+		case key.Matches(msg, m.keys.CopyURL):
+			return m, m.copySelectedURL()
+		case key.Matches(msg, m.keys.Help):
+			m.showHelp = !m.showHelp
+			return m, nil
 		case key.Matches(msg, m.keys.NextSection):
 			if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 				m.currSectionId++
@@ -366,10 +391,17 @@ func (m Model) View() tea.View {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
 	parts = append(parts, body, status,
-		helpStyle.Render("↑/↓ move · h/l section · s view · / search · p preview · c comment · m merge · x/X close/reopen · v review · d diff · C checkout · q quit"))
+		helpStyle.Render(m.helpLine()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true}
+}
+
+func (m Model) helpLine() string {
+	if m.showHelp {
+		return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout · q quit"
+	}
+	return "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh · c comment · m merge · d/ctrl+t diff · C/space checkout · ? help · q quit"
 }
 
 // currentViewSections returns the section slice for the active view.
@@ -618,6 +650,51 @@ func (m Model) openSelected() tea.Cmd {
 		}
 		return nil
 	}
+}
+
+func (m Model) copySelectedNumber() tea.Cmd {
+	row := m.getCurrRowData()
+	if row == nil {
+		return nil
+	}
+	return m.copyValue(fmt.Sprintf("%d", row.GetNumber()))
+}
+
+func (m Model) copySelectedURL() tea.Cmd {
+	row := m.getCurrRowData()
+	if row == nil || row.GetURL() == "" {
+		return nil
+	}
+	return m.copyValue(row.GetURL())
+}
+
+func (m Model) copyValue(value string) tea.Cmd {
+	copyFn := m.copyToClipboard
+	if copyFn == nil {
+		copyFn = writeClipboard
+	}
+	return func() tea.Msg {
+		return copyResultMsg{value: value, err: copyFn(value)}
+	}
+}
+
+func (m *Model) refreshAllSections() tea.Cmd {
+	var cmds []tea.Cmd
+	switch m.ctx.View {
+	case context.IssuesView:
+		m.issueDetails = map[string]*data.IssueDetail{}
+		m.issueEnrichErr = map[string]error{}
+	default:
+		m.pullDetails = map[string]*data.PullDetail{}
+		m.pullEnrichErr = map[string]error{}
+	}
+	for _, s := range m.currentViewSections() {
+		cmds = append(cmds, s.FetchRows())
+	}
+	if m.ctx.PreviewOpen {
+		m.syncSidebar()
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) startAction(kind actions.Kind) tea.Cmd {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionfeedback"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionprompt"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/prview"
@@ -40,6 +41,7 @@ type Model struct {
 	prs           []section.Section
 	issues        []section.Section
 	notifications []section.Section
+	actions       []section.Section
 	notice        string // transient status message (e.g. browser-open failure)
 
 	actionDispatcher func(actions.Intent) tea.Cmd
@@ -109,6 +111,8 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 			view = context.IssuesView
 		case "notifications":
 			view = context.NotificationsView
+		case "actions":
+			view = context.ActionsView
 		}
 	}
 	ctx := &context.ProgramContext{
@@ -160,6 +164,8 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 			sections[i] = issuesection.NewModel(i, ctx, cfg)
 		case context.NotificationsView:
 			sections[i] = notificationsection.NewModel(i, ctx, cfg)
+		case context.ActionsView:
+			sections[i] = actionsection.NewModel(i, ctx, cfg)
 		default:
 			sections[i] = pullsection.NewModel(i, ctx, cfg)
 		}
@@ -383,6 +389,8 @@ func (m Model) View() tea.View {
 		subtitle = "  my issues"
 	case context.NotificationsView:
 		subtitle = "  notifications"
+	case context.ActionsView:
+		subtitle = "  actions"
 	}
 	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
@@ -434,6 +442,8 @@ func (m Model) helpLine() string {
 // currentViewSections returns the section slice for the active view.
 func (m *Model) currentViewSections() []section.Section {
 	switch m.ctx.View {
+	case context.ActionsView:
+		return m.actions
 	case context.NotificationsView:
 		return m.notifications
 	case context.IssuesView:
@@ -446,6 +456,8 @@ func (m *Model) currentViewSections() []section.Section {
 // setCurrentViewSections stores s under the active view and rewires the tab bar.
 func (m *Model) setCurrentViewSections(s []section.Section) {
 	switch m.ctx.View {
+	case context.ActionsView:
+		m.actions = s
 	case context.NotificationsView:
 		m.notifications = s
 	case context.IssuesView:
@@ -570,6 +582,8 @@ func (m *Model) syncSidebar() {
 		rendered = prview.RenderIssue(r, m.issueDetails[key], w, m.expanded)
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
+	case data.ActionRun:
+		rendered = prview.RenderAction(r, w)
 	}
 	m.sidebar.SetContent(rendered)
 }
@@ -619,7 +633,7 @@ func (m *Model) clearPreviewCacheForAction(target actions.Target) {
 	}
 }
 
-// switchView cycles pulls -> issues -> notifications, lazily building and
+// switchView cycles pulls -> issues -> notifications -> actions, lazily building and
 // fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
 	switch m.ctx.View {
@@ -627,6 +641,8 @@ func (m *Model) switchView() tea.Cmd {
 		m.ctx.View = context.IssuesView
 	case context.IssuesView:
 		m.ctx.View = context.NotificationsView
+	case context.NotificationsView:
+		m.ctx.View = context.ActionsView
 	default:
 		m.ctx.View = context.PullsView
 	}
@@ -995,6 +1011,10 @@ func (m *Model) updateSection(id int, sType string, msg tea.Msg) tea.Cmd {
 		if id >= 0 && id < len(m.notifications) {
 			m.notifications[id], cmd = m.notifications[id].Update(msg)
 		}
+	case actionsection.SectionType:
+		if id >= 0 && id < len(m.actions) {
+			m.actions[id], cmd = m.actions[id].Update(msg)
+		}
 	}
 	return cmd
 }
@@ -1015,6 +1035,9 @@ func (m *Model) syncProgramContext() {
 		s.UpdateProgramContext(m.ctx)
 	}
 	for _, s := range m.notifications {
+		s.UpdateProgramContext(m.ctx)
+	}
+	for _, s := range m.actions {
 		s.UpdateProgramContext(m.ctx)
 	}
 	m.tabs.UpdateProgramContext(m.ctx)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -862,6 +862,43 @@ func TestNilActionDispatcherShowsNoticeOnSubmit(t *testing.T) {
 	}
 }
 
+func TestSuccessfulActionRefreshesRowsAndClearsPreviewCache(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+	key := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:  key,
+		pull: &data.PullDetail{Body: "staledetailtoken", BaseRef: "main", HeadRef: "feature"},
+	})
+	if _, ok := m.pullDetails[key]; !ok {
+		t.Fatalf("test setup: expected cached pull detail for %q", key)
+	}
+
+	next, cmd := m.Update(actions.ResultMsg{
+		Intent: actions.Intent{Kind: actions.KindClose, Target: actions.Target{
+			SectionID: 0, SectionType: pullsection.SectionType, RowKind: actions.RowKindPullRequest,
+			Repo: "gbarany/tea-dash", Number: 42,
+		}},
+		Status:  actions.ResultSucceeded,
+		Message: "Closed gbarany/tea-dash#42.",
+	})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("successful action should refresh the affected section")
+	}
+	if _, ok := m.pullDetails[key]; ok {
+		t.Fatalf("successful action should clear cached pull detail for %q", key)
+	}
+	view := m.View().Content
+	if strings.Contains(view, "staledetailtoken") || !strings.Contains(view, "Loading") {
+		t.Fatalf("successful action should replace stale preview with loading state:\n%s", view)
+	}
+}
+
 // isQuitCmd reports whether running cmd yields a tea.QuitMsg.
 func isQuitCmd(cmd tea.Cmd) bool {
 	if cmd == nil {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -661,6 +661,87 @@ func TestActionsPreviewRendersStaticSummary(t *testing.T) {
 	}
 }
 
+func TestActionsPreviewFetchesAndCachesRunDetail(t *testing.T) {
+	var runCalls, jobCalls int
+	srv := actionDetailServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/actions/runs/101", func(w http.ResponseWriter, _ *http.Request) {
+			runCalls++
+			fmt.Fprint(w, `{
+				"id": 101,
+				"run_number": 77,
+				"display_title": "CI passed",
+				"name": "CI",
+				"status": "completed",
+				"conclusion": "success",
+				"head_branch": "main",
+				"head_sha": "abc123"
+			}`)
+		})
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/actions/runs/101/jobs", func(w http.ResponseWriter, _ *http.Request) {
+			jobCalls++
+			fmt.Fprint(w, `{
+				"jobs": [{
+					"id": 201,
+					"run_id": 101,
+					"name": "build",
+					"status": "completed",
+					"conclusion": "success",
+					"runner_name": "ubuntu-latest",
+					"steps": [{
+						"number": 1,
+						"name": "checkout",
+						"status": "completed",
+						"conclusion": "success"
+					}]
+				}]
+			}`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	next, cmd := m.Update(actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Status: "completed", Conclusion: "success",
+	}}))
+	m = next.(Model)
+	msg := runEnrichedCommand(t, cmd)
+	if msg.err != nil {
+		t.Fatalf("action detail fetch returned error: %v", msg.err)
+	}
+	if msg.sectionType != actionsection.SectionType || msg.action == nil {
+		t.Fatalf("enrichedMsg = %+v, want action detail for action section", msg)
+	}
+
+	m = update(t, m, msg)
+	key := m.selKey()
+	if _, ok := m.actionDetails[key]; !ok {
+		t.Fatalf("actionDetails should contain %q after enrichedMsg", key)
+	}
+	view := m.View().Content
+	for _, want := range []string{"Jobs:", "build", "ubuntu-latest", "checkout"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("action detail preview missing %q:\n%s", want, view)
+		}
+	}
+	if runCalls != 1 || jobCalls != 1 {
+		t.Fatalf("detail endpoints called run=%d jobs=%d, want once each", runCalls, jobCalls)
+	}
+	if cmd := m.enrichCurrRow(); cmd != nil {
+		t.Fatal("cached action detail should suppress another lazy fetch")
+	}
+}
+
 // TestPreviewStartsOpenAndToggles verifies the preview pane is visible by
 // default: the initial window size gives it dimensions and the composed View()
 // renders the sidebar region. 'p' still toggles it closed and open again.
@@ -1246,6 +1327,46 @@ func isQuitCmd(cmd tea.Cmd) bool {
 	}
 	_, ok := cmd().(tea.QuitMsg)
 	return ok
+}
+
+func runEnrichedCommand(t *testing.T, cmd tea.Cmd) enrichedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected an enrichment command, got nil")
+	}
+	msg := cmd()
+	if enriched, ok := msg.(enrichedMsg); ok {
+		return enriched
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("enrichment command returned %T, want enrichedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		if nested == nil {
+			continue
+		}
+		if enriched, ok := nested().(enrichedMsg); ok {
+			return enriched
+		}
+	}
+	t.Fatal("enrichment batch did not contain an enrichedMsg")
+	return enrichedMsg{}
+}
+
+func actionDetailServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 var errBoom = errBoomType("boom")

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -773,7 +773,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
 		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
+		{name: "external diff ctrl-t alias", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, kind: actions.KindExternalDiff},
 		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
+		{name: "checkout space alias", key: tea.KeyPressMsg{Code: ' ', Text: " "}, kind: actions.KindCheckout},
 	}
 
 	for _, tt := range tests {
@@ -825,6 +827,124 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
 			}
 		})
+	}
+}
+
+func TestHelpKeyTogglesFullHelp(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("full help should be hidden before '?' is pressed")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	view := m.View().Content
+	for _, want := range []string{"R refresh all", "y copy number", "Y copy URL", "C/space checkout"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("full help missing %q:\n%s", want, view)
+		}
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	if strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("second '?' should hide full help")
+	}
+}
+
+func TestRefreshAllFetchesEveryCurrentSection(t *testing.T) {
+	cfg := &config.Config{
+		PRSections: []config.SectionConfig{
+			{Title: "Mine", Filter: config.PrIssueFilter{CreatedBy: "@me"}},
+			{Title: "Review", Filter: config.PrIssueFilter{ReviewRequested: "@me"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p0",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: []data.PullRequest{{
+				Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open",
+			}},
+			TotalCount: 1, TaskId: "p0",
+		},
+	})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 1, SectionType: pullsection.SectionType, TaskId: "p1",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: []data.PullRequest{{
+				Number: 2, Title: "Second row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open",
+			}},
+			TotalCount: 1, TaskId: "p1",
+		},
+	})
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("'R' should batch refresh commands for all current sections")
+	}
+	if len(m.tasks) != 2 {
+		t.Fatalf("len(tasks) = %d, want both sections to register refresh tasks", len(m.tasks))
+	}
+}
+
+func TestCopyHotkeysUseSelectedRow(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		want string
+	}{
+		{name: "copy number", key: tea.KeyPressMsg{Code: 'y', Text: "y"}, want: "42"},
+		{name: "copy url", key: tea.KeyPressMsg{Code: 'Y', Text: "Y"}, want: "https://example.test/gbarany/tea-dash/pulls/42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var copied string
+			m := New(&config.Config{}, nil)
+			m.copyToClipboard = func(s string) error {
+				copied = s
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedMsg([]data.PullRequest{{
+				Number: 42, Title: "Copy row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+			}}))
+
+			next, cmd := m.Update(tt.key)
+			m = next.(Model)
+			if cmd == nil {
+				t.Fatalf("%s should return a clipboard command", tt.name)
+			}
+			m = update(t, m, cmd())
+			if copied != tt.want {
+				t.Fatalf("copied = %q, want %q", copied, tt.want)
+			}
+			if !strings.Contains(m.View().Content, "Copied") {
+				t.Fatalf("copy result should be visible in the status area:\n%s", m.View().Content)
+			}
+		})
+	}
+}
+
+func TestGHDashFirstLastHotkeysMoveSelection(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("'G' selected #%d, want #2", got)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'g', Text: "g"})
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("'g' selected #%d, want #1", got)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -751,12 +751,24 @@ func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
 
 func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 	tests := []struct {
-		name string
-		key  tea.KeyPressMsg
-		kind actions.Kind
+		name        string
+		key         tea.KeyPressMsg
+		kind        actions.Kind
+		beforeEnter []tea.KeyPressMsg
+		wantPrompt  actions.Prompt
 	}{
 		{name: "comment", key: tea.KeyPressMsg{Code: 'c', Text: "c"}, kind: actions.KindComment},
-		{name: "merge", key: tea.KeyPressMsg{Code: 'm', Text: "m"}, kind: actions.KindMerge},
+		{
+			name:        "merge",
+			key:         tea.KeyPressMsg{Code: 'm', Text: "m"},
+			kind:        actions.KindMerge,
+			beforeEnter: []tea.KeyPressMsg{{Code: 'j', Text: "j"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptPicker,
+				Value: "squash",
+				Label: "Squash",
+			},
+		},
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
@@ -786,6 +798,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				m = update(t, m, tea.KeyPressMsg{Code: 'o', Text: "o"})
 				m = update(t, m, tea.KeyPressMsg{Code: 'k', Text: "k"})
 			}
+			for _, key := range tt.beforeEnter {
+				m = update(t, m, key)
+			}
 			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
 
 			if len(got) != 1 {
@@ -805,6 +820,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 			}
 			if tt.kind == actions.KindComment && got[0].Prompt.Value != "ok" {
 				t.Fatalf("comment prompt value = %q, want ok", got[0].Prompt.Value)
+			}
+			if tt.wantPrompt != (actions.Prompt{}) && got[0].Prompt != tt.wantPrompt {
+				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
 			}
 		})
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/data"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/actions"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -57,6 +58,17 @@ func fetchedIssuesMsg(issues []data.Issue) context.TaskFinishedMsg {
 		TaskId:      "i1",
 		Msg: issuesection.SectionIssuesFetchedMsg{
 			Rows: issues, TotalCount: len(issues), TaskId: "i1",
+		},
+	}
+}
+
+func actionFetchedMsg(rows []data.ActionRun) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: actionsection.SectionType,
+		TaskId:      "a1",
+		Msg: actionsection.SectionActionsFetchedMsg{
+			Rows: rows, TotalCount: len(rows), TaskId: "a1",
 		},
 	}
 }
@@ -196,6 +208,28 @@ func TestSwitchViewCyclesToNotifications(t *testing.T) {
 	}
 }
 
+func TestSwitchViewCyclesToActionsAndBackToPulls(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // issues
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = next.(Model)
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("View = %v, want ActionsView", m.ctx.View)
+	}
+	if len(m.actions) == 0 {
+		t.Fatal("expected action sections to be built lazily on switch")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch command after switching to the actions view")
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("View = %v, want PullsView after actions", m.ctx.View)
+	}
+}
+
 func TestSectionSwitchWithTwoSections(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{
@@ -313,6 +347,26 @@ func TestDefaultsViewStartsNotifications(t *testing.T) {
 	}
 }
 
+func TestDefaultsViewStartsActions(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("View = %v, want ActionsView", m.ctx.View)
+	}
+	if len(m.actions) == 0 {
+		t.Fatal("defaults.view=actions should build the action sections at startup")
+	}
+	if len(m.prs) != 0 || len(m.issues) != 0 || len(m.notifications) != 0 {
+		t.Fatalf("prs=%d issues=%d notifications=%d, want inactive views lazy",
+			len(m.prs), len(m.issues), len(m.notifications))
+	}
+}
+
 // TestCrossViewFetchRoutesToOwnSlice verifies a late PR fetch that lands while
 // the Issues view is active is still routed to the pulls slice by (id, type),
 // not to whatever section is currently on screen.
@@ -336,6 +390,7 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 	})
 	// Switch through Notifications back to the pulls view; the fetch must have
 	// landed in m.prs rather than whatever view is on screen.
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	if m.ctx.View != context.PullsView {
@@ -558,6 +613,54 @@ func TestMarkAllNotificationsReadRefreshesNotifications(t *testing.T) {
 	}
 }
 
+func TestModelRendersLoadedActions(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"}) // close preview for table assertions
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Actor: "octo", Event: "push",
+		Status: "completed", Conclusion: "success", UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"#77", "CI passed", "gbarany/tea-dash", "@octo push", "completed/success", "1 action run"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("actions view is missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
+func TestActionsPreviewRendersStaticSummary(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "CI passed", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash", Actor: "octo", Event: "push",
+		Status: "completed", Conclusion: "success", HeadBranch: "main", HeadSHA: "abc123",
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"gbarany/tea-dash · #77", "CI passed", "completed/success", "main", "abc123", "push", "@octo"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("actions preview missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
 // TestPreviewStartsOpenAndToggles verifies the preview pane is visible by
 // default: the initial window size gives it dimensions and the composed View()
 // renders the sidebar region. 'p' still toggles it closed and open again.
@@ -711,6 +814,7 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 	})
 
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // actions
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // pulls
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p1",

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -740,8 +740,8 @@ func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
 		t.Fatalf("'s' while an action prompt is active must not switch views: %v", m.ctx.View)
 	}
 	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
-	if m.ctx.PreviewOpen {
-		t.Fatal("'p' while an action prompt is active must not toggle preview")
+	if !m.ctx.PreviewOpen {
+		t.Fatal("'p' while an action prompt is active must not toggle the default-open preview")
 	}
 	m = update(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
 	if m.getCurrSection().IsSearchFocused() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,14 +1,20 @@
 package ui
 
 import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
@@ -457,6 +463,98 @@ func TestModelRendersLoadedNotifications(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("notifications view is missing %q\n---\n%s", want, view)
 		}
+	}
+}
+
+func TestMarkSelectedNotificationReadRefreshesNotifications(t *testing.T) {
+	var hit bool
+	client := newNotificationActionClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/notifications/threads/12" {
+				http.NotFound(w, r)
+				return
+			}
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			fmt.Fprint(w, `{"id":12,"unread":false}`)
+		},
+		nil,
+	)
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: true, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if cmd == nil {
+		t.Fatal("'m' on a notification should return a mark-read command")
+	}
+	m = next.(Model)
+	msg := cmd()
+	if !hit {
+		t.Fatal("mark-read command did not call the notification thread endpoint")
+	}
+	next, refresh := m.Update(msg)
+	m = next.(Model)
+	if refresh == nil {
+		t.Fatal("successful mark-read should refresh the notifications section")
+	}
+	if !strings.Contains(m.notice, "Marked notification read") {
+		t.Fatalf("notice = %q, want mark-read confirmation", m.notice)
+	}
+}
+
+func TestMarkAllNotificationsReadRefreshesNotifications(t *testing.T) {
+	var hit bool
+	client := newNotificationActionClient(t,
+		nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", r.Method)
+			}
+			q := r.URL.Query()
+			if got := q.Get("to-status"); got != "read" {
+				t.Fatalf("to-status = %q, want read", got)
+			}
+			if got := q["status-types"]; len(got) != 1 || got[0] != "unread" {
+				t.Fatalf("status-types = %v, want [unread]", got)
+			}
+			fmt.Fprint(w, `[]`)
+		},
+	)
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: true, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'M', Text: "M"})
+	if cmd == nil {
+		t.Fatal("'M' in notifications should return a mark-all-read command")
+	}
+	m = next.(Model)
+	msg := cmd()
+	if !hit {
+		t.Fatal("mark-all command did not call the notifications endpoint")
+	}
+	next, refresh := m.Update(msg)
+	m = next.(Model)
+	if refresh == nil {
+		t.Fatal("successful mark-all-read should refresh the notifications section")
+	}
+	if !strings.Contains(m.notice, "Marked all notifications read") {
+		t.Fatalf("notice = %q, want mark-all confirmation", m.notice)
 	}
 }
 
@@ -1051,3 +1149,32 @@ var errBoom = errBoomType("boom")
 type errBoomType string
 
 func (e errBoomType) Error() string { return string(e) }
+
+func newNotificationActionClient(
+	t *testing.T,
+	threadHandler http.HandlerFunc,
+	notificationsHandler http.HandlerFunc,
+) *gitea.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	if threadHandler != nil {
+		mux.HandleFunc("/api/v1/notifications/threads/12", threadHandler)
+	}
+	if notificationsHandler != nil {
+		mux.HandleFunc("/api/v1/notifications", notificationsHandler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -39,6 +40,17 @@ func notificationFetchedMsg(rows []data.Notification) context.TaskFinishedMsg {
 		TaskId:      "n1",
 		Msg: notificationsection.SectionNotificationsFetchedMsg{
 			Rows: rows, TotalCount: len(rows), TaskId: "n1",
+		},
+	}
+}
+
+func fetchedIssuesMsg(issues []data.Issue) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: issuesection.SectionType,
+		TaskId:      "i1",
+		Msg: issuesection.SectionIssuesFetchedMsg{
+			Rows: issues, TotalCount: len(issues), TaskId: "i1",
 		},
 	}
 }
@@ -702,6 +714,151 @@ func TestPreviewToggleGatedWhileSearching(t *testing.T) {
 	}
 	if got := m.getCurrSection().(*pullsection.Model).SearchBar.Value(); !strings.Contains(got, "p") {
 		t.Fatalf("search value = %q, want it to contain the typed \"p\"", got)
+	}
+}
+
+func TestActiveActionPromptCapturesGlobalKeys(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Prompt row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'c', Text: "c"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("'c' should open an action prompt")
+	}
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	m = next.(Model)
+	if isQuitCmd(cmd) {
+		t.Fatal("'q' while an action prompt is active must not quit")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("'s' while an action prompt is active must not switch views: %v", m.ctx.View)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
+	if m.ctx.PreviewOpen {
+		t.Fatal("'p' while an action prompt is active must not toggle preview")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+	if m.getCurrSection().IsSearchFocused() {
+		t.Fatal("'/' while an action prompt is active must not focus search")
+	}
+}
+
+func TestActionKeysDispatchExpectedIntents(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		kind actions.Kind
+	}{
+		{name: "comment", key: tea.KeyPressMsg{Code: 'c', Text: "c"}, kind: actions.KindComment},
+		{name: "merge", key: tea.KeyPressMsg{Code: 'm', Text: "m"}, kind: actions.KindMerge},
+		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
+		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
+		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
+		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
+		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedMsg([]data.PullRequest{{
+				Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+			}}))
+
+			m = update(t, m, tt.key)
+			if !m.actionPrompt.Active() {
+				t.Fatalf("%s key should open an action prompt", tt.name)
+			}
+			if tt.kind == actions.KindComment {
+				m = update(t, m, tea.KeyPressMsg{Code: 'o', Text: "o"})
+				m = update(t, m, tea.KeyPressMsg{Code: 'k', Text: "k"})
+			}
+			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:   0,
+				SectionType: pullsection.SectionType,
+				RowKind:     actions.RowKindPullRequest,
+				Repo:        "gbarany/tea-dash",
+				Number:      42,
+				Title:       "Action row",
+				URL:         "https://example.test/gbarany/tea-dash/pulls/42",
+			}
+			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want kind %q target %+v", got[0], tt.kind, wantTarget)
+			}
+			if tt.kind == actions.KindComment && got[0].Prompt.Value != "ok" {
+				t.Fatalf("comment prompt value = %q, want ok", got[0].Prompt.Value)
+			}
+		})
+	}
+}
+
+func TestInvalidActionOnIssueShowsNotice(t *testing.T) {
+	var dispatched bool
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m.actionDispatcher = func(actions.Intent) tea.Cmd {
+		dispatched = true
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 7, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if dispatched {
+		t.Fatal("merge on an issue must not dispatch")
+	}
+	if m.actionPrompt.Active() {
+		t.Fatal("merge on an issue must not open a prompt")
+	}
+	if !strings.Contains(m.notice, "pull requests") {
+		t.Fatalf("invalid action notice = %q, want pull requests message", m.notice)
+	}
+	if view := m.View().Content; !strings.Contains(view, "pull requests") {
+		t.Fatalf("invalid action notice should render in the view:\n%s", view)
+	}
+}
+
+func TestNilActionDispatcherShowsNoticeOnSubmit(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("'m' should open an action prompt")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.actionPrompt.Active() {
+		t.Fatal("submitted prompt should close")
+	}
+	if !strings.Contains(m.notice, "Action not wired yet") {
+		t.Fatalf("nil dispatcher notice = %q, want action-not-wired message", m.notice)
+	}
+	if view := m.View().Content; !strings.Contains(view, "Action not wired yet") {
+		t.Fatalf("nil dispatcher notice should render in the view:\n%s", view)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
+	"github.com/gbarany/tea-dash/internal/ui/components/branchsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
 	"github.com/gbarany/tea-dash/internal/ui/components/notificationsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
@@ -69,6 +71,17 @@ func actionFetchedMsg(rows []data.ActionRun) context.TaskFinishedMsg {
 		TaskId:      "a1",
 		Msg: actionsection.SectionActionsFetchedMsg{
 			Rows: rows, TotalCount: len(rows), TaskId: "a1",
+		},
+	}
+}
+
+func branchFetchedMsg(rows []localgit.Branch) context.TaskFinishedMsg {
+	return context.TaskFinishedMsg{
+		SectionId:   0,
+		SectionType: branchsection.SectionType,
+		TaskId:      "b1",
+		Msg: branchsection.SectionBranchesFetchedMsg{
+			Rows: rows, TotalCount: len(rows), TaskId: "b1",
 		},
 	}
 }
@@ -208,7 +221,7 @@ func TestSwitchViewCyclesToNotifications(t *testing.T) {
 	}
 }
 
-func TestSwitchViewCyclesToActionsAndBackToPulls(t *testing.T) {
+func TestSwitchViewCyclesToActionsBranchesAndBackToPulls(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // issues
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
@@ -224,9 +237,21 @@ func TestSwitchViewCyclesToActionsAndBackToPulls(t *testing.T) {
 		t.Fatal("expected a fetch command after switching to the actions view")
 	}
 
+	next, cmd = m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	m = next.(Model)
+	if m.ctx.View != context.BranchesView {
+		t.Fatalf("View = %v, want BranchesView", m.ctx.View)
+	}
+	if len(m.branches) == 0 {
+		t.Fatal("expected branch sections to be built lazily on switch")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch command after switching to the branches view")
+	}
+
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	if m.ctx.View != context.PullsView {
-		t.Fatalf("View = %v, want PullsView after actions", m.ctx.View)
+		t.Fatalf("next switch after branches should wrap to pulls: View = %v", m.ctx.View)
 	}
 }
 
@@ -367,6 +392,19 @@ func TestDefaultsViewStartsActions(t *testing.T) {
 	}
 }
 
+func TestDefaultsViewStartsBranches(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	if m.ctx.View != context.BranchesView {
+		t.Fatalf("View = %v, want BranchesView", m.ctx.View)
+	}
+	if len(m.branches) == 0 {
+		t.Fatal("defaults.view=branches should build the branch sections at startup")
+	}
+	if len(m.prs) != 0 || len(m.issues) != 0 || len(m.notifications) != 0 {
+		t.Fatalf("prs=%d issues=%d notifications=%d, want inactive views lazy", len(m.prs), len(m.issues), len(m.notifications))
+	}
+}
+
 // TestCrossViewFetchRoutesToOwnSlice verifies a late PR fetch that lands while
 // the Issues view is active is still routed to the pulls slice by (id, type),
 // not to whatever section is currently on screen.
@@ -388,8 +426,9 @@ func TestCrossViewFetchRoutesToOwnSlice(t *testing.T) {
 			TotalCount: 1, TaskId: "t1",
 		},
 	})
-	// Switch through Notifications back to the pulls view; the fetch must have
-	// landed in m.prs rather than whatever view is on screen.
+	// Switch through Notifications and Branches back to the pulls view; the
+	// fetch must have landed in m.prs rather than whatever view is on screen.
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"})
@@ -633,6 +672,24 @@ func TestModelRendersLoadedActions(t *testing.T) {
 	for _, want := range []string{"#77", "CI passed", "gbarany/tea-dash", "@octo push", "completed/success", "1 action run"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("actions view is missing %q\n---\n%s", want, view)
+		}
+	}
+}
+
+func TestModelRendersLoadedBranches(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"}) // close preview for table assertions
+	m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+		Repository: "tea-dash", Name: "m5/repo-branches", Current: true,
+		Upstream: "origin/m4/notifications", Ahead: 1, Commit: "abc1234",
+		Subject: "Add branches view", UpdatedAt: time.Now().Add(-time.Hour),
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"m5/repo-branches", "tea-dash", "origin/m4/notifications", "current", "ahead 1", "1 branch"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("branches view is missing %q\n---\n%s", want, view)
 		}
 	}
 }
@@ -896,6 +953,7 @@ func TestPreviewErrorsDoNotLeakBetweenPullsAndIssuesWithSameNumber(t *testing.T)
 
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // notifications
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // actions
+	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // branches
 	m = update(t, m, tea.KeyPressMsg{Code: 's', Text: "s"}) // pulls
 	m = update(t, m, context.TaskFinishedMsg{
 		SectionId: 0, SectionType: pullsection.SectionType, TaskId: "p1",

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func writeClipboard(value string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return runClipboardCommand(value, "pbcopy")
+	case "windows":
+		return runClipboardCommand(value, "clip")
+	default:
+		candidates := [][]string{
+			{"wl-copy"},
+			{"xclip", "-selection", "clipboard"},
+			{"xsel", "--clipboard", "--input"},
+		}
+		for _, args := range candidates {
+			if _, err := exec.LookPath(args[0]); err != nil {
+				continue
+			}
+			return runClipboardCommand(value, args...)
+		}
+		return fmt.Errorf("no clipboard command found (tried wl-copy, xclip, xsel)")
+	}
+}
+
+func runClipboardCommand(value string, args ...string) error {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = strings.NewReader(value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/ui/components/actionfeedback/actionfeedback.go
+++ b/internal/ui/components/actionfeedback/actionfeedback.go
@@ -1,0 +1,62 @@
+// Package actionfeedback renders compact footer feedback for action results.
+package actionfeedback
+
+// Kind identifies the feedback state.
+type Kind string
+
+const (
+	KindStart   Kind = "start"
+	KindSuccess Kind = "success"
+	KindError   Kind = "error"
+	KindCancel  Kind = "cancel"
+)
+
+// Message is the root-owned feedback value rendered by this component.
+type Message struct {
+	Kind Kind
+	Text string
+}
+
+func Start(text string) Message   { return Message{Kind: KindStart, Text: text} }
+func Success(text string) Message { return Message{Kind: KindSuccess, Text: text} }
+func Error(text string) Message   { return Message{Kind: KindError, Text: text} }
+func Cancel(text string) Message  { return Message{Kind: KindCancel, Text: text} }
+
+// Model stores the last action feedback message.
+type Model struct {
+	msg Message
+}
+
+func New() Model { return Model{} }
+
+func (m Model) Set(msg Message) Model {
+	m.msg = msg
+	return m
+}
+
+func (m Model) Clear() Model {
+	m.msg = Message{}
+	return m
+}
+
+func (m Model) Empty() bool { return m.msg.Text == "" }
+
+func (m Model) View(width int) string {
+	if m.msg.Text == "" {
+		return ""
+	}
+	return fit(m.msg.Text, width)
+}
+
+func fit(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if len(s) <= width {
+		return s
+	}
+	if width <= 3 {
+		return s[:width]
+	}
+	return s[:width-3] + "..."
+}

--- a/internal/ui/components/actionfeedback/actionfeedback_test.go
+++ b/internal/ui/components/actionfeedback/actionfeedback_test.go
@@ -1,0 +1,42 @@
+package actionfeedback
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFeedbackRendersKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want string
+	}{
+		{name: "start", msg: Start("Starting merge"), want: "Starting merge"},
+		{name: "success", msg: Success("Merged"), want: "Merged"},
+		{name: "error", msg: Error("Merge failed"), want: "Merge failed"},
+		{name: "cancel", msg: Cancel("Action cancelled"), want: "Action cancelled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := New().Set(tt.msg).View(80)
+			if !strings.Contains(view, tt.want) {
+				t.Fatalf("feedback view missing %q:\n%s", tt.want, view)
+			}
+		})
+	}
+}
+
+func TestFeedbackSmallWidthRender(t *testing.T) {
+	view := New().Set(Error("This message is too long for the footer")).View(10)
+	if view == "" {
+		t.Fatal("feedback with a message should render")
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if len(line) > 10 {
+			t.Fatalf("line %q is wider than 10 columns in:\n%s", line, view)
+		}
+	}
+	if !strings.Contains(view, "...") {
+		t.Fatalf("small-width render should truncate with ..., got:\n%s", view)
+	}
+}

--- a/internal/ui/components/actionprompt/actionprompt.go
+++ b/internal/ui/components/actionprompt/actionprompt.go
@@ -1,0 +1,204 @@
+// Package actionprompt implements the small blocking prompt used by root-level
+// action keys.
+package actionprompt
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+)
+
+// Mode selects the prompt interaction.
+type Mode string
+
+const (
+	ModeConfirm Mode = "confirm"
+	ModeText    Mode = "text"
+	ModePicker  Mode = "picker"
+)
+
+// Option is a selectable picker entry.
+type Option struct {
+	Label string
+	Value string
+}
+
+// Config describes a prompt instance.
+type Config struct {
+	Mode        Mode
+	Title       string
+	Message     string
+	Placeholder string
+	Options     []Option
+	Initial     string
+}
+
+// Result reports whether a prompt completed and what it submitted.
+type Result struct {
+	Submitted bool
+	Canceled  bool
+	Value     string
+	Label     string
+}
+
+// Model owns the active prompt state.
+type Model struct {
+	active   bool
+	cfg      Config
+	input    textinput.Model
+	selected int
+}
+
+func New() Model {
+	return Model{input: newInput(Config{})}
+}
+
+// Focus opens the prompt with cfg and initializes its local state.
+func (m Model) Focus(cfg Config) Model {
+	if cfg.Mode == "" {
+		cfg.Mode = ModeConfirm
+	}
+	m.active = true
+	m.cfg = cfg
+	m.input = newInput(cfg)
+	m.selected = 0
+	return m
+}
+
+func (m Model) Active() bool { return m.active }
+
+func (m Model) Value() string {
+	if !m.active && m.cfg.Mode != ModeText {
+		return ""
+	}
+	return m.input.Value()
+}
+
+func (m Model) Update(msg tea.Msg) (Model, Result, tea.Cmd) {
+	if !m.active {
+		return m, Result{}, nil
+	}
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, Result{}, nil
+	}
+	switch key.String() {
+	case "esc", "ctrl+c":
+		m.active = false
+		return m, Result{Canceled: true}, nil
+	case "enter":
+		return m.submit(), m.result(), nil
+	}
+
+	switch m.cfg.Mode {
+	case ModeText:
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, Result{}, cmd
+	case ModePicker:
+		switch key.String() {
+		case "j", "down", "right":
+			if m.selected < len(m.cfg.Options)-1 {
+				m.selected++
+			}
+		case "k", "up", "left":
+			if m.selected > 0 {
+				m.selected--
+			}
+		}
+	case ModeConfirm:
+		switch strings.ToLower(key.String()) {
+		case "y":
+			return m.submit(), m.result(), nil
+		case "n":
+			m.active = false
+			return m, Result{Canceled: true}, nil
+		}
+	}
+	return m, Result{}, nil
+}
+
+func (m Model) View(width int) string {
+	if !m.active {
+		return ""
+	}
+	var lines []string
+	if m.cfg.Title != "" {
+		lines = append(lines, "Action: "+m.cfg.Title)
+	}
+	if m.cfg.Message != "" {
+		lines = append(lines, m.cfg.Message)
+	}
+	switch m.cfg.Mode {
+	case ModeText:
+		value := m.input.Value()
+		if value == "" && m.cfg.Placeholder != "" {
+			value = m.cfg.Placeholder
+		}
+		lines = append(lines, "> "+value)
+	case ModePicker:
+		if len(m.cfg.Options) == 0 {
+			lines = append(lines, "No choices available")
+		}
+		for i, option := range m.cfg.Options {
+			prefix := "  "
+			if i == m.selected {
+				prefix = "> "
+			}
+			lines = append(lines, prefix+option.Label)
+		}
+	default:
+		lines = append(lines, "enter: confirm | esc: cancel")
+	}
+	if m.cfg.Mode != ModeConfirm {
+		lines = append(lines, "enter: submit | esc: cancel")
+	}
+	for i, line := range lines {
+		lines[i] = fit(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func newInput(cfg Config) textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = "> "
+	ti.Placeholder = cfg.Placeholder
+	ti.SetValue(cfg.Initial)
+	ti.Focus()
+	ti.CursorEnd()
+	return ti
+}
+
+func (m Model) submit() Model {
+	m.active = false
+	return m
+}
+
+func (m Model) result() Result {
+	switch m.cfg.Mode {
+	case ModeText:
+		return Result{Submitted: true, Value: m.input.Value()}
+	case ModePicker:
+		if len(m.cfg.Options) == 0 {
+			return Result{Submitted: true}
+		}
+		option := m.cfg.Options[m.selected]
+		return Result{Submitted: true, Value: option.Value, Label: option.Label}
+	default:
+		return Result{Submitted: true, Value: "confirm"}
+	}
+}
+
+func fit(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if len(s) <= width {
+		return s
+	}
+	if width <= 3 {
+		return s[:width]
+	}
+	return s[:width-3] + "..."
+}

--- a/internal/ui/components/actionprompt/actionprompt_test.go
+++ b/internal/ui/components/actionprompt/actionprompt_test.go
@@ -1,0 +1,121 @@
+package actionprompt
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func testKey(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+func TestConfirmSubmitAndCancel(t *testing.T) {
+	m := New()
+	m = m.Focus(Config{Mode: ModeConfirm, Title: "Merge", Message: "Merge #42?"})
+	if !m.Active() {
+		t.Fatal("prompt should be active after Focus")
+	}
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Canceled {
+		t.Fatalf("enter should submit confirm prompt: %+v", result)
+	}
+	if result.Value != "confirm" {
+		t.Fatalf("confirm value = %q, want confirm", result.Value)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after submit")
+	}
+
+	m = New().Focus(Config{Mode: ModeConfirm, Title: "Close", Message: "Close #42?"})
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Submitted {
+		t.Fatalf("esc should cancel confirm prompt: %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after cancel")
+	}
+}
+
+func TestTextSubmitAndCancel(t *testing.T) {
+	m := New().Focus(Config{Mode: ModeText, Title: "Comment", Placeholder: "Body"})
+	for _, r := range "ship it" {
+		var result Result
+		m, result, _ = m.Update(testKey(r))
+		if result.Submitted || result.Canceled {
+			t.Fatalf("typing %q should not finish prompt: %+v", r, result)
+		}
+	}
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Value != "ship it" {
+		t.Fatalf("enter should submit typed text, got %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after text submit")
+	}
+
+	m = New().Focus(Config{Mode: ModeText, Title: "Comment"})
+	m, _, _ = m.Update(testKey('x'))
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Value != "" {
+		t.Fatalf("esc should cancel text prompt without payload: %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after text cancel")
+	}
+}
+
+func TestPickerSubmitAndCancel(t *testing.T) {
+	cfg := Config{
+		Mode:  ModePicker,
+		Title: "Review",
+		Options: []Option{
+			{Label: "Comment", Value: "comment"},
+			{Label: "Approve", Value: "approve"},
+		},
+	}
+	m := New().Focus(cfg)
+	m, _, _ = m.Update(testKey('j'))
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Value != "approve" || result.Label != "Approve" {
+		t.Fatalf("enter should submit selected picker option, got %+v", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after picker submit")
+	}
+
+	m = New().Focus(cfg)
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if !result.Canceled || result.Submitted {
+		t.Fatalf("esc should cancel picker prompt: %+v", result)
+	}
+}
+
+func TestSmallWidthRender(t *testing.T) {
+	m := New().Focus(Config{
+		Mode:        ModeText,
+		Title:       "Comment on a long pull request title",
+		Message:     "This footer should stay within the available terminal width.",
+		Placeholder: "Write a useful comment",
+	})
+
+	view := m.View(12)
+	if view == "" {
+		t.Fatal("active prompt should render")
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if len(line) > 12 {
+			t.Fatalf("line %q is wider than 12 columns in:\n%s", line, view)
+		}
+	}
+	if !strings.Contains(view, "...") {
+		t.Fatalf("small-width render should truncate long text with ..., got:\n%s", view)
+	}
+}

--- a/internal/ui/components/actionsection/actionsection.go
+++ b/internal/ui/components/actionsection/actionsection.go
@@ -1,0 +1,168 @@
+// Package actionsection is the Actions dashboard section: thin wiring over the
+// generic section.Model parameterized for repo-scoped data.ActionRun rows.
+package actionsection
+
+import (
+	stdctx "context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+// SectionType is the routing type tag for Actions sections.
+const SectionType = "action"
+
+// Model is the Actions section (the generic section specialized for action
+// runs, with wider state columns for status/conclusion).
+type Model struct {
+	*section.Model[data.ActionRun]
+}
+
+// SectionActionsFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
+type SectionActionsFetchedMsg = section.RowsFetchedMsg[data.ActionRun]
+
+var _ section.Section = (*Model)(nil)
+
+// NewModel builds an Actions section.
+func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	base := section.New(section.Options[data.ActionRun]{
+		Id:           id,
+		Ctx:          ctx,
+		Config:       cfg,
+		Type:         SectionType,
+		FilterKind:   "",
+		LoadingText:  "Loading action runs...",
+		EmptyText:    actionEmptyText(cfg),
+		EmptyHint:    actionEmptyHint(cfg),
+		SingularForm: "action run",
+		PluralForm:   "action runs",
+		Limit:        func(c *config.Config) int { return c.Defaults.ActionsLimit },
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.ActionRun, int, error) {
+			repoRef := strings.TrimSpace(cfg.Repo)
+			if repoRef == "" {
+				return nil, 0, nil
+			}
+			if c == nil {
+				return nil, 0, errors.New("Gitea client is not configured")
+			}
+			repo, err := config.ParseRepo(repoRef)
+			if err != nil {
+				return nil, 0, err
+			}
+			if limit <= 0 {
+				limit = 50
+			}
+			return c.ListActionRuns(ctx, repo.Owner, repo.Name, gitea.ActionRunListOptions{
+				Event:   f.Event,
+				Branch:  f.Branch,
+				Status:  f.Status,
+				Actor:   f.Actor,
+				HeadSHA: f.HeadSHA,
+				Limit:   limit,
+			})
+		},
+		BuildRow: actionBuildRow,
+	})
+	m := &Model{Model: base}
+	m.setActionColumns(ctx.MainContentWidth)
+	return m
+}
+
+// Update preserves the actionsection wrapper when the embedded generic section
+// handles a message.
+func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
+	next, cmd := m.Model.Update(msg)
+	if base, ok := next.(*section.Model[data.ActionRun]); ok {
+		m.Model = base
+	}
+	return m, cmd
+}
+
+// UpdateProgramContext resizes the table and reapplies the Actions columns.
+func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
+	m.Model.UpdateProgramContext(ctx)
+	m.setActionColumns(ctx.MainContentWidth)
+}
+
+func (m *Model) setActionColumns(mainWidth int) {
+	m.Columns = actionColumns(mainWidth)
+	m.Table.SetColumns(m.Columns)
+}
+
+func actionEmptyText(cfg config.SectionConfig) string {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return "No configured Actions sections."
+	}
+	return "No action runs match this filter."
+}
+
+func actionEmptyHint(cfg config.SectionConfig) string {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return "Add actionsSections with repo: owner/name to your tea-dash config."
+	}
+	return "This board shows repo-scoped Gitea Actions workflow runs."
+}
+
+func actionColumns(mainWidth int) []table.Column {
+	const (
+		numW     = 8
+		repoW    = 22
+		actorW   = 18
+		stateW   = 18
+		updatedW = 10
+	)
+	titleW := mainWidth - (numW + repoW + actorW + stateW + updatedW) - 6
+	if titleW < 20 {
+		titleW = 20
+	}
+	return []table.Column{
+		{Title: "#", Width: numW},
+		{Title: "Title", Width: titleW},
+		{Title: "Repo", Width: repoW},
+		{Title: "Actor/Event", Width: actorW},
+		{Title: "Status", Width: stateW},
+		{Title: "Updated", Width: updatedW},
+	}
+}
+
+func actionBuildRow(run data.ActionRun) table.Row {
+	return table.Row{
+		fmt.Sprintf("#%d", run.GetNumber()),
+		run.GetTitle(),
+		run.RepoNameWithOwner,
+		actionActorEvent(run),
+		actionStatus(run),
+		section.HumanizeTime(run.GetUpdatedAt()),
+	}
+}
+
+func actionActorEvent(run data.ActionRun) string {
+	var parts []string
+	if run.Actor != "" {
+		parts = append(parts, "@"+run.Actor)
+	}
+	if run.Event != "" {
+		parts = append(parts, run.Event)
+	}
+	return strings.Join(parts, " ")
+}
+
+func actionStatus(run data.ActionRun) string {
+	switch {
+	case run.Status != "" && run.Conclusion != "":
+		return run.Status + "/" + run.Conclusion
+	case run.Conclusion != "":
+		return run.Conclusion
+	default:
+		return run.Status
+	}
+}

--- a/internal/ui/components/actionsection/actionsection_test.go
+++ b/internal/ui/components/actionsection/actionsection_test.go
@@ -1,0 +1,225 @@
+package actionsection
+
+import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/auth"
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	ctx := &appctx.ProgramContext{Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20}
+	return NewModel(0, ctx, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+}
+
+func newFetchModel(t *testing.T, client *gitea.Client, cfg config.SectionConfig) *Model {
+	t.Helper()
+	ctx := &appctx.ProgramContext{
+		Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{Defaults: config.Defaults{ActionsLimit: 25}},
+		Client: client,
+		StartTask: func(appctx.Task) tea.Cmd {
+			return nil
+		},
+	}
+	return NewModel(0, ctx, cfg)
+}
+
+func TestImplementsSection(t *testing.T) {
+	var _ section.Section = (*Model)(nil)
+}
+
+func TestFetchedMsgBuildsRows(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("a1")
+	next, _ := m.Update(SectionActionsFetchedMsg{
+		Rows: []data.ActionRun{{
+			ID: 101, RunNumber: 12, DisplayTitle: "Fix checkout flakes",
+			RepoNameWithOwner: "acme/widgets", Actor: "octo", Event: "push",
+			Status: "completed", Conclusion: "success", UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1, TaskId: "a1",
+	})
+	m = next.(*Model)
+
+	if m.GetTotalCount() != 1 || m.NumRows() != 1 {
+		t.Fatalf("counts: total=%d rows=%d", m.GetTotalCount(), m.NumRows())
+	}
+	if m.GetCurrRow() == nil || m.GetCurrRow().GetNumber() != 12 {
+		t.Fatalf("GetCurrRow = %+v", m.GetCurrRow())
+	}
+	row := m.BuildRows()[0]
+	joined := strings.Join([]string(row), "|")
+	for _, want := range []string{"#12", "Fix checkout flakes", "acme/widgets", "@octo push", "completed/success"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("row %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestFetchRowsNoRepoReturnsEmptyResult(t *testing.T) {
+	m := newFetchModel(t, nil, config.SectionConfig{Title: "Actions"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("blank repo should not error: %v", payload.Err)
+	}
+	if len(payload.Rows) != 0 || payload.TotalCount != 0 {
+		t.Fatalf("blank repo payload = rows %d total %d, want empty", len(payload.Rows), payload.TotalCount)
+	}
+}
+
+func TestFetchRowsNilClientReturnsErrorInsteadOfPanicking(t *testing.T) {
+	m := newFetchModel(t, nil, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err == nil || !strings.Contains(payload.Err.Error(), "Gitea client") {
+		t.Fatalf("nil client payload error = %v, want Gitea client error", payload.Err)
+	}
+}
+
+func TestFetchRowsUsesRepoFiltersAndLimit(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `{
+				"total_count": 1,
+				"workflow_runs": [{
+					"id": 101,
+					"run_number": 12,
+					"display_title": "Fix checkout flakes",
+					"event": "push",
+					"status": "completed",
+					"conclusion": "success",
+					"head_branch": "main",
+					"head_sha": "abc123",
+					"actor": {"login": "octo"},
+					"updated_at": "2026-07-02T08:05:00Z"
+				}]
+			}`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	m := newFetchModel(t, client, config.SectionConfig{
+		Title: "CI",
+		Repo:  "acme/widgets",
+		Limit: 10,
+		Filter: config.PrIssueFilter{
+			Status:  "completed",
+			Branch:  "main",
+			Event:   "push",
+			Actor:   "octo",
+			HeadSHA: "abc123",
+		},
+	})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if payload.TotalCount != 1 || len(payload.Rows) != 1 || payload.Rows[0].RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("payload = total %d rows %+v", payload.TotalCount, payload.Rows)
+	}
+	for _, want := range []string{
+		"status=completed",
+		"branch=main",
+		"event=push",
+		"actor=octo",
+		"head_sha=abc123",
+		"limit=10",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+func TestFetchRowsDefaultsLimitTo50(t *testing.T) {
+	var gotQuery string
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `[]`)
+		})
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &appctx.ProgramContext{
+		Styles: appctx.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{},
+		Client: client,
+		StartTask: func(appctx.Task) tea.Cmd {
+			return nil
+		},
+	}
+	m := NewModel(0, ctx, config.SectionConfig{Title: "CI", Repo: "acme/widgets"})
+
+	msg := runFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionActionsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if !strings.Contains(gotQuery, "limit=50") {
+		t.Fatalf("query %q missing default limit=50", gotQuery)
+	}
+}
+
+func runFetchCommand(t *testing.T, cmd tea.Cmd) appctx.TaskFinishedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("FetchRows returned nil command")
+	}
+	msg := cmd()
+	if finished, ok := msg.(appctx.TaskFinishedMsg); ok {
+		return finished
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("FetchRows command returned %T, want TaskFinishedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		got := nested()
+		if finished, ok := got.(appctx.TaskFinishedMsg); ok {
+			return finished
+		}
+	}
+	t.Fatal("FetchRows batch did not contain a TaskFinishedMsg")
+	return appctx.TaskFinishedMsg{}
+}
+
+func actionServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/ui/components/branchsection/branchsection.go
+++ b/internal/ui/components/branchsection/branchsection.go
@@ -1,0 +1,146 @@
+// Package branchsection is the read-only local git branches dashboard section.
+package branchsection
+
+import (
+	stdctx "context"
+	"os"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+// SectionType is the routing type tag for local branch sections.
+const SectionType = "branch"
+
+// Model is the branches section. It wraps the generic section so the branches
+// view can use columns sized for branch/upstream/status data.
+type Model struct {
+	*section.Model[localgit.Branch]
+}
+
+// SectionBranchesFetchedMsg is the fetch payload carried in TaskFinishedMsg.Msg.
+type SectionBranchesFetchedMsg = section.RowsFetchedMsg[localgit.Branch]
+
+// NewModel builds a local branches section.
+func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	m := &Model{Model: section.New(section.Options[localgit.Branch]{
+		Id:           id,
+		Ctx:          ctx,
+		Config:       cfg,
+		Type:         SectionType,
+		FilterKind:   "",
+		LoadingText:  "Loading local branches...",
+		EmptyText:    "No local branches.",
+		EmptyHint:    "Configure localRepos with paths to git checkouts, or start tea-dash inside a repository.",
+		SingularForm: "branch",
+		PluralForm:   "branches",
+		Limit:        func(c *config.Config) int { return c.Defaults.BranchesLimit },
+		Fetch: func(fetchCtx stdctx.Context, _ *gitea.Client, _ config.PrIssueFilter, limit int) ([]localgit.Branch, int, error) {
+			repos, err := repositoriesFromConfig(ctx.Config, os.Getwd)
+			if err != nil {
+				return nil, 0, err
+			}
+			branches, err := localgit.ListBranchesForRepositories(fetchCtx, repos)
+			if err != nil {
+				return nil, 0, err
+			}
+			total := len(branches)
+			if limit > 0 && len(branches) > limit {
+				branches = branches[:limit]
+			}
+			return branches, total, nil
+		},
+		BuildRow: branchBuildRow,
+	})}
+	m.applyColumns(ctx.MainContentWidth)
+	return m
+}
+
+// Update delegates to the generic section and returns the wrapper so branch
+// sections keep their custom column behavior after updates.
+func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
+	next, cmd := m.Model.Update(msg)
+	if typed, ok := next.(*section.Model[localgit.Branch]); ok {
+		m.Model = typed
+	}
+	return m, cmd
+}
+
+// UpdateProgramContext delegates generic resize work, then restores branch
+// columns instead of the PR/issue defaults.
+func (m *Model) UpdateProgramContext(ctx *appctx.ProgramContext) {
+	m.Model.UpdateProgramContext(ctx)
+	m.applyColumns(ctx.MainContentWidth)
+}
+
+func (m *Model) applyColumns(width int) {
+	cols := branchColumns(width)
+	m.Columns = cols
+	m.Table.SetColumns(cols)
+}
+
+func repositoriesFromConfig(cfg *config.Config, getwd func() (string, error)) ([]localgit.Repository, error) {
+	if cfg != nil && len(cfg.LocalRepos) > 0 {
+		repos := make([]localgit.Repository, 0, len(cfg.LocalRepos))
+		for _, r := range cfg.LocalRepos {
+			repos = append(repos, localgit.Repository{
+				Name: strings.TrimSpace(r.Name),
+				Path: strings.TrimSpace(r.Path),
+			})
+		}
+		return repos, nil
+	}
+	wd, err := getwd()
+	if err != nil {
+		return nil, err
+	}
+	return []localgit.Repository{{Path: wd}}, nil
+}
+
+func branchBuildRow(branch localgit.Branch) table.Row {
+	current := ""
+	if branch.Current {
+		current = "*"
+	}
+	upstream := branch.Upstream
+	if upstream == "" {
+		upstream = "local"
+	}
+	return table.Row{
+		current,
+		branch.Name,
+		branch.Repository,
+		upstream,
+		branch.Status(),
+		branch.Commit,
+	}
+}
+
+func branchColumns(mainWidth int) []table.Column {
+	const (
+		markW     = 3
+		repoW     = 20
+		upstreamW = 28
+		statusW   = 22
+		commitW   = 8
+	)
+	branchW := mainWidth - (markW + repoW + upstreamW + statusW + commitW) - 6
+	if branchW < 20 {
+		branchW = 20
+	}
+	return []table.Column{
+		{Title: "#", Width: markW},
+		{Title: "Branch", Width: branchW},
+		{Title: "Repo", Width: repoW},
+		{Title: "Upstream", Width: upstreamW},
+		{Title: "Status", Width: statusW},
+		{Title: "Commit", Width: commitW},
+	}
+}

--- a/internal/ui/components/branchsection/branchsection_test.go
+++ b/internal/ui/components/branchsection/branchsection_test.go
@@ -1,0 +1,82 @@
+package branchsection
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	localgit "github.com/gbarany/tea-dash/internal/git"
+	"github.com/gbarany/tea-dash/internal/ui/components/section"
+	"github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func newModel(t *testing.T) *Model {
+	t.Helper()
+	ctx := &context.ProgramContext{
+		Config:            &config.Config{},
+		Styles:            context.DefaultStyles(),
+		MainContentWidth:  120,
+		MainContentHeight: 20,
+	}
+	return NewModel(0, ctx, config.SectionConfig{Title: "Local Branches"})
+}
+
+func TestImplementsSection(t *testing.T) {
+	var _ section.Section = (*Model)(nil)
+}
+
+func TestFetchedMsgBuildsRows(t *testing.T) {
+	m := newModel(t)
+	m.SetLastFetchID("b1")
+	next, _ := m.Update(SectionBranchesFetchedMsg{
+		Rows: []localgit.Branch{{
+			Repository: "tea-dash", Name: "feature/repo-branches", Current: true,
+			Upstream: "origin/feature/repo-branches", Ahead: 2, Behind: 1,
+			Commit: "abc1234", Subject: "Add branch dashboard", UpdatedAt: time.Now().Add(-time.Hour),
+		}},
+		TotalCount: 1,
+		TaskId:     "b1",
+	})
+	m = next.(*Model)
+
+	if m.GetTotalCount() != 1 || m.NumRows() != 1 {
+		t.Fatalf("counts: total=%d rows=%d", m.GetTotalCount(), m.NumRows())
+	}
+	row := m.BuildRows()[0]
+	joined := strings.Join([]string(row), "|")
+	for _, want := range []string{"feature/repo-branches", "tea-dash", "origin/feature/repo-branches", "current", "ahead 2", "behind 1", "abc1234"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("row %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestRepositoriesFromConfigUsesConfiguredLocalRepos(t *testing.T) {
+	cfg := &config.Config{LocalRepos: []config.LocalRepoConfig{
+		{Name: "tea-dash", Path: "/tmp/tea-dash"},
+		{Name: "other", Path: "/tmp/other"},
+	}}
+	repos, err := repositoriesFromConfig(cfg, func() (string, error) {
+		return "/tmp/ignored", nil
+	})
+	if err != nil {
+		t.Fatalf("repositoriesFromConfig() error: %v", err)
+	}
+	if len(repos) != 2 || repos[0].Name != "tea-dash" || repos[0].Path != "/tmp/tea-dash" ||
+		repos[1].Name != "other" || repos[1].Path != "/tmp/other" {
+		t.Fatalf("repositoriesFromConfig() = %+v", repos)
+	}
+}
+
+func TestRepositoriesFromConfigFallsBackToWorkingDirectory(t *testing.T) {
+	repos, err := repositoriesFromConfig(&config.Config{}, func() (string, error) {
+		return "/tmp/current", nil
+	})
+	if err != nil {
+		t.Fatalf("repositoriesFromConfig() error: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Name != "" || repos[0].Path != "/tmp/current" {
+		t.Fatalf("repositoriesFromConfig() = %+v, want cwd fallback", repos)
+	}
+}

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -30,8 +30,10 @@ const (
 // maxChecks / maxComments cap how many per-check and per-comment lines render
 // before a "…and N more" summary line.
 const (
-	maxChecks   = 8
-	maxComments = 10
+	maxChecks      = 8
+	maxComments    = 10
+	maxActionJobs  = 12
+	maxActionSteps = 12
 )
 
 var (
@@ -122,43 +124,53 @@ func RenderNotification(row data.Notification, width int) string {
 	return compose(header, body, false, width, true, nil)
 }
 
-// RenderAction renders a repo-scoped Actions workflow run into the preview. It
-// is intentionally static: opening the run in Gitea is the path to jobs/logs.
-func RenderAction(row data.ActionRun, width int) string {
-	header := []string{
-		locator(row.RepoNameWithOwner, row.GetNumber()),
-		titleLine(row.GetTitle(), width),
+// RenderAction renders a repo-scoped Actions workflow run into the preview.
+// When detail is present it appends the loaded job and step statuses.
+func RenderAction(row data.ActionRun, detail *data.ActionRunDetail, width int) string {
+	run := row
+	if detail != nil {
+		run = mergeActionRun(row, detail.Run)
 	}
-	if status := actionRunStatus(row); status != "" {
-		header = append(header, pill(strings.ToUpper(status), actionRunColor(row)))
+	header := []string{
+		locator(run.RepoNameWithOwner, run.GetNumber()),
+		titleLine(run.GetTitle(), width),
+	}
+	if status := actionRunStatus(run); status != "" {
+		header = append(header, pill(strings.ToUpper(status), actionRunColor(run)))
 	}
 
 	var body []string
-	if row.WorkflowName != "" {
-		body = append(body, "Workflow: "+row.WorkflowName)
+	if run.WorkflowName != "" {
+		body = append(body, "Workflow: "+run.WorkflowName)
 	}
-	if status := actionRunStatus(row); status != "" {
+	if status := actionRunStatus(run); status != "" {
 		body = append(body, "Status: "+status)
 	}
-	if row.Event != "" {
-		body = append(body, "Event: "+row.Event)
+	if run.Event != "" {
+		body = append(body, "Event: "+run.Event)
 	}
-	if row.Actor != "" {
-		body = append(body, "Actor: @"+row.Actor)
+	if run.Actor != "" {
+		body = append(body, "Actor: @"+run.Actor)
 	}
-	if row.HeadBranch != "" {
-		body = append(body, "Branch: "+row.HeadBranch)
+	if run.HeadBranch != "" {
+		body = append(body, "Branch: "+run.HeadBranch)
 	}
-	if row.HeadSHA != "" {
-		body = append(body, "SHA: "+shortSHA(row.HeadSHA))
+	if run.HeadSHA != "" {
+		body = append(body, "SHA: "+shortSHA(run.HeadSHA))
 	}
-	if rel := section.HumanizeTime(row.GetUpdatedAt()); rel != "" {
+	if rel := section.HumanizeTime(run.GetUpdatedAt()); rel != "" {
 		body = append(body, "Updated: "+rel)
 	}
 	if len(body) == 0 {
 		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
 	}
-	return compose(header, strings.Join(body, "\n"), false, width, true, nil)
+	var extras []string
+	if detail == nil {
+		body = append(body, "", "Jobs: Loading...")
+	} else {
+		extras = []string{renderActionJobs(detail.Jobs, width)}
+	}
+	return compose(header, strings.Join(body, "\n"), false, width, true, extras)
 }
 
 // compose joins the header block with the rendered body, then appends any
@@ -291,6 +303,145 @@ func actionRunColor(row data.ActionRun) string {
 		return "#d29922"
 	default:
 		return "#1f6feb"
+	}
+}
+
+func mergeActionRun(base, detail data.ActionRun) data.ActionRun {
+	if detail.ID == 0 {
+		return base
+	}
+	if detail.RunNumber == 0 {
+		detail.RunNumber = base.RunNumber
+	}
+	if detail.RunAttempt == 0 {
+		detail.RunAttempt = base.RunAttempt
+	}
+	if detail.DisplayTitle == "" {
+		detail.DisplayTitle = base.DisplayTitle
+	}
+	if detail.WorkflowName == "" {
+		detail.WorkflowName = base.WorkflowName
+	}
+	if detail.Event == "" {
+		detail.Event = base.Event
+	}
+	if detail.Status == "" {
+		detail.Status = base.Status
+	}
+	if detail.Conclusion == "" {
+		detail.Conclusion = base.Conclusion
+	}
+	if detail.HeadBranch == "" {
+		detail.HeadBranch = base.HeadBranch
+	}
+	if detail.HeadSHA == "" {
+		detail.HeadSHA = base.HeadSHA
+	}
+	if detail.Actor == "" {
+		detail.Actor = base.Actor
+	}
+	if detail.RepoNameWithOwner == "" {
+		detail.RepoNameWithOwner = base.RepoNameWithOwner
+	}
+	if detail.HTMLURL == "" {
+		detail.HTMLURL = base.HTMLURL
+	}
+	if detail.CreatedAt.IsZero() {
+		detail.CreatedAt = base.CreatedAt
+	}
+	if detail.UpdatedAt.IsZero() {
+		detail.UpdatedAt = base.UpdatedAt
+	}
+	if detail.StartedAt.IsZero() {
+		detail.StartedAt = base.StartedAt
+	}
+	return detail
+}
+
+func renderActionJobs(jobs []data.ActionJob, width int) string {
+	lines := []string{titleStyle.Render("Jobs:")}
+	if len(jobs) == 0 {
+		return strings.Join(append(lines, dimStyle.Render("No jobs reported.")), "\n")
+	}
+
+	shown := jobs
+	extra := 0
+	if len(shown) > maxActionJobs {
+		extra = len(shown) - maxActionJobs
+		shown = shown[:maxActionJobs]
+	}
+	for _, job := range shown {
+		lines = append(lines, actionJobLine(job, width))
+		steps := job.Steps
+		stepExtra := 0
+		if len(steps) > maxActionSteps {
+			stepExtra = len(steps) - maxActionSteps
+			steps = steps[:maxActionSteps]
+		}
+		for _, step := range steps {
+			lines = append(lines, actionStepLine(step, width))
+		}
+		if stepExtra > 0 {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("  …and %d more steps", stepExtra)))
+		}
+	}
+	if extra > 0 {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("…and %d more jobs", extra)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func actionJobLine(job data.ActionJob, width int) string {
+	icon, st := actionStatusIcon(job.Status, job.Conclusion)
+	text := job.Name
+	if status := actionItemStatus(job.Status, job.Conclusion); status != "" {
+		text += " · " + status
+	}
+	if job.RunnerName != "" {
+		text += " · " + job.RunnerName
+	}
+	return st.Render(icon) + " " + truncateText(text, width-2)
+}
+
+func actionStepLine(step data.ActionStep, width int) string {
+	icon, st := actionStatusIcon(step.Status, step.Conclusion)
+	text := step.Name
+	if step.Number != 0 {
+		text = fmt.Sprintf("%d. %s", step.Number, text)
+	}
+	if status := actionItemStatus(step.Status, step.Conclusion); status != "" {
+		text += " · " + status
+	}
+	return "  " + st.Render(icon) + " " + truncateText(text, width-4)
+}
+
+func actionItemStatus(status, conclusion string) string {
+	switch {
+	case status != "" && conclusion != "":
+		return status + "/" + conclusion
+	case conclusion != "":
+		return conclusion
+	default:
+		return status
+	}
+}
+
+func actionStatusIcon(status, conclusion string) (string, lipgloss.Style) {
+	switch strings.ToLower(conclusion) {
+	case "success":
+		return "✓", greenStyle
+	case "failure", "cancelled", "timed_out":
+		return "✗", redStyle
+	case "skipped":
+		return "•", dimStyle
+	}
+	switch strings.ToLower(status) {
+	case "completed":
+		return "•", dimStyle
+	case "queued", "waiting", "in_progress", "requested":
+		return "•", yellowStyle
+	default:
+		return "•", yellowStyle
 	}
 }
 

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -122,6 +122,45 @@ func RenderNotification(row data.Notification, width int) string {
 	return compose(header, body, false, width, true, nil)
 }
 
+// RenderAction renders a repo-scoped Actions workflow run into the preview. It
+// is intentionally static: opening the run in Gitea is the path to jobs/logs.
+func RenderAction(row data.ActionRun, width int) string {
+	header := []string{
+		locator(row.RepoNameWithOwner, row.GetNumber()),
+		titleLine(row.GetTitle(), width),
+	}
+	if status := actionRunStatus(row); status != "" {
+		header = append(header, pill(strings.ToUpper(status), actionRunColor(row)))
+	}
+
+	var body []string
+	if row.WorkflowName != "" {
+		body = append(body, "Workflow: "+row.WorkflowName)
+	}
+	if status := actionRunStatus(row); status != "" {
+		body = append(body, "Status: "+status)
+	}
+	if row.Event != "" {
+		body = append(body, "Event: "+row.Event)
+	}
+	if row.Actor != "" {
+		body = append(body, "Actor: @"+row.Actor)
+	}
+	if row.HeadBranch != "" {
+		body = append(body, "Branch: "+row.HeadBranch)
+	}
+	if row.HeadSHA != "" {
+		body = append(body, "SHA: "+shortSHA(row.HeadSHA))
+	}
+	if rel := section.HumanizeTime(row.GetUpdatedAt()); rel != "" {
+		body = append(body, "Updated: "+rel)
+	}
+	if len(body) == 0 {
+		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
+	}
+	return compose(header, strings.Join(body, "\n"), false, width, true, nil)
+}
+
 // compose joins the header block with the rendered body, then appends any
 // non-empty extra sections (CI / reviews / comments) below the fold, each
 // separated by a blank line so the viewport scrolls through them. When loading
@@ -225,6 +264,41 @@ func notificationColor(row data.Notification) string {
 	default:
 		return stateColor(row.SubjectState)
 	}
+}
+
+func actionRunStatus(row data.ActionRun) string {
+	switch {
+	case row.Status != "" && row.Conclusion != "":
+		return row.Status + "/" + row.Conclusion
+	case row.Conclusion != "":
+		return row.Conclusion
+	default:
+		return row.Status
+	}
+}
+
+func actionRunColor(row data.ActionRun) string {
+	switch strings.ToLower(row.Conclusion) {
+	case "success":
+		return colOpen
+	case "failure", "cancelled", "timed_out":
+		return colClosed
+	}
+	switch strings.ToLower(row.Status) {
+	case "completed":
+		return colDraft
+	case "queued", "waiting":
+		return "#d29922"
+	default:
+		return "#1f6feb"
+	}
+}
+
+func shortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
 }
 
 // renderCI renders the CI block: a colored "Checks: ✓N ✗M •K" summary line

--- a/internal/ui/components/prview/prview_test.go
+++ b/internal/ui/components/prview/prview_test.go
@@ -184,6 +184,57 @@ func TestRenderIssueSingleComment(t *testing.T) {
 	}
 }
 
+func TestRenderActionWithDetailShowsJobsAndSteps(t *testing.T) {
+	row := data.ActionRun{
+		ID:                101,
+		RunNumber:         77,
+		DisplayTitle:      "CI passed",
+		WorkflowName:      "CI",
+		RepoNameWithOwner: "gbarany/tea-dash",
+		Status:            "completed",
+		Conclusion:        "success",
+	}
+	detail := &data.ActionRunDetail{
+		Run: row,
+		Jobs: []data.ActionJob{{
+			ID:         201,
+			RunID:      101,
+			Name:       "build",
+			Status:     "completed",
+			Conclusion: "success",
+			RunnerName: "ubuntu-latest",
+			Steps: []data.ActionStep{{
+				Number:     1,
+				Name:       "checkout",
+				Status:     "completed",
+				Conclusion: "success",
+			}, {
+				Number:     2,
+				Name:       "go test",
+				Status:     "completed",
+				Conclusion: "failure",
+			}},
+		}},
+	}
+
+	out := RenderAction(row, detail, 80)
+	for _, want := range []string{
+		"gbarany/tea-dash · #77",
+		"CI passed",
+		"Jobs:",
+		"build",
+		"ubuntu-latest",
+		"checkout",
+		"go test",
+		"completed/success",
+		"completed/failure",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("action detail preview missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // TestRenderNilDetailNoComments verifies a nil detail keeps the Loading
 // placeholder and renders no comments/CI sections.
 func TestRenderNilDetailNoComments(t *testing.T) {

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -23,6 +23,7 @@ const (
 	PullsView ViewType = iota
 	IssuesView
 	NotificationsView
+	ActionsView
 )
 
 // TaskState is the lifecycle of an async task.
@@ -61,7 +62,7 @@ type ProgramContext struct {
 	Config *config.Config
 	Client *gitea.Client // may be nil in tests
 	User   string        // client.Me(); "" when client is nil
-	View   ViewType      // PullsView | IssuesView | NotificationsView
+	View   ViewType      // PullsView | IssuesView | NotificationsView | ActionsView
 	Error  error
 	Styles Styles
 
@@ -74,6 +75,13 @@ type ProgramContext struct {
 // default section.
 func (c *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 	switch c.View {
+	case ActionsView:
+		if c.Config != nil && len(c.Config.ActionsSections) > 0 {
+			return c.Config.ActionsSections
+		}
+		return []config.SectionConfig{{
+			Title: "Actions",
+		}}
 	case NotificationsView:
 		if c.Config != nil && len(c.Config.NotificationsSections) > 0 {
 			return c.Config.NotificationsSections

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -24,6 +24,7 @@ const (
 	IssuesView
 	NotificationsView
 	ActionsView
+	BranchesView
 )
 
 // TaskState is the lifecycle of an async task.
@@ -62,7 +63,7 @@ type ProgramContext struct {
 	Config *config.Config
 	Client *gitea.Client // may be nil in tests
 	User   string        // client.Me(); "" when client is nil
-	View   ViewType      // PullsView | IssuesView | NotificationsView | ActionsView
+	View   ViewType      // PullsView | IssuesView | NotificationsView | ActionsView | BranchesView
 	Error  error
 	Styles Styles
 
@@ -81,6 +82,13 @@ func (c *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 		}
 		return []config.SectionConfig{{
 			Title: "Actions",
+		}}
+	case BranchesView:
+		if c.Config != nil && len(c.Config.BranchSections) > 0 {
+			return c.Config.BranchSections
+		}
+		return []config.SectionConfig{{
+			Title: "Local Branches",
 		}}
 	case NotificationsView:
 		if c.Config != nil && len(c.Config.NotificationsSections) > 0 {

--- a/internal/ui/context/context_test.go
+++ b/internal/ui/context/context_test.go
@@ -2,6 +2,8 @@ package context
 
 import (
 	"testing"
+
+	"github.com/gbarany/tea-dash/internal/config"
 )
 
 func TestDefaultStylesNonZero(t *testing.T) {
@@ -38,5 +40,28 @@ func TestGetViewSectionsConfigIssues(t *testing.T) {
 	}
 	if secs[0].Filter.CreatedBy != "@me" || secs[0].Filter.State != "open" {
 		t.Fatalf("default issues filter = %+v, want CreatedBy=@me State=open", secs[0].Filter)
+	}
+}
+
+func TestGetViewSectionsConfigActions(t *testing.T) {
+	ctx := &ProgramContext{View: ActionsView}
+	secs := ctx.GetViewSectionsConfig()
+	if len(secs) != 1 || secs[0].Title != "Actions" {
+		t.Fatalf("GetViewSectionsConfig(ActionsView) = %+v, want one empty-state section", secs)
+	}
+	if secs[0].Repo != "" {
+		t.Fatalf("default actions repo = %q, want blank repo for no-config empty state", secs[0].Repo)
+	}
+
+	ctx = &ProgramContext{
+		View: ActionsView,
+		Config: &config.Config{ActionsSections: []config.SectionConfig{{
+			Title: "CI",
+			Repo:  "acme/widgets",
+		}}},
+	}
+	secs = ctx.GetViewSectionsConfig()
+	if len(secs) != 1 || secs[0].Title != "CI" || secs[0].Repo != "acme/widgets" {
+		t.Fatalf("configured actions sections = %+v", secs)
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -6,6 +6,7 @@ import "charm.land/bubbles/v2/key"
 // keys) is handled by the underlying table widget.
 type keyMap struct {
 	Refresh       key.Binding
+	RefreshAll    key.Binding
 	Open          key.Binding
 	Quit          key.Binding
 	NextSection   key.Binding
@@ -23,6 +24,9 @@ type keyMap struct {
 	Review        key.Binding
 	ExternalDiff  key.Binding
 	Checkout      key.Binding
+	CopyNumber    key.Binding
+	CopyURL       key.Binding
+	Help          key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -30,6 +34,10 @@ func defaultKeyMap() keyMap {
 		Refresh: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
+		),
+		RefreshAll: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "refresh all"),
 		),
 		Open: key.NewBinding(
 			key.WithKeys("o", "enter"),
@@ -92,12 +100,24 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("v", "review"),
 		),
 		ExternalDiff: key.NewBinding(
-			key.WithKeys("d"),
-			key.WithHelp("d", "external diff"),
+			key.WithKeys("d", "ctrl+t"),
+			key.WithHelp("d/ctrl+t", "external diff"),
 		),
 		Checkout: key.NewBinding(
-			key.WithKeys("C"),
-			key.WithHelp("C", "checkout"),
+			key.WithKeys("C", " ", "space"),
+			key.WithHelp("C/space", "checkout"),
+		),
+		CopyNumber: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "copy number"),
+		),
+		CopyURL: key.NewBinding(
+			key.WithKeys("Y"),
+			key.WithHelp("Y", "copy URL"),
+		),
+		Help: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
 		),
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -16,6 +16,13 @@ type keyMap struct {
 	ScrollUp      key.Binding
 	ScrollDown    key.Binding
 	Expand        key.Binding
+	Comment       key.Binding
+	Merge         key.Binding
+	Close         key.Binding
+	Reopen        key.Binding
+	Review        key.Binding
+	ExternalDiff  key.Binding
+	Checkout      key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -63,6 +70,34 @@ func defaultKeyMap() keyMap {
 		Expand: key.NewBinding(
 			key.WithKeys("e"),
 			key.WithHelp("e", "expand"),
+		),
+		Comment: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "comment"),
+		),
+		Merge: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "merge"),
+		),
+		Close: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "close"),
+		),
+		Reopen: key.NewBinding(
+			key.WithKeys("X"),
+			key.WithHelp("X", "reopen"),
+		),
+		Review: key.NewBinding(
+			key.WithKeys("v"),
+			key.WithHelp("v", "review"),
+		),
+		ExternalDiff: key.NewBinding(
+			key.WithKeys("d"),
+			key.WithHelp("d", "external diff"),
+		),
+		Checkout: key.NewBinding(
+			key.WithKeys("C"),
+			key.WithHelp("C", "checkout"),
 		),
 	}
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -27,6 +27,8 @@ type keyMap struct {
 	CopyNumber    key.Binding
 	CopyURL       key.Binding
 	Help          key.Binding
+	MarkRead      key.Binding
+	MarkAllRead   key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -118,6 +120,14 @@ func defaultKeyMap() keyMap {
 		Help: key.NewBinding(
 			key.WithKeys("?"),
 			key.WithHelp("?", "help"),
+		),
+		MarkRead: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "mark read"),
+		),
+		MarkAllRead: key.NewBinding(
+			key.WithKeys("M"),
+			key.WithHelp("M", "mark all read"),
 		),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/actionrunner"
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/build"
 	"github.com/gbarany/tea-dash/internal/config"
@@ -63,7 +64,17 @@ func run() error {
 		return fmt.Errorf("connecting to %s: %w", authCfg.URL, err)
 	}
 
-	p := tea.NewProgram(ui.New(cfg, client))
+	model := ui.New(cfg, client)
+	cwd, _ := os.Getwd()
+	runner := actionrunner.New(actionrunner.Options{
+		Client:      client,
+		Config:      cfg,
+		InstanceURL: authCfg.URL,
+		CWD:         cwd,
+	})
+	model.SetActionDispatcher(runner.Dispatch)
+
+	p := tea.NewProgram(model)
 	_, err = p.Run()
 	return err
 }


### PR DESCRIPTION
## Summary

Integrates the stacked feature branches that were merged into intermediate branches but had not all landed on `main`.

This promotes the current feature stack onto `main` in one clean rollup:

- PR / issue actions: comment, merge, close / reopen, review, external diff, checkout
- Standard hotkeys aligned with gh-dash / lazygit-style expectations
- Notification mark-read actions (`m` selected, `M` all)
- Actions data layer, Actions runs view, and Actions run detail preview
- Read-only local branches view
- Conflict resolution across the combined view registry: PRs -> Issues -> Notifications -> Actions -> Branches
- Keeps default-open preview and closed PR history behavior

This PR supersedes the remaining stacked PRs that target non-main branches.

## Verification

```sh
GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/git ./internal/ui ./internal/ui/components/branchsection ./internal/ui/components/actionsection ./internal/gitea ./internal/data -v
GOCACHE=/tmp/tea-dash-go-cache make check
GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build
```
