### PR TITLE
Control Actions runs from the Actions view

### DIFF
--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -27,6 +27,8 @@ type Client interface {
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
+	RerunActionRun(ctx context.Context, owner, repo string, runID int64) error
+	CancelActionRun(ctx context.Context, owner, repo string, runID int64) error
 }
 
 // CheckoutFunc runs or fakes a local PR checkout.
@@ -204,9 +206,30 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 			return "", err
 		}
 		return fmt.Sprintf("Checked out %s in %s.", plan.Branch, plan.RepoPath), nil
+
+	case uiactions.KindRerunRun:
+		runID := targetRunID(intent.Target)
+		if err := r.client.RerunActionRun(ctx, owner, repo, runID); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Rerun requested for %s run #%d.", intent.Target.Repo, intent.Target.Number), nil
+
+	case uiactions.KindCancelRun:
+		runID := targetRunID(intent.Target)
+		if err := r.client.CancelActionRun(ctx, owner, repo, runID); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Cancel requested for %s run #%d.", intent.Target.Repo, intent.Target.Number), nil
 	default:
 		return "", fmt.Errorf("unsupported action %q", intent.Kind)
 	}
+}
+
+func targetRunID(target uiactions.Target) int64 {
+	if target.RunID != 0 {
+		return target.RunID
+	}
+	return target.Number
 }
 
 func (r Runner) setState(owner, repo string, index int64, kind uiactions.RowKind, state data.ItemState) error {
@@ -276,6 +299,10 @@ func actionLabel(kind uiactions.Kind) string {
 		return "checkout"
 	case uiactions.KindSwitchBranch:
 		return "switch branch"
+	case uiactions.KindRerunRun:
+		return "rerun"
+	case uiactions.KindCancelRun:
+		return "cancel run"
 	default:
 		return string(kind)
 	}

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -60,6 +60,19 @@ func branchIntent(kind uiactions.Kind) uiactions.Intent {
 	}
 }
 
+func actionRunIntent(kind uiactions.Kind) uiactions.Intent {
+	return uiactions.Intent{
+		Kind: kind,
+		Target: uiactions.Target{
+			RowKind: uiactions.RowKindActionRun,
+			Repo:    "acme/widgets",
+			Number:  77,
+			RunID:   101,
+			Title:   "CI",
+		},
+	}
+}
+
 func TestDispatchCommentAndClose(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})
@@ -194,6 +207,27 @@ func TestDispatchSwitchBranchDoesNotRequireClient(t *testing.T) {
 	}
 }
 
+func TestDispatchActionRunControlsUseRunID(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	got := runDispatch(t, r, actionRunIntent(uiactions.KindRerunRun))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("rerun result = %+v", got)
+	}
+	if client.rerunRunID != 101 {
+		t.Fatalf("rerunRunID = %d, want 101", client.rerunRunID)
+	}
+
+	got = runDispatch(t, r, actionRunIntent(uiactions.KindCancelRun))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("cancel result = %+v", got)
+	}
+	if client.cancelRunID != 101 {
+		t.Fatalf("cancelRunID = %d, want 101", client.cancelRunID)
+	}
+}
+
 func TestDispatchReturnsErrorResult(t *testing.T) {
 	client := &fakeClient{err: errors.New("boom")}
 	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMerge))
@@ -210,6 +244,8 @@ type fakeClient struct {
 	merge       data.MergeOptions
 	review      data.PullReviewOptions
 	diff        []byte
+	rerunRunID  int64
+	cancelRunID int64
 }
 
 func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
