### PR TITLE
Progressively load PR and issue pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ leaving the terminal.
 > pull requests, issues, unread notifications, Actions runs, and read-only local
 > branch status (fetched via the Gitea API (Go SDK + REST) and local `git`),
 > with view switching (`s`), configurable sections you page through with `h`/`l`,
-> live keyword search (`/`), a default-open preview, and PR / issue actions. See
-> [`docs/architecture.md`](docs/architecture.md) for the design.
+> live keyword search (`/`), progressive PR/issue loading, a default-open
+> preview, and PR / issue actions. See [`docs/architecture.md`](docs/architecture.md)
+> for the design.
 
 ## Why
 
@@ -86,11 +87,13 @@ tea-dash --help
 | `y` / `Y`       | copy row number / URL   |
 | `c`             | add comment             |
 | `m`             | merge PR                |
+| `m` / `u` / `M` | mark notification read / unread / all read |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
 | `d` / `ctrl+t`  | open PR diff in external pager |
-| `C` / `space`   | checkout PR locally     |
-| `r` / `R`       | refresh section / all sections |
+| `C` / `space`   | checkout PR locally; switch branch in Branches view |
+| `R` / `!`       | rerun / cancel Actions run |
+| `r` / `R`       | refresh section / all sections (`ctrl+r` refreshes all in Actions view) |
 | `?`             | show / hide full help   |
 | `q` / `ctrl+c`  | quit                    |
 
@@ -113,8 +116,8 @@ instance:
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
-  prsLimit: 50           # rows fetched per PR section (0 -> 50)
-  issuesLimit: 50        # rows fetched per issue section (0 -> 50)
+  prsLimit: 50           # PR page size; more rows load when you reach the bottom (0 -> 50)
+  issuesLimit: 50        # issue page size; more rows load when you reach the bottom (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
   actionsLimit: 50       # rows fetched per Actions section (0 -> 50)
   branchesLimit: 0       # local branches shown (0 -> all)
@@ -148,7 +151,7 @@ prSections:
   - title: Review Requested
     filter:
       reviewRequested: "@me"
-    limit: 25              # per-section cap; overrides defaults.prsLimit
+    limit: 25              # per-section page size; overrides defaults.prsLimit
 
 issuesSections:
   - title: My Issues
