### PR TITLE
Select rows with mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ tea-dash --help
 | Key             | Action                  |
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
+| mouse click      | select row              |
+| mouse wheel      | move selection          |
 | `g` / `G`       | first / last row        |
 | `s`             | switch view (PRs/issues/notifications/actions/branches)|
 | `h` / `l`       | prev / next section     |

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -275,6 +275,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case notificationActionMsg:
 		return m.handleNotificationAction(msg)
 
+	case tea.MouseClickMsg:
+		return m.handleMouseClick(msg)
+
+	case tea.MouseWheelMsg:
+		return m.handleMouseWheel(msg)
+
 	case spinner.TickMsg:
 		// A tick belongs to whichever section started the spinner, but sibling
 		// sections in the current view share one animation; route it to every one
@@ -432,7 +438,7 @@ func (m Model) View() tea.View {
 		helpStyle.Render(m.helpLine()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
-	return tea.View{Content: content, AltScreen: true}
+	return tea.View{Content: content, AltScreen: true, MouseMode: tea.MouseModeCellMotion}
 }
 
 func (m Model) helpLine() string {
@@ -730,6 +736,88 @@ func (m *Model) switchView() tea.Cmd {
 		cmds = append(cmds, m.enrichCurrRow())
 	}
 	return tea.Batch(cmds...)
+}
+
+func (m Model) tableDataStartY() int {
+	y := 1 // appStyle top padding
+	y++    // title
+	if len(m.currentViewSections()) > 1 {
+		y++ // tabs
+	}
+	if s := m.getCurrSection(); s != nil && s.IsSearchFocused() {
+		y++ // search bar
+	}
+	y++ // table header
+	return y
+}
+
+func (m Model) inMainListPane(x, y int) bool {
+	if x < 2 || y < m.tableDataStartY() {
+		return false
+	}
+	width := m.ctx.MainContentWidth
+	if width <= 0 {
+		width = m.ctx.ScreenWidth - 4
+	}
+	return x < 2+width
+}
+
+func (m Model) rowIndexAtY(y int) (int, bool) {
+	s := m.getCurrSection()
+	if s == nil || s.GetIsLoading() || s.GetError() != nil {
+		return 0, false
+	}
+	i := y - m.tableDataStartY()
+	if i < 0 || i >= s.NumRows() {
+		return 0, false
+	}
+	return i, true
+}
+
+func (m Model) selectRowFromMouse(x, y int) (Model, tea.Cmd) {
+	if !m.inMainListPane(x, y) {
+		return m, nil
+	}
+	i, ok := m.rowIndexAtY(y)
+	if !ok {
+		return m, nil
+	}
+	s := m.getCurrSection()
+	before := m.selKey()
+	s.SelectRow(i)
+	if !m.ctx.PreviewOpen || m.selKey() == before {
+		return m, nil
+	}
+	m.syncSidebar()
+	return m, m.enrichCurrRow()
+}
+
+func (m Model) handleMouseClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
+	if msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+	return m.selectRowFromMouse(msg.X, msg.Y)
+}
+
+func (m Model) handleMouseWheel(msg tea.MouseWheelMsg) (Model, tea.Cmd) {
+	if !m.inMainListPane(msg.X, msg.Y) {
+		return m, nil
+	}
+	before := m.selKey()
+	var cmd tea.Cmd
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		cmd = m.updateCurrentSection(tea.KeyPressMsg{Code: tea.KeyUp})
+	case tea.MouseWheelDown:
+		cmd = m.updateCurrentSection(tea.KeyPressMsg{Code: tea.KeyDown})
+	default:
+		return m, nil
+	}
+	if m.ctx.PreviewOpen && m.selKey() != before {
+		m.syncSidebar()
+		cmd = tea.Batch(cmd, m.enrichCurrRow())
+	}
+	return m, cmd
 }
 
 func (m Model) failedPreview(row data.RowData, err error) string {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -107,6 +107,109 @@ func TestModelRendersLoadedPulls(t *testing.T) {
 	}
 }
 