@@ -239,6 +275,16 @@ func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewO
 
 func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {
 	return f.diff, f.err
+}
+
+func (f *fakeClient) RerunActionRun(_ context.Context, _, _ string, runID int64) error {
+	f.rerunRunID = runID
+	return f.err
+}
+
+func (f *fakeClient) CancelActionRun(_ context.Context, _, _ string, runID int64) error {
+	f.cancelRunID = runID
+	return f.err
 }
 
 type fakeShellRunner struct {

--- a/internal/gitea/actions.go
+++ b/internal/gitea/actions.go
@@ -142,6 +142,22 @@ func (c *Client) ListActionJobs(ctx context.Context, owner, repo string, runID i
 	return jobs, nil
 }
 
+// RerunActionRun asks the server to rerun one repo-scoped Actions workflow run.
+func (c *Client) RerunActionRun(ctx context.Context, owner, repo string, runID int64) error {
+	if err := c.rawPost(ctx, actionRunControlPath(owner, repo, runID, "rerun")); err != nil {
+		return fmt.Errorf("rerun action run %s/%s#%d: %w", owner, repo, runID, err)
+	}
+	return nil
+}
+
+// CancelActionRun asks the server to cancel one repo-scoped Actions workflow run.
+func (c *Client) CancelActionRun(ctx context.Context, owner, repo string, runID int64) error {
+	if err := c.rawPost(ctx, actionRunControlPath(owner, repo, runID, "cancel")); err != nil {
+		return fmt.Errorf("cancel action run %s/%s#%d: %w", owner, repo, runID, err)
+	}
+	return nil
+}
+
 func buildActionRunParams(opts ActionRunListOptions) url.Values {
 	q := url.Values{}
 	if opts.Event != "" {
@@ -312,4 +328,8 @@ func actionRunPath(owner, repo string, runID int64) string {
 
 func actionJobsPath(owner, repo string, runID int64) string {
 	return actionRunPath(owner, repo, runID) + "/jobs"
+}
+
+func actionRunControlPath(owner, repo string, runID int64, control string) string {
+	return actionRunPath(owner, repo, runID) + "/" + control
 }

--- a/internal/gitea/actions_test.go
+++ b/internal/gitea/actions_test.go
@@ -211,6 +211,59 @@ func TestListActionJobsMapsWrappedResponse(t *testing.T) {
 	}
 }
 
+func TestRerunActionRunPostsRunControlEndpoint(t *testing.T) {
+	called := false
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101/rerun", func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			if r.Header.Get("Authorization") != "token t" {
+				t.Fatalf("Authorization header = %q, want token auth", r.Header.Get("Authorization"))
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.RerunActionRun(context.Background(), "acme", "widgets", 101); err != nil {
+		t.Fatalf("RerunActionRun: %v", err)
+	}
+	if !called {
+		t.Fatal("rerun endpoint was not called")
+	}
+}
+
+func TestCancelActionRunPostsRunControlEndpoint(t *testing.T) {
+	called := false
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101/cancel", func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.CancelActionRun(context.Background(), "acme", "widgets", 101); err != nil {
+		t.Fatalf("CancelActionRun: %v", err)
+	}
+	if !called {
+		t.Fatal("cancel endpoint was not called")
+	}
+}
+
 func actionServer(t *testing.T, register func(*http.ServeMux)) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -220,6 +220,33 @@ func (c *Client) rawGet(ctx context.Context, path string, out any) (http.Header,
 	return resp.Header, nil
 }
 
+// rawPost issues an authenticated POST against {baseURL}/api/v1{path} using the
+// shared HTTP client and token. It accepts any 2xx response and ignores the
+// body, which matches control endpoints that often return 202 or 204.
+func (c *Client) rawPost(ctx context.Context, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1"+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+c.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("gitea POST %s: %s: %s", path, resp.Status, truncate(body, 500))
+	}
+	return nil
+}
+
 // truncate returns b as a string, clipped to max bytes with an ellipsis marker
 // appended when it was longer, so an HTML error page cannot flood the TUI.
 func truncate(b []byte, max int) string {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -14,6 +14,8 @@ const (
 	KindExternalDiff Kind = "external_diff"
 	KindCheckout     Kind = "checkout"
 	KindSwitchBranch Kind = "switch_branch"
+	KindRerunRun     Kind = "rerun_run"
+	KindCancelRun    Kind = "cancel_run"
 )
 
 // RowKind identifies the selected row's domain type.
@@ -23,6 +25,7 @@ const (
 	RowKindPullRequest RowKind = "pull_request"
 	RowKindIssue       RowKind = "issue"
 	RowKindBranch      RowKind = "branch"
+	RowKindActionRun   RowKind = "action_run"
 )
 
 // PromptMode records which kind of prompt produced a submitted value.
@@ -42,6 +45,7 @@ type Target struct {
 	Repo           string
 	RepositoryPath string
 	Number         int64
+	RunID          int64
 	Title          string
 	URL            string
 }

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -11,6 +11,8 @@ func TestKindConstants(t *testing.T) {
 		KindReview:       "review",
 		KindExternalDiff: "external_diff",
 		KindCheckout:     "checkout",
+		KindRerunRun:     "rerun_run",
+		KindCancelRun:    "cancel_run",
 	}
 	for got, want := range tests {
 		if string(got) != want {
@@ -28,12 +30,14 @@ func TestIntentCarriesTargetAndPrompt(t *testing.T) {
 			RowKind:     RowKindPullRequest,
 			Repo:        "gbarany/tea-dash",
 			Number:      42,
+			RunID:       101,
 			Title:       "Add action UI",
 			URL:         "https://example.test/pr/42",
 		},
 		Prompt: Prompt{Mode: PromptText, Value: "ship it"},
 	}
-	if intent.Kind != KindComment || intent.Target.Repo != "gbarany/tea-dash" || intent.Prompt.Value != "ship it" {
+	if intent.Kind != KindComment || intent.Target.Repo != "gbarany/tea-dash" ||
+		intent.Target.RunID != 101 || intent.Prompt.Value != "ship it" {
 		t.Fatalf("intent did not retain values: %+v", intent)
 	}
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -304,6 +304,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.markSelectedNotificationUnread()
 		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
 			return m.markAllNotificationsRead()
+		case m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.RerunRun):
+			return m, m.startAction(actions.KindRerunRun)
+		case m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.CancelRun):
+			return m, m.startAction(actions.KindCancelRun)
 		case key.Matches(msg, m.keys.Comment):
 			return m, m.startAction(actions.KindComment)
 		case key.Matches(msg, m.keys.Merge):
@@ -451,21 +455,27 @@ func (m Model) View() tea.View {
 func (m Model) helpLine() string {
 	if m.showHelp {
 		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
-		if m.ctx.View == context.NotificationsView {
+		switch m.ctx.View {
+		case context.ActionsView:
+			text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · ctrl+r refresh all · R rerun · ! cancel run · o/enter open · y copy number · Y copy URL"
+		case context.NotificationsView:
 			text += " · m mark read · u mark unread · M mark all read"
-		} else if m.ctx.View == context.BranchesView {
+		case context.BranchesView:
 			text += " · C/space switch"
-		} else {
+		default:
 			text += " · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
 	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
-	if m.ctx.View == context.NotificationsView {
+	switch m.ctx.View {
+	case context.ActionsView:
+		text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r refresh · R rerun · ! cancel"
+	case context.NotificationsView:
 		text += " · m read · u unread · M all read"
-	} else if m.ctx.View == context.BranchesView {
+	case context.BranchesView:
 		text += " · C/space switch"
-	} else {
+	default:
 		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
 	}
 	return text + " · ? help · q quit"
@@ -711,6 +721,9 @@ func (m *Model) clearPreviewCacheForAction(target actions.Target) {
 	case actions.RowKindIssue:
 		delete(m.issueDetails, key)
 		delete(m.issueEnrichErr, key)
+	case actions.RowKindActionRun:
+		delete(m.actionDetails, key)
+		delete(m.actionEnrichErr, key)
 	}
 }
 
@@ -892,6 +905,9 @@ func (m *Model) refreshAllSections() tea.Cmd {
 	case context.IssuesView:
 		m.issueDetails = map[string]*data.IssueDetail{}
 		m.issueEnrichErr = map[string]error{}
+	case context.ActionsView:
+		m.actionDetails = map[string]*data.ActionRunDetail{}
+		m.actionEnrichErr = map[string]error{}
 	default:
 		m.pullDetails = map[string]*data.PullDetail{}
 		m.pullEnrichErr = map[string]error{}
@@ -911,8 +927,8 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 		m.notice = "Select a row before running an action."
 		return nil
 	}
-	if actionRequiresPullRequest(kind) && target.RowKind != actions.RowKindPullRequest {
-		m.notice = fmt.Sprintf("%s is only available for pull requests.", actionLabel(kind))
+	if err := validateActionTarget(kind, target); err != nil {
+		m.notice = err.Error()
 		return nil
 	}
 	if kind == actions.KindSwitchBranch {
@@ -930,6 +946,9 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 		Kind:   kind,
 		Target: target,
 		Prompt: actions.Prompt{Mode: promptModeForAction(kind)},
+	}
+	if actionDispatchesDirectly(kind) {
+		return m.dispatchActionIntent(intent)
 	}
 	m.pendingAction = intent
 	m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(kind, target))
@@ -956,8 +975,7 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		m.notice = "Action not wired yet."
 		return cmd
 	}
-	m.actionFeedback = m.actionFeedback.Set(actionfeedback.Start(actionStartText(intent)))
-	dispatchCmd := m.actionDispatcher(intent)
+	dispatchCmd := m.dispatchActionIntent(intent)
 	if cmd == nil {
 		return dispatchCmd
 	}
@@ -967,6 +985,15 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 	return tea.Batch(cmd, dispatchCmd)
 }
 
+func (m *Model) dispatchActionIntent(intent actions.Intent) tea.Cmd {
+	if m.actionDispatcher == nil {
+		m.notice = "Action not wired yet."
+		return nil
+	}
+	m.actionFeedback = m.actionFeedback.Set(actionfeedback.Start(actionStartText(intent)))
+	return m.actionDispatcher(intent)
+}
+
 func (m Model) selectedActionTarget() (actions.Target, bool) {
 	s := m.getCurrSection()
 	row := m.getCurrRowData()
@@ -974,13 +1001,17 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		return actions.Target{}, false
 	}
 	rowKind := actions.RowKind(s.GetType())
-	switch row.(type) {
+	runID := int64(0)
+	switch r := row.(type) {
 	case data.PullRequest:
 		rowKind = actions.RowKindPullRequest
 	case data.Issue:
 		rowKind = actions.RowKindIssue
 	case localgit.Branch:
 		rowKind = actions.RowKindBranch
+	case data.ActionRun:
+		rowKind = actions.RowKindActionRun
+		runID = r.ID
 	}
 	target := actions.Target{
 		SectionID:   s.GetId(),
@@ -988,6 +1019,7 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		RowKind:     rowKind,
 		Repo:        row.GetRepoNameWithOwner(),
 		Number:      row.GetNumber(),
+		RunID:       runID,
 		Title:       row.GetTitle(),
 		URL:         row.GetURL(),
 	}
@@ -997,13 +1029,28 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 	return target, true
 }
 
-func actionRequiresPullRequest(kind actions.Kind) bool {
+func validateActionTarget(kind actions.Kind, target actions.Target) error {
 	switch kind {
 	case actions.KindMerge, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
-		return true
+		if target.RowKind != actions.RowKindPullRequest {
+			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
+		}
+	case actions.KindComment, actions.KindClose, actions.KindReopen:
+		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
+			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
+		}
+	case actions.KindRerunRun, actions.KindCancelRun:
+		if target.RowKind != actions.RowKindActionRun {
+			return fmt.Errorf("%s is only available for action runs.", actionLabel(kind))
+		}
 	default:
-		return false
+		return nil
 	}
+	return nil
+}
+
+func actionDispatchesDirectly(kind actions.Kind) bool {
+	return kind == actions.KindRerunRun
 }
 
 func promptModeForAction(kind actions.Kind) actions.PromptMode {
@@ -1055,6 +1102,12 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
 			},
 		}
+	case actions.KindCancelRun:
+		return actionprompt.Config{
+			Mode:    actionprompt.ModeConfirm,
+			Title:   title,
+			Message: fmt.Sprintf("Cancel %s run #%d - %s", target.Repo, target.Number, target.Title),
+		}
 	default:
 		return actionprompt.Config{
 			Mode:    actionprompt.ModeConfirm,
@@ -1082,6 +1135,10 @@ func actionLabel(kind actions.Kind) string {
 		return "Checkout"
 	case actions.KindSwitchBranch:
 		return "Switch branch"
+	case actions.KindRerunRun:
+		return "Rerun"
+	case actions.KindCancelRun:
+		return "Cancel run"
 	default:
 		return string(kind)
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1367,6 +1367,85 @@ func TestBranchSwitchHotkeysDispatchExpectedIntent(t *testing.T) {
 	}
 }
 
+func TestActionsViewRunControlKeysDispatchExpectedIntents(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        tea.KeyPressMsg
+		kind       actions.Kind
+		direct     bool
+		wantPrompt actions.Prompt
+	}{
+		{
+			name:   "rerun",
+			key:    tea.KeyPressMsg{Code: 'R', Text: "R"},
+			kind:   actions.KindRerunRun,
+			direct: true,
+		},
+		{
+			name: "cancel",
+			key:  tea.KeyPressMsg{Code: '!', Text: "!"},
+			kind: actions.KindCancelRun,
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptConfirm,
+				Value: "confirm",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{
+				Defaults: config.Defaults{View: "actions"},
+				ActionsSections: []config.SectionConfig{{
+					Title: "CI", Repo: "gbarany/tea-dash",
+				}},
+			}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+				ID: 101, RunNumber: 77, DisplayTitle: "Action row", WorkflowName: "CI",
+				RepoNameWithOwner: "gbarany/tea-dash", HTMLURL: "https://example.test/gbarany/tea-dash/actions/runs/101",
+			}}))
+
+			m = update(t, m, tt.key)
+			if tt.direct {
+				if m.actionPrompt.Active() {
+					t.Fatalf("%s key should dispatch directly without a prompt", tt.name)
+				}
+			} else {
+				if !m.actionPrompt.Active() {
+					t.Fatalf("%s key should open a confirmation prompt", tt.name)
+				}
+				m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:   0,
+				SectionType: actionsection.SectionType,
+				RowKind:     actions.RowKindActionRun,
+				Repo:        "gbarany/tea-dash",
+				Number:      77,
+				RunID:       101,
+				Title:       "Action row",
+				URL:         "https://example.test/gbarany/tea-dash/actions/runs/101",
+			}
+			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want kind %q target %+v", got[0], tt.kind, wantTarget)
+			}
+			if tt.wantPrompt != (actions.Prompt{}) && got[0].Prompt != tt.wantPrompt {
+				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
+			}
+		})
+	}
+}
+
 func TestBranchSwitchCurrentBranchShowsNotice(t *testing.T) {
 	var dispatched bool
 	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
@@ -1428,6 +1507,24 @@ func TestNotificationsHelpShowsUnreadShortcut(t *testing.T) {
 	}
 }
 
