### PR TITLE
Switch local branches from the Branches view

### DIFF
--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -32,26 +32,31 @@ type Client interface {
 // CheckoutFunc runs or fakes a local PR checkout.
 type CheckoutFunc func(context.Context, localgit.CheckoutOptions) (localgit.CheckoutPlan, error)
 
+// BranchSwitchFunc runs or fakes a local branch switch.
+type BranchSwitchFunc func(context.Context, localgit.SwitchBranchOptions) (localgit.SwitchBranchResult, error)
+
 // Options configures a Runner.
 type Options struct {
-	Client      Client
-	Config      *config.Config
-	InstanceURL string
-	CWD         string
-	ShellRunner shell.Runner
-	GitRunner   localgit.Runner
-	Checkout    CheckoutFunc
+	Client       Client
+	Config       *config.Config
+	InstanceURL  string
+	CWD          string
+	ShellRunner  shell.Runner
+	GitRunner    localgit.Runner
+	Checkout     CheckoutFunc
+	BranchSwitch BranchSwitchFunc
 }
 
 // Runner executes actions and returns ResultMsg values for the UI.
 type Runner struct {
-	client      Client
-	cfg         *config.Config
-	instanceURL string
-	cwd         string
-	shellRunner shell.Runner
-	gitRunner   localgit.Runner
-	checkout    CheckoutFunc
+	client       Client
+	cfg          *config.Config
+	instanceURL  string
+	cwd          string
+	shellRunner  shell.Runner
+	gitRunner    localgit.Runner
+	checkout     CheckoutFunc
+	branchSwitch BranchSwitchFunc
 }
 
 // New constructs a Runner with production defaults for omitted runners.
@@ -68,14 +73,19 @@ func New(opts Options) Runner {
 	if checkout == nil {
 		checkout = localgit.RunCheckout
 	}
+	branchSwitch := opts.BranchSwitch
+	if branchSwitch == nil {
+		branchSwitch = localgit.SwitchBranch
+	}
 	return Runner{
-		client:      opts.Client,
-		cfg:         cfg,
-		instanceURL: opts.InstanceURL,
-		cwd:         opts.CWD,
-		shellRunner: shellRunner,
-		gitRunner:   opts.GitRunner,
-		checkout:    checkout,
+		client:       opts.Client,
+		cfg:          cfg,
+		instanceURL:  opts.InstanceURL,
+		cwd:          opts.CWD,
+		shellRunner:  shellRunner,
+		gitRunner:    opts.GitRunner,
+		checkout:     checkout,
+		branchSwitch: branchSwitch,
 	}
 }
 
@@ -95,6 +105,17 @@ func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
 }
 
 func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error) {
+	if intent.Kind == uiactions.KindSwitchBranch {
+		branch, err := r.branchSwitch(ctx, localgit.SwitchBranchOptions{
+			RepoPath: intent.Target.RepositoryPath,
+			Branch:   intent.Target.Title,
+			Runner:   r.gitRunner,
+		})
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Switched to %s in %s.", branch.Branch, branch.RepoPath), nil
+	}
 	if r.client == nil {
 		return "", fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))
 	}
@@ -253,6 +274,8 @@ func actionLabel(kind uiactions.Kind) string {
 		return "external diff"
 	case uiactions.KindCheckout:
 		return "checkout"
+	case uiactions.KindSwitchBranch:
+		return "switch branch"
 	default:
 		return string(kind)
 	}

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -48,6 +48,18 @@ func issueIntent(kind uiactions.Kind) uiactions.Intent {
 	return in
 }
 
+func branchIntent(kind uiactions.Kind) uiactions.Intent {
+	return uiactions.Intent{
+		Kind: kind,
+		Target: uiactions.Target{
+			RowKind:        uiactions.RowKindBranch,
+			Repo:           "tea-dash",
+			RepositoryPath: "/src/tea-dash",
+			Title:          "feature/local-ops",
+		},
+	}
+}
+
 func TestDispatchCommentAndClose(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})