+func TestViewEnablesMouseCellMotion(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	view := m.View()
+	if view.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("MouseMode = %v, want MouseModeCellMotion", view.MouseMode)
+	}
+}
+
+func TestMouseClickSelectsVisibleRowAndRefreshesPreview(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+	firstKey := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:  firstKey,
+		pull: &data.PullDetail{Body: "firstdetailtoken", BaseRef: "main", HeadRef: "first"},
+	})
+
+	click := tea.MouseClickMsg{X: 3, Y: m.tableDataStartY() + 1, Button: tea.MouseLeft}
+	next, _ := m.Update(click)
+	m = next.(Model)
+
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("clicked row number = %d, want 2", got)
+	}
+	view := m.View().Content
+	if strings.Contains(view, "firstdetailtoken") {
+		t.Fatalf("click should refresh preview away from first row detail:\n%s", view)
+	}
+	if !strings.Contains(view, "Loading") {
+		t.Fatalf("click should show the newly selected row's loading preview:\n%s", view)
+	}
+}
+
+func TestMouseClickInPreviewDoesNotChangeSelection(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	previewX := 2 + m.ctx.MainContentWidth + 2
+	click := tea.MouseClickMsg{X: previewX, Y: m.tableDataStartY() + 1, Button: tea.MouseLeft}
+	m = update(t, m, click)
+
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("selection changed after preview click: row = %d, want 1", got)
+	}
+}
+
+func TestMouseWheelMovesSelectionInList(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 3, Title: "Third", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	firstKey := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:  firstKey,
+		pull: &data.PullDetail{Body: "firstdetailtoken", BaseRef: "main", HeadRef: "first"},
+	})
+
+	listY := m.tableDataStartY()
+	m = update(t, m, tea.MouseWheelMsg{X: 3, Y: listY, Button: tea.MouseWheelDown})
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("wheel down selected row = %d, want 2", got)
+	}
+	view := m.View().Content
+	if strings.Contains(view, "firstdetailtoken") || !strings.Contains(view, "Loading") {
+		t.Fatalf("wheel down should refresh preview to the selected row loading state:\n%s", view)
+	}
+	m = update(t, m, tea.MouseWheelMsg{X: 3, Y: listY, Button: tea.MouseWheelDown})
+	if got := m.getCurrRowData().GetNumber(); got != 3 {
+		t.Fatalf("second wheel down selected row = %d, want 3", got)
+	}
+	m = update(t, m, tea.MouseWheelMsg{X: 3, Y: listY, Button: tea.MouseWheelUp})
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("wheel up selected row = %d, want 2", got)
+	}
+}
+
+func TestMouseWheelInPreviewDoesNotMoveListSelection(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	previewX := 2 + m.ctx.MainContentWidth + 2
+	m = update(t, m, tea.MouseWheelMsg{X: previewX, Y: m.tableDataStartY(), Button: tea.MouseWheelDown})
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("preview wheel changed list selection: row = %d, want 1", got)
+	}
+}
+
 func TestModelRendersError(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 80, Height: 24})

--- a/internal/ui/components/section/section.go
+++ b/internal/ui/components/section/section.go
@@ -30,6 +30,7 @@ type Section interface {
 
 	NumRows() int
 	GetCurrRow() data.RowData
+	SelectRow(index int)
 	FetchRows() tea.Cmd
 
 	GetItemSingular() string
@@ -129,6 +130,9 @@ func (m *BaseModel) SetLastFetchID(id string) { m.lastFetchID = id }
 
 func (m *BaseModel) NumRows() int { return m.numRows }
 func (m *BaseModel) CurrRow() int { return m.Table.Cursor() }
+
+// SelectRow moves the table cursor to index, clamping to the available rows.
+func (m *BaseModel) SelectRow(index int) { m.Table.SetCursor(index) }
 
 // IsSearchFocused reports whether the embedded search bar is currently active.
 func (m *BaseModel) IsSearchFocused() bool { return m.isSearching }


### PR DESCRIPTION
## Summary

Adds mouse support to the dashboard list pane:

- enables Bubble Tea mouse cell mode
- left-click on a visible list row selects that row
- mouse wheel over the list moves selection up/down
- click/wheel in the preview pane does not affect list selection
- preview refresh/enrichment follows mouse selection like keyboard navigation
- README documents click and wheel behavior

## Verification

```sh
GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui -run 'TestViewEnablesMouseCellMotion|TestMouseClickSelectsVisibleRowAndRefreshesPreview|TestMouseClickInPreviewDoesNotChangeSelection|TestMouseWheelMovesSelectionInList|TestMouseWheelInPreviewDoesNotMoveListSelection' -v
GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui ./internal/ui/components/section ./internal/ui/components/pullsection ./internal/ui/components/issuesection ./internal/ui/components/actionsection ./internal/ui/components/branchsection -v
GOCACHE=/tmp/tea-dash-go-cache make check
GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build
```

Also launched the built binary in tmux pane `main:9.3` using the existing 1Password token command and confirmed the real dashboard renders with the default-open preview.