+func TestActionsHelpShowsRunControlsAndRefreshAllFallback(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI", Repo: "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	view := m.View().Content
+	for _, want := range []string{"R rerun", "! cancel run", "ctrl+r refresh all"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("actions full help missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestRefreshAllFetchesEveryCurrentSection(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{
@@ -1465,6 +1562,45 @@ func TestRefreshAllFetchesEveryCurrentSection(t *testing.T) {
 	}
 	if len(m.tasks) != 2 {
 		t.Fatalf("len(tasks) = %d, want both sections to register refresh tasks", len(m.tasks))
+	}
+}
+
+func TestActionsViewRefreshAllUsesCtrlRBecauseRerunIsScopedToR(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{
+			{Title: "CI", Repo: "gbarany/tea-dash"},
+			{Title: "Nightly", Repo: "gbarany/tea-dash"},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 0, SectionType: actionsection.SectionType, TaskId: "a0",
+		Msg: actionsection.SectionActionsFetchedMsg{
+			Rows: []data.ActionRun{{
+				ID: 101, RunNumber: 77, DisplayTitle: "First row", RepoNameWithOwner: "gbarany/tea-dash",
+			}},
+			TotalCount: 1, TaskId: "a0",
+		},
+	})
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId: 1, SectionType: actionsection.SectionType, TaskId: "a1",
+		Msg: actionsection.SectionActionsFetchedMsg{
+			Rows: []data.ActionRun{{
+				ID: 102, RunNumber: 78, DisplayTitle: "Second row", RepoNameWithOwner: "gbarany/tea-dash",
+			}},
+			TotalCount: 1, TaskId: "a1",
+		},
+	})
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("ctrl+r should batch refresh commands for all Actions sections")
+	}
+	if len(m.tasks) != 2 {
+		t.Fatalf("len(tasks) = %d, want both Actions sections to register refresh tasks", len(m.tasks))
 	}
 }
 
