### PR TITLE
Mark notifications unread

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -97,6 +97,7 @@ type enrichedMsg struct {
 type notificationActionMsg struct {
 	sectionID int
 	all       bool
+	unread    bool
 	err       error
 }
 
@@ -298,6 +299,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
 			return m.markSelectedNotificationRead()
+		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkUnread):
+			return m.markSelectedNotificationUnread()
 		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
 			return m.markAllNotificationsRead()
 		case key.Matches(msg, m.keys.Comment):
@@ -445,7 +448,7 @@ func (m Model) helpLine() string {
 	if m.showHelp {
 		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
 		if m.ctx.View == context.NotificationsView {
-			text += " · m mark read · M mark all read"
+			text += " · m mark read · u mark unread · M mark all read"
 		} else {
 			text += " · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
@@ -453,7 +456,7 @@ func (m Model) helpLine() string {
 	}
 	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
 	if m.ctx.View == context.NotificationsView {
-		text += " · m/M read"
+		text += " · m read · u unread · M all read"
 	} else {
 		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
 	}
@@ -1095,6 +1098,23 @@ func (m Model) markSelectedNotificationRead() (Model, tea.Cmd) {
 	return m, markNotificationReadCmd(m.ctx.Client, m.currSectionId, row.ID)
 }
 
+func (m Model) markSelectedNotificationUnread() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.Notification)
+	if !ok {
+		m.notice = "Select a notification to mark unread."
+		return m, nil
+	}
+	if row.ID == 0 {
+		m.notice = "Selected notification has no thread id."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to mark notifications unread."
+		return m, nil
+	}
+	return m, markNotificationUnreadCmd(m.ctx.Client, m.currSectionId, row.ID)
+}
+
 func (m Model) markAllNotificationsRead() (Model, tea.Cmd) {
 	if m.ctx.View != context.NotificationsView {
 		m.notice = "Switch to notifications to mark all read."
@@ -1118,6 +1138,18 @@ func markNotificationReadCmd(client *gitea.Client, sectionID int, threadID int64
 	}
 }
 
+func markNotificationUnreadCmd(client *gitea.Client, sectionID int, threadID int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			unread:    true,
+			err:       client.MarkNotificationUnread(ctx, threadID),
+		}
+	}
+}
+
 func markAllNotificationsReadCmd(client *gitea.Client, sectionID int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
@@ -1134,6 +1166,8 @@ func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.C
 	if msg.err != nil {
 		if msg.all {
 			m.notice = fmt.Sprintf("Couldn't mark all notifications read: %v", msg.err)
+		} else if msg.unread {
+			m.notice = fmt.Sprintf("Couldn't mark notification unread: %v", msg.err)
 		} else {
 			m.notice = fmt.Sprintf("Couldn't mark notification read: %v", msg.err)
 		}
@@ -1141,6 +1175,8 @@ func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.C
 	}
 	if msg.all {
 		m.notice = "Marked all notifications read."
+	} else if msg.unread {
+		m.notice = "Marked notification unread."
 	} else {
 		m.notice = "Marked notification read."
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -709,6 +709,52 @@ func TestMarkSelectedNotificationReadRefreshesNotifications(t *testing.T) {
 	}
 }
 
+func TestMarkSelectedNotificationUnreadRefreshesNotifications(t *testing.T) {
+	var hit bool
+	client := newNotificationActionClient(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/notifications/threads/12" {
+				http.NotFound(w, r)
+				return
+			}
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "unread" {
+				t.Fatalf("to-status = %q, want unread", got)
+			}
+			fmt.Fprint(w, `{"id":12,"unread":true}`)
+		},
+		nil,
+	)
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+		SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+		Unread: false, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
+	if cmd == nil {
+		t.Fatal("'u' on a notification should return a mark-unread command")
+	}
+	m = next.(Model)
+	msg := cmd()
+	if !hit {
+		t.Fatal("mark-unread command did not call the notification thread endpoint")
+	}
+	next, refresh := m.Update(msg)
+	m = next.(Model)
+	if refresh == nil {
+		t.Fatal("successful mark-unread should refresh the notifications section")
+	}
+	if !strings.Contains(m.notice, "Marked notification unread") {
+		t.Fatalf("notice = %q, want mark-unread confirmation", m.notice)
+	}
+}
+
 func TestMarkAllNotificationsReadRefreshesNotifications(t *testing.T) {
 	var hit bool
 	client := newNotificationActionClient(t,
@@ -1291,6 +1337,19 @@ func TestHelpKeyTogglesFullHelp(t *testing.T) {
 	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
 	if strings.Contains(m.View().Content, "R refresh all") {
 		t.Fatal("second '?' should hide full help")
+	}
+}
+
+func TestNotificationsHelpShowsUnreadShortcut(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if view := m.View().Content; !strings.Contains(view, "u unread") {
+		t.Fatalf("compact notifications help missing unread shortcut:\n%s", view)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	if view := m.View().Content; !strings.Contains(view, "u mark unread") {
+		t.Fatalf("full notifications help missing mark-unread shortcut:\n%s", view)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -28,6 +28,7 @@ type keyMap struct {
 	CopyURL       key.Binding
 	Help          key.Binding
 	MarkRead      key.Binding
+	MarkUnread    key.Binding
 	MarkAllRead   key.Binding
 }
 
@@ -124,6 +125,10 @@ func defaultKeyMap() keyMap {
 		MarkRead: key.NewBinding(
 			key.WithKeys("m"),
 			key.WithHelp("m", "mark read"),
+		),
+		MarkUnread: key.NewBinding(
+			key.WithKeys("u"),
+			key.WithHelp("u", "mark unread"),
 		),
 		MarkAllRead: key.NewBinding(
 			key.WithKeys("M"),


### PR DESCRIPTION
## Summary

- add a Notifications-view `u` shortcut to mark the selected notification unread
- wire the existing Gitea unread endpoint through the UI action flow
- refresh notifications after the action and cover the hotkey/help text in tests

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui ./internal/gitea -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`