@@ -158,6 +170,27 @@ func TestDispatchCheckoutPassesConfig(t *testing.T) {
 		gotOpts.InstanceURL != "https://git.example" || gotOpts.Remote != "upstream" ||
 		gotOpts.BranchTemplate != "review-{{.PrIndex}}" {
 		t.Fatalf("checkout opts = %+v", gotOpts)
+	}
+}
+
+func TestDispatchSwitchBranchDoesNotRequireClient(t *testing.T) {
+	var gotOpts localgit.SwitchBranchOptions
+	r := New(Options{
+		BranchSwitch: func(_ context.Context, opts localgit.SwitchBranchOptions) (localgit.SwitchBranchResult, error) {
+			gotOpts = opts
+			return localgit.SwitchBranchResult{RepoPath: opts.RepoPath, Branch: opts.Branch}, nil
+		},
+	})
+
+	got := runDispatch(t, r, branchIntent(uiactions.KindSwitchBranch))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("switch branch result = %+v", got)
+	}
+	if gotOpts.RepoPath != "/src/tea-dash" || gotOpts.Branch != "feature/local-ops" {
+		t.Fatalf("switch branch opts = %+v", gotOpts)
+	}
+	if !strings.Contains(got.Message, "Switched to feature/local-ops") {
+		t.Fatalf("switch branch message = %q", got.Message)
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -345,6 +345,61 @@ func RunCheckout(ctx context.Context, opts CheckoutOptions) (CheckoutPlan, error
 	return plan, nil
 }
 
+// SwitchBranchOptions configures switching to an existing local branch.
+type SwitchBranchOptions struct {
+	RepoPath string
+	Branch   string
+	Runner   Runner
+}
+
+// SwitchBranchResult is the local branch switch that completed.
+type SwitchBranchResult struct {
+	RepoPath string
+	Branch   string
+}
+
+// SwitchBranch switches an existing local repository to branch. It refuses a
+// no-op switch to the current branch and wraps common git failures with
+// operator-facing recovery guidance.
+func SwitchBranch(ctx context.Context, opts SwitchBranchOptions) (SwitchBranchResult, error) {
+	repoPath := strings.TrimSpace(opts.RepoPath)
+	branch := strings.TrimSpace(opts.Branch)
+	if repoPath == "" {
+		return SwitchBranchResult{}, errors.New("repository path is required")
+	}
+	if branch == "" {
+		return SwitchBranchResult{}, errors.New("branch name is required")
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	current, err := runGit(ctx, runner, repoPath, "branch", "--show-current")
+	if err != nil {
+		return SwitchBranchResult{}, err
+	}
+	if strings.TrimSpace(current.Stdout) == branch {
+		return SwitchBranchResult{}, fmt.Errorf("branch %s is already current in %s", branch, repoPath)
+	}
+	if _, err := runGit(ctx, runner, repoPath, "switch", branch); err != nil {
+		return SwitchBranchResult{}, switchBranchError(repoPath, branch, err)
+	}
+	return SwitchBranchResult{RepoPath: repoPath, Branch: branch}, nil
+}
+
+func switchBranchError(repoPath, branch string, err error) error {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "local changes") && strings.Contains(msg, "would be overwritten"):
+		return fmt.Errorf("could not switch to %s in %s: commit, stash, or discard local changes first: %w", branch, repoPath, err)
+	case strings.Contains(msg, "already checked out"):
+		return fmt.Errorf("could not switch to %s in %s: branch is already checked out in another worktree; use that worktree or switch it away first: %w", branch, repoPath, err)
+	default:
+		return fmt.Errorf("could not switch to %s in %s: %w", branch, repoPath, err)
+	}
+}
+
 func branchExists(ctx context.Context, runner Runner, dir, branch string) (bool, error) {
 	res, err := runner.Run(ctx, Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}})
 	if err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -254,6 +254,81 @@ func TestRunCheckoutMissingRepoPath(t *testing.T) {
 	}
 }
 