@@ -168,7 +171,9 @@ branchSections:
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),
-`sort`. The row cap follows section `limit` -> per-view default -> 50.
+`sort`. PR and issue sections fetch one page at a time; reaching the loaded
+bottom automatically requests the next page until the server total is loaded.
+The page size follows section `limit` -> per-view default -> 50.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` only — a plain login is

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -51,6 +51,10 @@ func isMe(s string) bool { return s == "@me" }
 // created_by/assigned_by params, which the search endpoint ignores — this is
 // the C1 guard. limit is clamped to a positive value (default 50).
 func buildSearchParams(f config.PrIssueFilter, limit int) url.Values {
+	return buildSearchParamsPage(f, limit, 0)
+}
+
+func buildSearchParamsPage(f config.PrIssueFilter, limit, page int) url.Values {
 	q := url.Values{}
 	q.Set("type", f.Type)
 	q.Set("state", f.State)
@@ -85,16 +89,24 @@ func buildSearchParams(f config.PrIssueFilter, limit int) url.Values {
 		limit = 50
 	}
 	q.Set("limit", strconv.Itoa(limit))
+	if page > 0 {
+		q.Set("page", strconv.Itoa(page))
+	}
 	return q
 }
 
 // search runs one page of the cross-repo /repos/issues/search endpoint for the
 // given filter and returns the raw rows plus the server's total (from the
 // X-Total-Count header, falling back to the returned row count). The page is
-// capped at limit (full pagination is deferred), so total may exceed len(rows).
+// capped at limit, so total may exceed len(rows) until callers request later
+// pages.
 func (c *Client) search(ctx context.Context, f config.PrIssueFilter, limit int) ([]searchIssue, int, error) {
+	return c.searchPage(ctx, f, limit, 0)
+}
+
+func (c *Client) searchPage(ctx context.Context, f config.PrIssueFilter, limit, page int) ([]searchIssue, int, error) {
 	var rows []searchIssue
-	header, err := c.rawGet(ctx, "/repos/issues/search?"+buildSearchParams(f, limit).Encode(), &rows)
+	header, err := c.rawGet(ctx, "/repos/issues/search?"+buildSearchParamsPage(f, limit, page).Encode(), &rows)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -111,8 +123,12 @@ func (c *Client) search(ctx context.Context, f config.PrIssueFilter, limit int) 
 // plus the server's total count. f.Type is forced to "pulls" and the "open"
 // state default is applied. limit caps the page (0 -> buildSearchParams' 50).
 func (c *Client) SearchPulls(ctx context.Context, f config.PrIssueFilter, limit int) ([]data.PullRequest, int, error) {
+	return c.SearchPullsPage(ctx, f, limit, 0)
+}
+
+func (c *Client) SearchPullsPage(ctx context.Context, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
 	f = f.WithDefaults("pulls")
-	rows, total, err := c.search(ctx, f, limit)
+	rows, total, err := c.searchPage(ctx, f, limit, page)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -127,8 +143,12 @@ func (c *Client) SearchPulls(ctx context.Context, f config.PrIssueFilter, limit 
 // the server's total count. f.Type is forced to "issues" and the "open" state
 // default is applied. limit caps the page (0 -> buildSearchParams' 50).
 func (c *Client) SearchIssues(ctx context.Context, f config.PrIssueFilter, limit int) ([]data.Issue, int, error) {
+	return c.SearchIssuesPage(ctx, f, limit, 0)
+}
+
+func (c *Client) SearchIssuesPage(ctx context.Context, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
 	f = f.WithDefaults("issues")
-	rows, total, err := c.search(ctx, f, limit)
+	rows, total, err := c.searchPage(ctx, f, limit, page)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/gitea/search_test.go
+++ b/internal/gitea/search_test.go
@@ -166,6 +166,31 @@ func TestSearchPullsLimitReachesQuery(t *testing.T) {
 	}
 }
 
+func TestSearchPullsPageReachesQuery(t *testing.T) {
+	var gotQuery string
+	srv := searchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("X-Total-Count", "75")
+		fmt.Fprint(w, searchJSON)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, total, err := c.SearchPullsPage(context.Background(), config.PrIssueFilter{State: "open", CreatedBy: "@me"}, 25, 3); err != nil {
+		t.Fatalf("SearchPullsPage: %v", err)
+	} else if total != 75 {
+		t.Fatalf("total = %d, want 75", total)
+	}
+	for _, want := range []string{"limit=25", "page=3"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
 func TestSearchIssues(t *testing.T) {
 	var gotQuery string
 	srv := searchServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -809,11 +809,12 @@ func (m Model) selectRowFromMouse(x, y int) (Model, tea.Cmd) {
 	s := m.getCurrSection()
 	before := m.selKey()
 	s.SelectRow(i)
+	moreCmd := s.MaybeFetchNextPage()
 	if !m.ctx.PreviewOpen || m.selKey() == before {
-		return m, nil
+		return m, moreCmd
 	}
 	m.syncSidebar()
-	return m, m.enrichCurrRow()
+	return m, tea.Batch(moreCmd, m.enrichCurrRow())
 }
 
 func (m Model) handleMouseClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {

--- a/internal/ui/components/actionsection/actionsection.go
+++ b/internal/ui/components/actionsection/actionsection.go
@@ -46,7 +46,7 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "action run",
 		PluralForm:   "action runs",
 		Limit:        func(c *config.Config) int { return c.Defaults.ActionsLimit },
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.ActionRun, int, error) {
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, _ int) ([]data.ActionRun, int, error) {
 			repoRef := strings.TrimSpace(cfg.Repo)
 			if repoRef == "" {
 				return nil, 0, nil

--- a/internal/ui/components/branchsection/branchsection.go
+++ b/internal/ui/components/branchsection/branchsection.go
@@ -42,7 +42,7 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "branch",
 		PluralForm:   "branches",
 		Limit:        func(c *config.Config) int { return c.Defaults.BranchesLimit },
-		Fetch: func(fetchCtx stdctx.Context, _ *gitea.Client, _ config.PrIssueFilter, limit int) ([]localgit.Branch, int, error) {
+		Fetch: func(fetchCtx stdctx.Context, _ *gitea.Client, _ config.PrIssueFilter, limit, _ int) ([]localgit.Branch, int, error) {
 			repos, err := repositoriesFromConfig(ctx.Config, os.Getwd)
 			if err != nil {
 				return nil, 0, err

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -38,8 +38,9 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "issue",
 		PluralForm:   "issues",
 		Limit:        func(c *config.Config) int { return c.Defaults.IssuesLimit },
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.Issue, int, error) {
-			return c.SearchIssues(ctx, f, limit)
+		Pageable:     true,
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
+			return c.SearchIssuesPage(ctx, f, limit, page)
 		},
 		BuildRow: issueBuildRow,
 	})

--- a/internal/ui/components/notificationsection/notificationsection.go
+++ b/internal/ui/components/notificationsection/notificationsection.go
@@ -40,7 +40,7 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "notification",
 		PluralForm:   "notifications",
 		Limit:        func(c *config.Config) int { return c.Defaults.NotificationsLimit },
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, _ config.PrIssueFilter, limit int) ([]data.Notification, int, error) {
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, _ config.PrIssueFilter, limit, _ int) ([]data.Notification, int, error) {
 			return c.ListNotifications(ctx, limit)
 		},
 		BuildRow: notificationBuildRow,

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -38,8 +38,9 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "pull request",
 		PluralForm:   "pull requests",
 		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit int) ([]data.PullRequest, int, error) {
-			return c.SearchPulls(ctx, f, limit)
+		Pageable:     true,
+		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
+			return c.SearchPullsPage(ctx, f, limit, page)
 		},
 		BuildRow: prBuildRow,
 	})

--- a/internal/ui/components/section/model.go
+++ b/internal/ui/components/section/model.go
@@ -22,6 +22,8 @@ type RowsFetchedMsg[T data.RowData] struct {
 	Rows       []T
 	TotalCount int
 	TaskId     string
+	Page       int
+	Append     bool
 	Err        error
 }
 
@@ -43,20 +45,24 @@ type Options[T data.RowData] struct {
 	SingularForm string
 	PluralForm   string
 
-	Fetch    func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int) ([]T, int, error)
+	Fetch    func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
 	BuildRow func(T) table.Row
 	Limit    func(*config.Config) int
+	Pageable bool
 }
 
 // Model is the generic dashboard section shared by the pull-request and issue
 // views. It embeds BaseModel and holds the per-type seams.
 type Model[T data.RowData] struct {
 	BaseModel
-	rows       []T
-	fetch      func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int) ([]T, int, error)
-	buildRow   func(T) table.Row
-	limitFn    func(*config.Config) int
-	filterKind string
+	rows        []T
+	fetch       func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
+	buildRow    func(T) table.Row
+	limitFn     func(*config.Config) int
+	filterKind  string
+	page        int
+	loadingMore bool
+	pageable    bool
 }
 
 // compile-time interface assertions
@@ -93,17 +99,51 @@ func New[T data.RowData](o Options[T]) *Model[T] {
 	m.buildRow = o.BuildRow
 	m.limitFn = o.Limit
 	m.filterKind = o.FilterKind
+	m.pageable = o.Pageable
 	return m
 }
 
 // FetchRows fetches the current user's rows across all repos.
 func (m *Model[T]) FetchRows() tea.Cmd {
+	m.page = 0
+	m.loadingMore = false
+	return m.fetchPage(1, false)
+}
+
+func (m *Model[T]) MaybeFetchNextPage() tea.Cmd {
+	if m.GetIsLoading() || m.GetError() != nil || m.loadingMore {
+		return nil
+	}
+	if !m.pageable {
+		return nil
+	}
+	if len(m.rows) == 0 || len(m.rows) >= m.GetTotalCount() {
+		return nil
+	}
+	if m.CurrRow() < len(m.rows)-1 {
+		return nil
+	}
+	nextPage := m.page + 1
+	if nextPage <= 1 {
+		nextPage = 2
+	}
+	return m.fetchPage(nextPage, true)
+}
+
+func (m *Model[T]) fetchPage(page int, appendRows bool) tea.Cmd {
 	taskId := fmt.Sprintf("fetch-%s-%d-%d", m.GetType(), m.GetId(), time.Now().UnixNano())
 	m.SetLastFetchID(taskId)
-	m.SetIsLoading(true)
+	if appendRows {
+		m.loadingMore = true
+	} else {
+		m.SetIsLoading(true)
+	}
 	client := m.Ctx.Client
 	id, sType := m.GetId(), m.GetType()
-	start := m.Ctx.StartTask(appctx.Task{Id: taskId, StartText: m.loadingText, State: appctx.TaskStart})
+	var start tea.Cmd
+	if m.Ctx.StartTask != nil {
+		start = m.Ctx.StartTask(appctx.Task{Id: taskId, StartText: m.loadingText, State: appctx.TaskStart})
+	}
 	f := m.Config.Filter.WithDefaults(m.filterKind)
 	limit := m.Config.Limit
 	if limit == 0 && m.Ctx.Config != nil {
@@ -112,10 +152,13 @@ func (m *Model[T]) FetchRows() tea.Cmd {
 	fetch := func() tea.Msg {
 		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), fetchTimeout)
 		defer cancel()
-		rows, total, err := m.fetch(ctx, client, f, limit)
+		rows, total, err := m.fetch(ctx, client, f, limit, page)
 		return appctx.TaskFinishedMsg{
 			SectionId: id, SectionType: sType, TaskId: taskId,
-			Msg: RowsFetchedMsg[T]{Rows: rows, TotalCount: total, TaskId: taskId, Err: err},
+			Msg: RowsFetchedMsg[T]{
+				Rows: rows, TotalCount: total, TaskId: taskId,
+				Page: page, Append: appendRows, Err: err,
+			},
 		}
 	}
 	return tea.Batch(start, m.Spinner.Tick, fetch)
@@ -147,12 +190,25 @@ func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
 		if m.LastFetchID() != "" && m.LastFetchID() != msg.TaskId {
 			return m, nil // stale/superseded fetch
 		}
-		m.SetIsLoading(false)
+		if msg.Append {
+			m.loadingMore = false
+		} else {
+			m.SetIsLoading(false)
+		}
 		if msg.Err != nil {
 			m.SetError(msg.Err)
 			return m, nil
 		}
-		m.rows = msg.Rows
+		if msg.Append {
+			m.rows = append(m.rows, msg.Rows...)
+		} else {
+			m.rows = msg.Rows
+		}
+		if msg.Page > 0 {
+			m.page = msg.Page
+		} else if !msg.Append {
+			m.page = 1
+		}
 		m.SetTotalCount(msg.TotalCount)
 		m.SetError(nil)
 		// SetRows clamps but does not reset the cursor, so a refresh keeps the
@@ -175,7 +231,7 @@ func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
 	}
 	var cmd tea.Cmd
 	m.Table, cmd = m.Table.Update(msg)
-	return m, cmd
+	return m, tea.Batch(cmd, m.MaybeFetchNextPage())
 }
 
 // UpdateProgramContext resizes the table and refreshes columns for the new width.

--- a/internal/ui/components/section/model_test.go
+++ b/internal/ui/components/section/model_test.go
@@ -1,0 +1,113 @@
+package section
+
+import (
+	stdctx "context"
+	"testing"
+
+	"charm.land/bubbles/v2/table"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
+	appctx "github.com/gbarany/tea-dash/internal/ui/context"
+)
+
+func TestModelFetchesNextPageAtBottomAndAppendsRows(t *testing.T) {
+	var pages []int
+	ctx := &appctx.ProgramContext{
+		Styles:           contextStyles(t),
+		MainContentWidth: 100, MainContentHeight: 20,
+		Config:    &config.Config{Defaults: config.Defaults{PRsLimit: 1}},
+		StartTask: func(appctx.Task) tea.Cmd { return nil },
+	}
+	m := New(Options[data.PullRequest]{
+		Id:           0,
+		Type:         "pr",
+		FilterKind:   "pulls",
+		Ctx:          ctx,
+		Config:       config.SectionConfig{Title: "PRs"},
+		LoadingText:  "Loading pull requests…",
+		EmptyText:    "No pull requests.",
+		EmptyHint:    "Try another filter.",
+		SingularForm: "pull request",
+		PluralForm:   "pull requests",
+		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
+		Pageable:     true,
+		Fetch: func(_ stdctx.Context, _ *gitea.Client, _ config.PrIssueFilter, _ int, page int) ([]data.PullRequest, int, error) {
+			pages = append(pages, page)
+			return []data.PullRequest{{
+				Number: int64(page), Title: "page row",
+				RepoNameWithOwner: "gbarany/tea-dash",
+			}}, 2, nil
+		},
+		BuildRow: func(pr data.PullRequest) table.Row {
+			return table.Row{pr.GetTitle()}
+		},
+	})
+	m.SetLastFetchID("t1")
+	next, _ := m.Update(RowsFetchedMsg[data.PullRequest]{
+		Rows: []data.PullRequest{{
+			Number: 1, Title: "first",
+			RepoNameWithOwner: "gbarany/tea-dash",
+		}},
+		TotalCount: 2,
+		TaskId:     "t1",
+		Page:       1,
+	})
+	m = next.(*Model[data.PullRequest])
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = next.(*Model[data.PullRequest])
+	if cmd == nil {
+		t.Fatal("moving at the bottom with more rows should start fetching the next page")
+	}
+	msg := runFetchCommand(t, cmd)
+	finished, ok := msg.(appctx.TaskFinishedMsg)
+	if !ok {
+		t.Fatalf("fetch command returned %T, want TaskFinishedMsg", msg)
+	}
+	fetched, ok := finished.Msg.(RowsFetchedMsg[data.PullRequest])
+	if !ok {
+		t.Fatalf("finished payload = %T, want RowsFetchedMsg[data.PullRequest]", finished.Msg)
+	}
+	if !fetched.Append || fetched.Page != 2 {
+		t.Fatalf("fetched Append=%v Page=%d, want append page 2", fetched.Append, fetched.Page)
+	}
+	next, _ = m.Update(fetched)
+	m = next.(*Model[data.PullRequest])
+
+	if got := m.NumRows(); got != 2 {
+		t.Fatalf("NumRows = %d, want appended rows count 2", got)
+	}
+	if len(pages) != 1 || pages[0] != 2 {
+		t.Fatalf("fetched pages = %v, want [2]", pages)
+	}
+	if cmd := m.MaybeFetchNextPage(); cmd != nil {
+		t.Fatal("all rows are loaded; MaybeFetchNextPage should return nil")
+	}
+}
+
+func runFetchCommand(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if msg := c(); msg != nil {
+				if _, ok := msg.(appctx.TaskFinishedMsg); ok {
+					return msg
+				}
+			}
+		}
+		t.Fatal("batch did not include a TaskFinishedMsg")
+	}
+	return msg
+}
+
+func contextStyles(t *testing.T) appctx.Styles {
+	t.Helper()
+	return appctx.DefaultStyles()
+}

--- a/internal/ui/components/section/section.go
+++ b/internal/ui/components/section/section.go
@@ -32,6 +32,7 @@ type Section interface {
 	GetCurrRow() data.RowData
 	SelectRow(index int)
 	FetchRows() tea.Cmd
+	MaybeFetchNextPage() tea.Cmd
 
 	GetItemSingular() string
 	GetItemPlural() string
@@ -133,6 +134,10 @@ func (m *BaseModel) CurrRow() int { return m.Table.Cursor() }
 
 // SelectRow moves the table cursor to index, clamping to the available rows.
 func (m *BaseModel) SelectRow(index int) { m.Table.SetCursor(index) }
+
+// MaybeFetchNextPage is a no-op for sections that do not support progressive
+// pagination.
+func (m *BaseModel) MaybeFetchNextPage() tea.Cmd { return nil }
 
 // IsSearchFocused reports whether the embedded search bar is currently active.
 func (m *BaseModel) IsSearchFocused() bool { return m.isSearching }


### PR DESCRIPTION
## Summary

- add page-aware Gitea search wrappers for pull requests and issues
- make the generic PR/issue section append the next page when the selected row reaches the loaded bottom
- trigger the same next-page check for keyboard navigation, mouse wheel movement, and mouse row clicks
- keep Actions, Notifications, and Branches non-pageable for now via an explicit opt-in flag
- update README wording: PR/issue limits are page sizes, not hard caps

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/gitea ./internal/ui ./internal/ui/components/section ./internal/ui/components/pullsection ./internal/ui/components/issuesection ./internal/ui/components/actionsection ./internal/ui/components/notificationsection ./internal/ui/components/branchsection -v`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`

## Smoke note

Attempted to launch in tmux pane `main:9.3`, but `op read` could not connect to the 1Password desktop app in this session, so the token substitution failed before tea-dash could authenticate.