@@ -1641,6 +1777,44 @@ func TestSuccessfulBranchSwitchRefreshesBranches(t *testing.T) {
 	}
 	if len(m.tasks) != 1 {
 		t.Fatalf("len(tasks) = %d, want branch refresh task registered", len(m.tasks))
+	}
+}
+
+func TestSuccessfulActionRunControlRefreshesActionsAndClearsPreviewCache(t *testing.T) {
+	m := New(&config.Config{
+		Defaults: config.Defaults{View: "actions"},
+		ActionsSections: []config.SectionConfig{{
+			Title: "CI", Repo: "gbarany/tea-dash",
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "Action row", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash",
+	}}))
+	key := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:    key,
+		action: &data.ActionRunDetail{Run: data.ActionRun{ID: 101, DisplayTitle: "staledetailtoken"}},
+	})
+	if _, ok := m.actionDetails[key]; !ok {
+		t.Fatalf("test setup: expected cached action detail for %q", key)
+	}
+
+	next, cmd := m.Update(actions.ResultMsg{
+		Intent: actions.Intent{Kind: actions.KindRerunRun, Target: actions.Target{
+			SectionID: 0, SectionType: actionsection.SectionType, RowKind: actions.RowKindActionRun,
+			Repo: "gbarany/tea-dash", Number: 77, RunID: 101,
+		}},
+		Status:  actions.ResultSucceeded,
+		Message: "Rerun requested for gbarany/tea-dash run #77.",
+	})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("successful action run control should refresh the affected Actions section")
+	}
+	if _, ok := m.actionDetails[key]; ok {
+		t.Fatalf("successful action run control should clear cached action detail for %q", key)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -24,6 +24,8 @@ type keyMap struct {
 	Review        key.Binding
 	ExternalDiff  key.Binding
 	Checkout      key.Binding
+	RerunRun      key.Binding
+	CancelRun     key.Binding
 	CopyNumber    key.Binding
 	CopyURL       key.Binding
 	Help          key.Binding
@@ -39,7 +41,7 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("r", "refresh"),
 		),
 		RefreshAll: key.NewBinding(
-			key.WithKeys("R"),
+			key.WithKeys("R", "ctrl+r"),
 			key.WithHelp("R", "refresh all"),
 		),
 		Open: key.NewBinding(
@@ -109,6 +111,14 @@ func defaultKeyMap() keyMap {
 		Checkout: key.NewBinding(
 			key.WithKeys("C", " ", "space"),
 			key.WithHelp("C/space", "checkout"),
+		),
+		RerunRun: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "rerun"),
+		),
+		CancelRun: key.NewBinding(
+			key.WithKeys("!"),
+			key.WithHelp("!", "cancel run"),
 		),
 		CopyNumber: key.NewBinding(
 			key.WithKeys("y"),


### PR DESCRIPTION
## Summary

- add Actions-view run controls: `R` reruns the selected run, `!` cancels with confirmation
- add raw Gitea REST helpers for rerun/cancel run endpoints
- keep API `run_id` separate from displayed `run_number`
- refresh Actions rows and clear stale Actions preview detail after successful controls
- preserve `ctrl+r` as refresh-all in Actions view because `R` is scoped to rerun there

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/gitea ./internal/actionrunner ./internal/ui ./internal/ui/actions -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`