+func TestSwitchBranchRunsGitSwitch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{Stdout: "main\n", ExitCode: 0},
+		{ExitCode: 0},
+	}}
+
+	result, err := SwitchBranch(context.Background(), SwitchBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("SwitchBranch: %v", err)
+	}
+	if result.RepoPath != repo || result.Branch != "feature/local-ops" {
+		t.Fatalf("result = %+v", result)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"branch", "--show-current"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "feature/local-ops"}},
+	})
+}
+
+func TestSwitchBranchRefusesCurrentBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{Stdout: "feature/local-ops\n", ExitCode: 0}}}
+
+	_, err := SwitchBranch(context.Background(), SwitchBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "already current") {
+		t.Fatalf("SwitchBranch current error = %v", err)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"branch", "--show-current"}},
+	})
+}
+
+func TestSwitchBranchDirtyTreeFailureIsActionable(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{Stdout: "main\n", ExitCode: 0},
+		{ExitCode: 1, Stderr: "error: Your local changes to the following files would be overwritten by checkout:\n\tREADME.md\n"},
+	}}
+
+	_, err := SwitchBranch(context.Background(), SwitchBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "commit, stash, or discard") {
+		t.Fatalf("SwitchBranch dirty-tree error = %v", err)
+	}
+}
+
+func TestSwitchBranchWorktreeConflictFailureIsActionable(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{Stdout: "main\n", ExitCode: 0},
+		{ExitCode: 128, Stderr: "fatal: 'feature/local-ops' is already checked out at '/tmp/other'"},
+	}}
+
+	_, err := SwitchBranch(context.Background(), SwitchBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "another worktree") {
+		t.Fatalf("SwitchBranch worktree-conflict error = %v", err)
+	}
+}
+
 func makeGitDir(t *testing.T, remoteURL string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -13,6 +13,7 @@ const (
 	KindReview       Kind = "review"
 	KindExternalDiff Kind = "external_diff"
 	KindCheckout     Kind = "checkout"
+	KindSwitchBranch Kind = "switch_branch"
 )
 
 // RowKind identifies the selected row's domain type.
@@ -21,6 +22,7 @@ type RowKind string
 const (
 	RowKindPullRequest RowKind = "pull_request"
 	RowKindIssue       RowKind = "issue"
+	RowKindBranch      RowKind = "branch"
 )
 
 // PromptMode records which kind of prompt produced a submitted value.
@@ -34,13 +36,14 @@ const (
 
 // Target is the immutable row/section context for an action.
 type Target struct {
-	SectionID   int
-	SectionType string
-	RowKind     RowKind
-	Repo        string
-	Number      int64
-	Title       string
-	URL         string
+	SectionID      int
+	SectionType    string
+	RowKind        RowKind
+	Repo           string
+	RepositoryPath string
+	Number         int64
+	Title          string
+	URL            string
 }
 
 // Prompt carries the prompt payload that was submitted with the intent.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	localgit "github.com/gbarany/tea-dash/internal/git"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/actions"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionfeedback"
@@ -316,6 +317,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.ExternalDiff):
 			return m, m.startAction(actions.KindExternalDiff)
 		case key.Matches(msg, m.keys.Checkout):
+			if m.ctx.View == context.BranchesView {
+				return m, m.startAction(actions.KindSwitchBranch)
+			}
 			return m, m.startAction(actions.KindCheckout)
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
@@ -449,6 +453,8 @@ func (m Model) helpLine() string {
 		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
 		if m.ctx.View == context.NotificationsView {
 			text += " · m mark read · u mark unread · M mark all read"
+		} else if m.ctx.View == context.BranchesView {
+			text += " · C/space switch"
 		} else {
 			text += " · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
@@ -457,6 +463,8 @@ func (m Model) helpLine() string {
 	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
 	if m.ctx.View == context.NotificationsView {
 		text += " · m read · u unread · M all read"
+	} else if m.ctx.View == context.BranchesView {
+		text += " · C/space switch"
 	} else {
 		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
 	}
@@ -907,6 +915,17 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 		m.notice = fmt.Sprintf("%s is only available for pull requests.", actionLabel(kind))
 		return nil
 	}
+	if kind == actions.KindSwitchBranch {
+		branch, ok := m.getCurrRowData().(localgit.Branch)
+		if !ok || target.RowKind != actions.RowKindBranch {
+			m.notice = "Switch branch is only available for local branches."
+			return nil
+		}
+		if branch.Current {
+			m.notice = fmt.Sprintf("%s is already current in %s.", branch.Name, branch.Repository)
+			return nil
+		}
+	}
 	intent := actions.Intent{
 		Kind:   kind,
 		Target: target,
@@ -960,8 +979,10 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		rowKind = actions.RowKindPullRequest
 	case data.Issue:
 		rowKind = actions.RowKindIssue
+	case localgit.Branch:
+		rowKind = actions.RowKindBranch
 	}
-	return actions.Target{
+	target := actions.Target{
 		SectionID:   s.GetId(),
 		SectionType: s.GetType(),
 		RowKind:     rowKind,
@@ -969,7 +990,11 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		Number:      row.GetNumber(),
 		Title:       row.GetTitle(),
 		URL:         row.GetURL(),
-	}, true
+	}
+	if branch, ok := row.(localgit.Branch); ok {
+		target.RepositoryPath = branch.RepositoryPath
+	}
+	return target, true
 }
 
 func actionRequiresPullRequest(kind actions.Kind) bool {
@@ -995,6 +1020,9 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 func promptConfigForAction(kind actions.Kind, target actions.Target) actionprompt.Config {
 	title := fmt.Sprintf("%s #%d", actionLabel(kind), target.Number)
 	message := fmt.Sprintf("%s - %s", target.Repo, target.Title)
+	if kind == actions.KindSwitchBranch {
+		title = actionLabel(kind)
+	}
 	switch kind {
 	case actions.KindComment:
 		return actionprompt.Config{
@@ -1052,12 +1080,17 @@ func actionLabel(kind actions.Kind) string {
 		return "External diff"
 	case actions.KindCheckout:
 		return "Checkout"
+	case actions.KindSwitchBranch:
+		return "Switch branch"
 	default:
 		return string(kind)
 	}
 }
 
 func actionStartText(intent actions.Intent) string {
+	if intent.Kind == actions.KindSwitchBranch {
+		return fmt.Sprintf("Starting %s for %s.", actionLabel(intent.Kind), intent.Target.Title)
+	}
 	return fmt.Sprintf("Starting %s for %s#%d.", actionLabel(intent.Kind), intent.Target.Repo, intent.Target.Number)
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1320,6 +1320,81 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 	}
 }
 
+func TestBranchSwitchHotkeysDispatchExpectedIntent(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{name: "C", key: tea.KeyPressMsg{Code: 'C', Text: "C"}},
+		{name: "space", key: tea.KeyPressMsg{Code: ' ', Text: " "}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+				Repository: "tea-dash", RepositoryPath: "/src/tea-dash",
+				Name: "feature/local-ops", Current: false,
+			}}))
+
+			m = update(t, m, tt.key)
+			if !m.actionPrompt.Active() {
+				t.Fatalf("%s should open a branch switch prompt", tt.name)
+			}
+			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:      0,
+				SectionType:    branchsection.SectionType,
+				RowKind:        actions.RowKindBranch,
+				Repo:           "tea-dash",
+				RepositoryPath: "/src/tea-dash",
+				Title:          "feature/local-ops",
+			}
+			if got[0].Kind != actions.KindSwitchBranch || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want switch branch target %+v", got[0], wantTarget)
+			}
+		})
+	}
+}
+
+func TestBranchSwitchCurrentBranchShowsNotice(t *testing.T) {
+	var dispatched bool
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	m.actionDispatcher = func(actions.Intent) tea.Cmd {
+		dispatched = true
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+		Repository: "tea-dash", RepositoryPath: "/src/tea-dash",
+		Name: "main", Current: true,
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'C', Text: "C"})
+	if dispatched {
+		t.Fatal("current branch switch must not dispatch")
+	}
+	if m.actionPrompt.Active() {
+		t.Fatal("current branch switch must not open a prompt")
+	}
+	if !strings.Contains(m.notice, "already current") {
+		t.Fatalf("current branch notice = %q", m.notice)
+	}
+	if view := m.View().Content; !strings.Contains(view, "already current") {
+		t.Fatalf("current branch notice should render in the view:\n%s", view)
+	}
+}
+
 func TestHelpKeyTogglesFullHelp(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -1537,6 +1612,35 @@ func TestSuccessfulActionRefreshesRowsAndClearsPreviewCache(t *testing.T) {
 	view := m.View().Content
 	if strings.Contains(view, "staledetailtoken") || !strings.Contains(view, "Loading") {
 		t.Fatalf("successful action should replace stale preview with loading state:\n%s", view)
+	}
+}
+
+func TestSuccessfulBranchSwitchRefreshesBranches(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+		Repository: "tea-dash", RepositoryPath: "/src/tea-dash",
+		Name: "feature/local-ops",
+	}}))
+
+	next, cmd := m.Update(actions.ResultMsg{
+		Intent: actions.Intent{Kind: actions.KindSwitchBranch, Target: actions.Target{
+			SectionID:      0,
+			SectionType:    branchsection.SectionType,
+			RowKind:        actions.RowKindBranch,
+			Repo:           "tea-dash",
+			RepositoryPath: "/src/tea-dash",
+			Title:          "feature/local-ops",
+		}},
+		Status:  actions.ResultSucceeded,
+		Message: "Switched to feature/local-ops in /src/tea-dash.",
+	})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("successful branch switch should refresh the branch section")
+	}
+	if len(m.tasks) != 1 {
+		t.Fatalf("len(tasks) = %d, want branch refresh task registered", len(m.tasks))
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a Branches-view `C` / space action to switch to the selected local branch
- route branch switching through the actionrunner/local-git layer
- refuse current branch switches and surface dirty-tree/worktree conflicts as actionable errors
- refresh the Branches section after a successful switch

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/git ./internal/actionrunner ./internal/ui ./internal/ui/components/branchsection -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`