### PR TITLE
Add configurable keybindings and custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ instance:
   # token:        ""                                   # a literal token (not recommended in plaintext)
   # tokenCommand: op read "op://Private/tea-dash/credential"   # e.g. 1Password, pass, gopass
   # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
+  # Example for 1Password:
+  # tokenCommand: op read "op://Appic/tea-dash PAT/credential"
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
@@ -167,6 +169,31 @@ notificationsSections:
 
 branchSections:
   - title: Local Branches
+
+keybindings:
+  universal:
+    - key: tab
+      builtin: nextSection
+    - key: H
+      builtin: help
+  prs:
+    - key: O
+      builtin: checkout
+    - key: g
+      name: lazygit
+      command: cd {{.RepoPath}} && lazygit
+  issues:
+    - key: i
+      command: echo issue {{.IssueNumber}} in {{.RepoName}}
+  notifications:
+    - key: D
+      builtin: markAllRead
+  actions:
+    - key: a
+      command: echo run {{.RunID}} in {{.RepoName}}
+  branches:
+    - key: B
+      command: git -C {{.RepoPath}} status
 ```
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
@@ -174,6 +201,12 @@ branchSections:
 `sort`. PR and issue sections fetch one page at a time; reaching the loaded
 bottom automatically requests the next page until the server total is loaded.
 The page size follows section `limit` -> per-view default -> 50.
+
+`keybindings` follows gh-dash's shape: each entry has a `key`, optional `name`,
+and exactly one of `builtin` or `command`. Built-ins remap implemented tea-dash
+actions; commands run through your shell with row template fields such as
+`RepoName`, `RepoPath`, `PrIndex`/`PrNumber`, `IssueIndex`/`IssueNumber`,
+`RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `Url`/`URL`.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` only — a plain login is

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -3,9 +3,12 @@
 package actionrunner
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
+	"text/template"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -37,6 +40,10 @@ type CheckoutFunc func(context.Context, localgit.CheckoutOptions) (localgit.Chec
 // BranchSwitchFunc runs or fakes a local branch switch.
 type BranchSwitchFunc func(context.Context, localgit.SwitchBranchOptions) (localgit.SwitchBranchResult, error)
 
+// ExecProcessFunc wraps Bubble Tea's ExecProcess for interactive shell
+// commands. Tests replace it to avoid running a real process.
+type ExecProcessFunc func(*exec.Cmd, tea.ExecCallback) tea.Cmd
+
 // Options configures a Runner.
 type Options struct {
 	Client       Client
@@ -47,6 +54,7 @@ type Options struct {
 	GitRunner    localgit.Runner
 	Checkout     CheckoutFunc
 	BranchSwitch BranchSwitchFunc
+	ExecProcess  ExecProcessFunc
 }
 
 // Runner executes actions and returns ResultMsg values for the UI.
@@ -59,6 +67,7 @@ type Runner struct {
 	gitRunner    localgit.Runner
 	checkout     CheckoutFunc
 	branchSwitch BranchSwitchFunc
+	execProcess  ExecProcessFunc
 }
 
 // New constructs a Runner with production defaults for omitted runners.
@@ -79,6 +88,10 @@ func New(opts Options) Runner {
 	if branchSwitch == nil {
 		branchSwitch = localgit.SwitchBranch
 	}
+	execProcess := opts.ExecProcess
+	if execProcess == nil {
+		execProcess = tea.ExecProcess
+	}
 	return Runner{
 		client:       opts.Client,
 		cfg:          cfg,
@@ -88,12 +101,16 @@ func New(opts Options) Runner {
 		gitRunner:    opts.GitRunner,
 		checkout:     checkout,
 		branchSwitch: branchSwitch,
+		execProcess:  execProcess,
 	}
 }
 
 // Dispatch returns a Bubble Tea command that executes intent off the update
 // path and reports the result back as actions.ResultMsg.
 func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
+	if intent.Kind == uiactions.KindCustomCommand {
+		return r.dispatchCustomCommand(intent)
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
@@ -103,6 +120,38 @@ func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
 			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
 		}
 		return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultSucceeded, Message: message}
+	}
+}
+
+func (r Runner) dispatchCustomCommand(intent uiactions.Intent) tea.Cmd {
+	command := strings.TrimSpace(intent.Command)
+	if command == "" {
+		return actionResult(intent, uiactions.ResultErrored, "", fmt.Errorf("custom command is empty"))
+	}
+	rendered, err := r.renderCustomCommand(command, intent.Target)
+	if err != nil {
+		return actionResult(intent, uiactions.ResultErrored, "", err)
+	}
+	dir := intent.Target.RepositoryPath
+	if dir == "" {
+		dir = r.cwd
+	}
+	cmd := shell.BuildExecCommand(rendered, nil, dir)
+	name := strings.TrimSpace(intent.Name)
+	if name == "" {
+		name = "custom command"
+	}
+	return r.execProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("run custom command %q: %w", command, err)}
+		}
+		return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultSucceeded, Message: fmt.Sprintf("Ran %s for %s.", name, intent.Target.Title)}
+	})
+}
+
+func actionResult(intent uiactions.Intent, status uiactions.ResultStatus, message string, err error) tea.Cmd {
+	return func() tea.Msg {
+		return uiactions.ResultMsg{Intent: intent, Status: status, Message: message, Err: err}
 	}
 }
 
@@ -223,6 +272,58 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 	default:
 		return "", fmt.Errorf("unsupported action %q", intent.Kind)
 	}
+}
+
+type customCommandContext struct {
+	RepoName    string
+	RepoPath    string
+	Number      int64
+	PrIndex     int64
+	PrNumber    int64
+	IssueIndex  int64
+	IssueNumber int64
+	RunID       int64
+	Title       string
+	IssueTitle  string
+	BranchName  string
+	Author      string
+	Sha         string
+	SHA         string
+	InstanceURL string
+	URL         string
+	Url         string
+}
+
+func (r Runner) renderCustomCommand(command string, target uiactions.Target) (string, error) {
+	tmpl, err := template.New("custom-command").Option("missingkey=error").Parse(command)
+	if err != nil {
+		return "", fmt.Errorf("parse custom command template: %w", err)
+	}
+	url := target.URL
+	ctx := customCommandContext{
+		RepoName:    target.Repo,
+		RepoPath:    target.RepositoryPath,
+		Number:      target.Number,
+		PrIndex:     target.Number,
+		PrNumber:    target.Number,
+		IssueIndex:  target.Number,
+		IssueNumber: target.Number,
+		RunID:       targetRunID(target),
+		Title:       target.Title,
+		IssueTitle:  target.Title,
+		BranchName:  target.Title,
+		Author:      target.Author,
+		Sha:         target.SHA,
+		SHA:         target.SHA,
+		InstanceURL: r.instanceURL,
+		URL:         url,
+		Url:         url,
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		return "", fmt.Errorf("render custom command template: %w", err)
+	}
+	return buf.String(), nil
 }
 
 func targetRunID(target uiactions.Target) int64 {

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -3,6 +3,7 @@ package actionrunner
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -162,6 +163,59 @@ func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
 	}
 }
 
+func TestDispatchCustomCommandRendersSelectedRowTemplate(t *testing.T) {
+	execProcess := &fakeExecProcess{}
+	r := New(Options{
+		Config:      &config.Config{},
+		InstanceURL: "https://git.example",
+		CWD:         "/fallback",
+		ExecProcess: execProcess.Run,
+	})
+	intent := pullIntent(uiactions.KindCustomCommand)
+	intent.Command = "cd {{.RepoPath}} && echo {{.RepoName}} {{.PrNumber}}/{{.PrIndex}} {{.Title}} {{.Author}} {{.InstanceURL}} {{.Url}}"
+	intent.Name = "lazygit"
+	intent.Target.RepositoryPath = "/src/widgets"
+	intent.Target.URL = "https://git.example/acme/widgets/pulls/7"
+	intent.Target.Author = "alice"
+
+	got := runDispatch(t, r, intent)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("custom command result = %+v", got)
+	}
+	if execProcess.cmd == nil {
+		t.Fatal("exec process was not called")
+	}
+	if len(execProcess.cmd.Args) != 3 || execProcess.cmd.Args[1] != "-c" {
+		t.Fatalf("shell args = %#v, want shell -c", execProcess.cmd.Args)
+	}
+	want := "cd /src/widgets && echo acme/widgets 7/7 PR title alice https://git.example https://git.example/acme/widgets/pulls/7"
+	if execProcess.cmd.Args[2] != want {
+		t.Fatalf("rendered command = %q, want %q", execProcess.cmd.Args[2], want)
+	}
+	if execProcess.cmd.Dir != "/src/widgets" {
+		t.Fatalf("command dir = %q, want selected repo path", execProcess.cmd.Dir)
+	}
+	if !strings.Contains(got.Message, "lazygit") {
+		t.Fatalf("custom command message = %q", got.Message)
+	}
+}
+
+func TestDispatchCustomCommandMissingVariableDoesNotRunShell(t *testing.T) {
+	execProcess := &fakeExecProcess{}
+	r := New(Options{ExecProcess: execProcess.Run})
+	intent := pullIntent(uiactions.KindCustomCommand)
+	intent.Command = "echo {{.NoSuchField}}"
+
+	got := runDispatch(t, r, intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "render custom command template") {
+		t.Fatalf("custom command missing variable result = %+v", got)
+	}
+	if execProcess.cmd != nil {
+		t.Fatalf("exec should not run for a missing template variable, ran %+v", execProcess.cmd)
+	}
+}
+
 func TestDispatchCheckoutPassesConfig(t *testing.T) {
 	var gotOpts localgit.CheckoutOptions
 	r := New(Options{
@@ -295,6 +349,18 @@ type fakeShellRunner struct {
 func (f *fakeShellRunner) Run(_ context.Context, cmd shell.Command) ([]byte, error) {
 	f.command = cmd
 	return nil, f.err
+}
+
+type fakeExecProcess struct {
+	cmd *exec.Cmd
+	err error
+}
+
+func (f *fakeExecProcess) Run(cmd *exec.Cmd, cb tea.ExecCallback) tea.Cmd {
+	f.cmd = cmd
+	return func() tea.Msg {
+		return cb(f.err)
+	}
 }
 
 var _ tea.Cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	RepoPaths map[string]string `yaml:"repoPaths"`
 	// Git configures local git checkout behavior.
 	Git Git `yaml:"git"`
+	// Keybindings overrides built-in keys and adds custom shell commands.
+	Keybindings Keybindings `yaml:"keybindings"`
 }
 
 // Defaults holds startup and limit defaults. Per-view limits set the row-fetch
@@ -78,6 +80,26 @@ func (p Pager) DiffCommand() string {
 type Git struct {
 	Remote           string `yaml:"remote"`
 	PRBranchTemplate string `yaml:"prBranchTemplate"`
+}
+
+// Keybindings groups configurable bindings by scope. Universal bindings are
+// active in every view; scoped bindings apply only while that view is active.
+type Keybindings struct {
+	Universal     []Keybinding `yaml:"universal"`
+	PRs           []Keybinding `yaml:"prs"`
+	Issues        []Keybinding `yaml:"issues"`
+	Notifications []Keybinding `yaml:"notifications"`
+	Actions       []Keybinding `yaml:"actions"`
+	Branches      []Keybinding `yaml:"branches"`
+}
+
+// Keybinding is one user-configured key entry. Builtin remaps a native command;
+// Command runs a shell command using the selected row as template context.
+type Keybinding struct {
+	Key     string `yaml:"key"`
+	Builtin string `yaml:"builtin"`
+	Command string `yaml:"command"`
+	Name    string `yaml:"name"`
 }
 
 // RemoteName returns the configured remote name or the origin default.
@@ -209,12 +231,88 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("localRepos entry %q: path is required", r.Name)
 		}
 	}
+	if err := c.Keybindings.Validate(); err != nil {
+		return err
+	}
 	switch c.Defaults.View {
 	case "", "prs", "issues", "notifications", "actions", "branches":
 	default:
 		return fmt.Errorf("defaults.view = %q: want \"prs\", \"issues\", \"notifications\", \"actions\", or \"branches\"", c.Defaults.View)
 	}
 	return nil
+}
+
+// Validate rejects keybinding entries that cannot be matched or executed.
+func (k Keybindings) Validate() error {
+	for _, group := range []struct {
+		name     string
+		bindings []Keybinding
+		builtins map[string]struct{}
+	}{
+		{"keybindings.universal", k.Universal, universalBuiltins},
+		{"keybindings.prs", k.PRs, prBuiltins},
+		{"keybindings.issues", k.Issues, issueBuiltins},
+		{"keybindings.notifications", k.Notifications, notificationBuiltins},
+		{"keybindings.actions", k.Actions, actionBuiltins},
+		{"keybindings.branches", k.Branches, branchBuiltins},
+	} {
+		for i, b := range group.bindings {
+			if strings.TrimSpace(b.Key) == "" {
+				return fmt.Errorf("%s[%d].key is required", group.name, i)
+			}
+			hasBuiltin := strings.TrimSpace(b.Builtin) != ""
+			hasCommand := strings.TrimSpace(b.Command) != ""
+			if hasBuiltin == hasCommand {
+				return fmt.Errorf("%s[%d] must set builtin or command", group.name, i)
+			}
+			if hasBuiltin {
+				name := normalizeBuiltinName(b.Builtin)
+				if _, ok := group.builtins[name]; !ok {
+					return fmt.Errorf("%s[%d].builtin = %q is not supported in this scope", group.name, i, b.Builtin)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+var universalBuiltins = builtinSet(
+	"refresh", "refreshAll", "openGithub", "open", "search", "togglePreview",
+	"pageUp", "pageDown", "scrollUp", "scrollDown", "prevSection",
+	"previousSection", "nextSection", "switchView", "copyurl", "copyNumber",
+	"help", "quit", "expand", "summaryViewMore",
+)
+
+var prBuiltins = builtinSet(
+	"comment", "merge", "close", "reopen", "diff", "checkout", "approve",
+	"review", "summaryViewMore", "expand",
+)
+
+var issueBuiltins = builtinSet("comment", "close", "reopen")
+
+var notificationBuiltins = builtinSet(
+	"openGithub", "open", "markAsRead", "markRead", "markAsUnread",
+	"markUnread", "markAllAsRead", "markAllRead", "markAsDone", "markDone",
+	"markAllAsDone", "markAllDone",
+)
+
+var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun")
+
+var branchBuiltins = builtinSet("checkout")
+
+func builtinSet(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		out[normalizeBuiltinName(name)] = struct{}{}
+	}
+	return out
+}
+
+func normalizeBuiltinName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "-", "")
+	name = strings.ReplaceAll(name, "_", "")
+	return strings.ToLower(name)
 }
 
 // WithDefaults fills the section-driven Type and the "open" State default,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,97 @@ git:
 	}
 }
 
+func TestUnmarshalKeybindings(t *testing.T) {
+	const y = `
+keybindings:
+  universal:
+    - key: tab
+      builtin: nextSection
+  prs:
+    - key: O
+      builtin: checkout
+    - key: g
+      name: lazygit
+      command: cd {{.RepoPath}} && lazygit
+  issues:
+    - key: i
+      command: echo {{.IssueNumber}}
+  notifications:
+    - key: D
+      builtin: markAllRead
+  actions:
+    - key: a
+      command: echo {{.RunID}}
+  branches:
+    - key: B
+      command: git -C {{.RepoPath}} status
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(c.Keybindings.Universal) != 1 || c.Keybindings.Universal[0].Key != "tab" ||
+		c.Keybindings.Universal[0].Builtin != "nextSection" {
+		t.Fatalf("universal keybindings = %+v", c.Keybindings.Universal)
+	}
+	if len(c.Keybindings.PRs) != 2 || c.Keybindings.PRs[1].Name != "lazygit" ||
+		!strings.Contains(c.Keybindings.PRs[1].Command, "lazygit") {
+		t.Fatalf("prs keybindings = %+v", c.Keybindings.PRs)
+	}
+	if c.Keybindings.Notifications[0].Builtin != "markAllRead" ||
+		c.Keybindings.Actions[0].Key != "a" ||
+		c.Keybindings.Branches[0].Command == "" {
+		t.Fatalf("keybindings = %+v", c.Keybindings)
+	}
+}
+
+func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "missing key",
+			cfg: Config{Keybindings: Keybindings{Universal: []Keybinding{{
+				Builtin: "refresh",
+			}}}},
+		},
+		{
+			name: "missing builtin and command",
+			cfg: Config{Keybindings: Keybindings{PRs: []Keybinding{{
+				Key: "g",
+			}}}},
+		},
+		{
+			name: "both builtin and command",
+			cfg: Config{Keybindings: Keybindings{PRs: []Keybinding{{
+				Key: "g", Builtin: "checkout", Command: "lazygit",
+			}}}},
+		},
+		{
+			name: "unsupported scoped builtin",
+			cfg: Config{Keybindings: Keybindings{Issues: []Keybinding{{
+				Key: "m", Builtin: "merge",
+			}}}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Fatal("Validate() should reject the invalid keybinding")
+			}
+		})
+	}
+
+	ok := Config{Keybindings: Keybindings{Universal: []Keybinding{
+		{Key: "R", Builtin: "refreshAll"},
+		{Key: "g", Command: "lazygit"},
+	}}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected valid keybindings: %v", err)
+	}
+}
+
 func TestPagerDiffCommandDefaults(t *testing.T) {
 	t.Setenv("PAGER", "bat --plain")
 	if got := (Pager{}).DiffCommand(); got != "bat --plain" {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -31,6 +31,18 @@ func BuildCommand(command string, stdin []byte, dir string) Command {
 	}
 }
 
+// BuildExecCommand builds an *exec.Cmd suitable for Bubble Tea's ExecProcess,
+// so interactive full-screen commands can temporarily take over the terminal.
+func BuildExecCommand(command string, stdin []byte, dir string) *exec.Cmd {
+	c := BuildCommand(command, stdin, dir)
+	cmd := exec.Command(c.Name, c.Args...)
+	cmd.Dir = c.Dir
+	if c.Stdin != nil {
+		cmd.Stdin = bytes.NewReader(c.Stdin)
+	}
+	return cmd
+}
+
 // Runner runs shell commands.
 type Runner interface {
 	Run(context.Context, Command) ([]byte, error)

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -37,3 +37,25 @@ func TestBuildCommandDefaultsToBinSh(t *testing.T) {
 		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
 	}
 }
+
+func TestBuildExecCommandUsesShellCDirAndOptionalStdin(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+
+	cmd := BuildExecCommand("lazygit", []byte("input"), "/tmp/repo")
+
+	if cmd.Path != "/bin/zsh" {
+		t.Fatalf("Path = %q, want /bin/zsh", cmd.Path)
+	}
+	if want := []string{"/bin/zsh", "-c", "lazygit"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, want)
+	}
+	if cmd.Dir != "/tmp/repo" {
+		t.Fatalf("Dir = %q, want /tmp/repo", cmd.Dir)
+	}
+	if cmd.Stdin == nil {
+		t.Fatal("Stdin should be populated when stdin bytes are provided")
+	}
+	if cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Fatal("Stdout/Stderr should stay nil so Bubble Tea ExecProcess can wire terminal output")
+	}
+}

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -6,16 +6,17 @@ package actions
 type Kind string
 
 const (
-	KindComment      Kind = "comment"
-	KindMerge        Kind = "merge"
-	KindClose        Kind = "close"
-	KindReopen       Kind = "reopen"
-	KindReview       Kind = "review"
-	KindExternalDiff Kind = "external_diff"
-	KindCheckout     Kind = "checkout"
-	KindSwitchBranch Kind = "switch_branch"
-	KindRerunRun     Kind = "rerun_run"
-	KindCancelRun    Kind = "cancel_run"
+	KindComment       Kind = "comment"
+	KindMerge         Kind = "merge"
+	KindClose         Kind = "close"
+	KindReopen        Kind = "reopen"
+	KindReview        Kind = "review"
+	KindExternalDiff  Kind = "external_diff"
+	KindCheckout      Kind = "checkout"
+	KindSwitchBranch  Kind = "switch_branch"
+	KindRerunRun      Kind = "rerun_run"
+	KindCancelRun     Kind = "cancel_run"
+	KindCustomCommand Kind = "custom_command"
 )
 
 // RowKind identifies the selected row's domain type.
@@ -48,6 +49,8 @@ type Target struct {
 	RunID          int64
 	Title          string
 	URL            string
+	Author         string
+	SHA            string
 }
 
 // Prompt carries the prompt payload that was submitted with the intent.
@@ -59,9 +62,11 @@ type Prompt struct {
 
 // Intent is the value passed through the app-level dispatcher seam.
 type Intent struct {
-	Kind   Kind
-	Target Target
-	Prompt Prompt
+	Kind    Kind
+	Target  Target
+	Prompt  Prompt
+	Command string
+	Name    string
 }
 
 // ResultStatus describes feedback returned by a dispatcher command.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -135,9 +135,11 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		return nil
 	}
 
+	keys := defaultKeyMap()
+	keys.applyConfig(cfg)
 	m := Model{
 		ctx:             ctx,
-		keys:            defaultKeyMap(),
+		keys:            keys,
 		tabs:            tabs.New(ctx),
 		sidebar:         sidebar.New(ctx),
 		tasks:           tasks,
@@ -182,6 +184,58 @@ func buildSections(view context.ViewType, ctx *context.ProgramContext) []section
 		}
 	}
 	return sections
+}
+
+func (m Model) matchCustomKeybinding(msg tea.KeyPressMsg) (config.Keybinding, bool) {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return config.Keybinding{}, false
+	}
+	for _, b := range m.activeKeybindings() {
+		if b.Command == "" {
+			continue
+		}
+		if key.Matches(msg, key.NewBinding(key.WithKeys(b.Key))) {
+			return b, true
+		}
+	}
+	return config.Keybinding{}, false
+}
+
+func (m Model) matchBuiltinKeybinding(msg tea.KeyPressMsg) (config.Keybinding, bool) {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return config.Keybinding{}, false
+	}
+	for _, b := range m.activeKeybindings() {
+		if b.Builtin == "" {
+			continue
+		}
+		if key.Matches(msg, key.NewBinding(key.WithKeys(b.Key))) {
+			return b, true
+		}
+	}
+	return config.Keybinding{}, false
+}
+
+func (m Model) activeKeybindings() []config.Keybinding {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return nil
+	}
+	k := m.ctx.Config.Keybindings
+	out := make([]config.Keybinding, 0, len(k.Universal)+4)
+	out = append(out, k.Universal...)
+	switch m.ctx.View {
+	case context.IssuesView:
+		out = append(out, k.Issues...)
+	case context.NotificationsView:
+		out = append(out, k.Notifications...)
+	case context.ActionsView:
+		out = append(out, k.Actions...)
+	case context.BranchesView:
+		out = append(out, k.Branches...)
+	default:
+		out = append(out, k.PRs...)
+	}
+	return out
 }
 
 // Init starts the initial fetch for every section in the current view.
@@ -297,6 +351,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		m.notice = "" // any key dismisses a transient notice
+		if b, ok := m.matchCustomKeybinding(msg); ok {
+			return m, m.startCustomCommand(b)
+		}
+		if b, ok := m.matchBuiltinKeybinding(msg); ok {
+			if next, cmd, handled := m.handleBuiltinKeybinding(b); handled {
+				return next, cmd
+			}
+		}
 		switch {
 		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
 			return m.markSelectedNotificationRead()
@@ -956,6 +1018,138 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 	return nil
 }
 
+func (m *Model) startCustomCommand(binding config.Keybinding) tea.Cmd {
+	target, ok := m.selectedActionTarget()
+	if !ok {
+		m.notice = "Select a row before running a custom command."
+		return nil
+	}
+	intent := actions.Intent{
+		Kind:    actions.KindCustomCommand,
+		Target:  target,
+		Command: binding.Command,
+		Name:    binding.Name,
+	}
+	return m.dispatchActionIntent(intent)
+}
+
+func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cmd, bool) {
+	switch normalizeBuiltin(binding.Builtin) {
+	case "refresh":
+		if s := m.getCurrSection(); s != nil && !s.GetIsLoading() {
+			if m.ctx.PreviewOpen {
+				m.clearSelectedPreviewCache()
+				m.syncSidebar()
+			}
+			return m, s.FetchRows(), true
+		}
+		return m, nil, true
+	case "refreshall":
+		return m, m.refreshAllSections(), true
+	case "opengithub", "open", "openbrowser":
+		return m, m.openSelected(), true
+	case "quit":
+		return m, tea.Quit, true
+	case "nextsection":
+		if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
+			m.currSectionId++
+		}
+		m.tabs.SetCurrSectionId(m.currSectionId)
+		if m.ctx.PreviewOpen {
+			m.syncSidebar()
+			return m, m.enrichCurrRow(), true
+		}
+		return m, nil, true
+	case "prevsection", "previoussection":
+		if m.currSectionId > 0 {
+			m.currSectionId--
+		}
+		m.tabs.SetCurrSectionId(m.currSectionId)
+		if m.ctx.PreviewOpen {
+			m.syncSidebar()
+			return m, m.enrichCurrRow(), true
+		}
+		return m, nil, true
+	case "viewissues", "viewprs", "switchview":
+		return m, m.switchView(), true
+	case "search":
+		if s := m.getCurrSection(); s != nil {
+			return m, s.SetIsSearching(true), true
+		}
+		return m, nil, true
+	case "togglepreview":
+		m.ctx.PreviewOpen = !m.ctx.PreviewOpen
+		m.syncMainContentDimensions()
+		m.syncProgramContext()
+		if m.ctx.PreviewOpen {
+			m.expanded = false
+			m.syncSidebar()
+			return m, m.enrichCurrRow(), true
+		}
+		return m, nil, true
+	case "summaryviewmore", "expand":
+		if m.ctx.PreviewOpen {
+			m.expanded = !m.expanded
+			m.syncSidebar()
+		}
+		return m, nil, true
+	case "pageup", "scrollup":
+		if m.ctx.PreviewOpen {
+			var cmd tea.Cmd
+			m.sidebar, cmd = m.sidebar.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+			return m, cmd, true
+		}
+		return m, nil, true
+	case "pagedown", "scrolldown":
+		if m.ctx.PreviewOpen {
+			var cmd tea.Cmd
+			m.sidebar, cmd = m.sidebar.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+			return m, cmd, true
+		}
+		return m, nil, true
+	case "copyurl":
+		return m, m.copySelectedURL(), true
+	case "copynumber":
+		return m, m.copySelectedNumber(), true
+	case "help":
+		m.showHelp = !m.showHelp
+		return m, nil, true
+	case "markasread", "markread", "markasdone", "markdone":
+		next, cmd := m.markSelectedNotificationRead()
+		return next, cmd, true
+	case "markasunread", "markunread":
+		next, cmd := m.markSelectedNotificationUnread()
+		return next, cmd, true
+	case "markallasread", "markallread", "markallasdone", "markalldone":
+		next, cmd := m.markAllNotificationsRead()
+		return next, cmd, true
+	case "comment":
+		return m, m.startAction(actions.KindComment), true
+	case "merge":
+		return m, m.startAction(actions.KindMerge), true
+	case "close":
+		return m, m.startAction(actions.KindClose), true
+	case "reopen":
+		return m, m.startAction(actions.KindReopen), true
+	case "approve", "review":
+		return m, m.startAction(actions.KindReview), true
+	case "diff":
+		return m, m.startAction(actions.KindExternalDiff), true
+	case "checkout":
+		if m.ctx.View == context.BranchesView {
+			return m, m.startAction(actions.KindSwitchBranch), true
+		}
+		return m, m.startAction(actions.KindCheckout), true
+	case "rerun", "rerunrun":
+		return m, m.startAction(actions.KindRerunRun), true
+	case "cancel", "cancelrun":
+		return m, m.startAction(actions.KindCancelRun), true
+	default:
+		m.notice = fmt.Sprintf("Unknown builtin keybinding %q.", binding.Builtin)
+		return m, nil, true
+	}
+}
+
 func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 	var result actionprompt.Result
 	var cmd tea.Cmd
@@ -1003,16 +1197,22 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 	}
 	rowKind := actions.RowKind(s.GetType())
 	runID := int64(0)
+	author := ""
+	sha := ""
 	switch r := row.(type) {
 	case data.PullRequest:
 		rowKind = actions.RowKindPullRequest
+		author = r.Author
 	case data.Issue:
 		rowKind = actions.RowKindIssue
+		author = r.Author
 	case localgit.Branch:
 		rowKind = actions.RowKindBranch
 	case data.ActionRun:
 		rowKind = actions.RowKindActionRun
 		runID = r.ID
+		author = r.Actor
+		sha = r.HeadSHA
 	}
 	target := actions.Target{
 		SectionID:   s.GetId(),
@@ -1023,9 +1223,15 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		RunID:       runID,
 		Title:       row.GetTitle(),
 		URL:         row.GetURL(),
+		Author:      author,
+		SHA:         sha,
 	}
 	if branch, ok := row.(localgit.Branch); ok {
 		target.RepositoryPath = branch.RepositoryPath
+	} else if m.ctx.Config != nil {
+		if repoPath, ok, err := config.MatchRepoPath(row.GetRepoNameWithOwner(), m.ctx.Config.RepoPaths); err == nil && ok {
+			target.RepositoryPath = repoPath
+		}
 	}
 	return target, true
 }
@@ -1140,12 +1346,21 @@ func actionLabel(kind actions.Kind) string {
 		return "Rerun"
 	case actions.KindCancelRun:
 		return "Cancel run"
+	case actions.KindCustomCommand:
+		return "Custom command"
 	default:
 		return string(kind)
 	}
 }
 
 func actionStartText(intent actions.Intent) string {
+	if intent.Kind == actions.KindCustomCommand {
+		label := intent.Name
+		if label == "" {
+			label = "custom command"
+		}
+		return fmt.Sprintf("Starting %s for %s.", label, intent.Target.Title)
+	}
 	if intent.Kind == actions.KindSwitchBranch {
 		return fmt.Sprintf("Starting %s for %s.", actionLabel(intent.Kind), intent.Target.Title)
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1306,6 +1306,7 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				Number:      42,
 				Title:       "Action row",
 				URL:         "https://example.test/gbarany/tea-dash/pulls/42",
+				Author:      "me",
 			}
 			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
 				t.Fatalf("intent = %+v, want kind %q target %+v", got[0], tt.kind, wantTarget)
@@ -1491,6 +1492,117 @@ func TestHelpKeyTogglesFullHelp(t *testing.T) {
 	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
 	if strings.Contains(m.View().Content, "R refresh all") {
 		t.Fatal("second '?' should hide full help")
+	}
+}
+
+func TestConfigKeybindingRebindsBuiltin(t *testing.T) {
+	m := New(&config.Config{
+		Keybindings: config.Keybindings{
+			Universal: []config.Keybinding{{Key: "H", Builtin: "help"}},
+		},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
+	if strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("default '?' help key should be replaced by the configured binding")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'H', Text: "H"})
+	if !strings.Contains(m.View().Content, "R refresh all") {
+		t.Fatal("configured 'H' key should toggle full help")
+	}
+}
+
+func TestConfigCustomKeybindingDispatchesSelectedRowCommand(t *testing.T) {
+	cfg := &config.Config{
+		RepoPaths: map[string]string{"gbarany/tea-dash": "/src/tea-dash"},
+		Keybindings: config.Keybindings{
+			PRs: []config.Keybinding{{
+				Key:     "g",
+				Name:    "lazygit",
+				Command: "cd {{.RepoPath}} && echo {{.PrNumber}}",
+			}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 12, Title: "Custom command row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://git.example/gbarany/tea-dash/pulls/12",
+	}}))
+
+	var got actions.Intent
+	m.SetActionDispatcher(func(intent actions.Intent) tea.Cmd {
+		got = intent
+		return func() tea.Msg {
+			return actions.ResultMsg{Intent: intent, Status: actions.ResultSucceeded, Message: "ran"}
+		}
+	})
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("custom keybinding should dispatch a command")
+	}
+	if got.Kind != actions.KindCustomCommand || got.Command != "cd {{.RepoPath}} && echo {{.PrNumber}}" {
+		t.Fatalf("custom intent = %+v", got)
+	}
+	if got.Target.Number != 12 || got.Target.RepositoryPath != "/src/tea-dash" {
+		t.Fatalf("custom target = %+v", got.Target)
+	}
+}
+
+func TestScopedBuiltinKeybindingRunsInActiveView(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{View: "issues"},
+		Keybindings: config.Keybindings{
+			Issues: []config.Keybinding{{Key: "m", Builtin: "close"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 5, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	var got actions.Intent
+	m.SetActionDispatcher(func(intent actions.Intent) tea.Cmd {
+		got = intent
+		return nil
+	})
+	next, _ := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	m = next.(Model)
+	if !m.actionPrompt.Active() {
+		t.Fatal("scoped issue close binding should open the confirm prompt")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if got.Kind != actions.KindClose {
+		t.Fatalf("scoped issue builtin dispatched %+v, want close", got)
+	}
+}
+
+func TestScopedBuiltinKeybindingDoesNotLeakToOtherViews(t *testing.T) {
+	cfg := &config.Config{
+		Keybindings: config.Keybindings{
+			Issues: []config.Keybinding{{Key: "m", Builtin: "close"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 8, Title: "PR row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Merge") {
+		t.Fatalf("PR view 'm' should keep the default merge prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Close") {
+		t.Fatalf("PR view 'x' should keep the default close prompt, got:\n%s", m.actionPrompt.View(120))
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -1,6 +1,12 @@
 package ui
 
-import "charm.land/bubbles/v2/key"
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+
+	"github.com/gbarany/tea-dash/internal/config"
+)
 
 // keyMap defines the app-level key bindings. Row navigation (↑/↓, j/k, page
 // keys) is handled by the underlying table widget.
@@ -145,4 +151,90 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("M", "mark all read"),
 		),
 	}
+}
+
+func (k *keyMap) applyConfig(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	for _, b := range cfg.Keybindings.Universal {
+		if strings.TrimSpace(b.Builtin) == "" {
+			continue
+		}
+		k.rebindBuiltin(b.Builtin, b.Key)
+	}
+}
+
+func (k *keyMap) rebindBuiltin(name, keyName string) {
+	keyName = strings.TrimSpace(keyName)
+	if keyName == "" {
+		return
+	}
+	switch normalizeBuiltin(name) {
+	case "refresh":
+		k.Refresh = binding(keyName, "refresh")
+	case "refreshall":
+		k.RefreshAll = binding(keyName, "refresh all")
+	case "opengithub", "open", "openbrowser":
+		k.Open = binding(keyName, "open in browser")
+	case "quit":
+		k.Quit = binding(keyName, "quit")
+	case "nextsection":
+		k.NextSection = binding(keyName, "next section")
+	case "prevsection", "previoussection":
+		k.PrevSection = binding(keyName, "prev section")
+	case "viewissues", "viewprs", "switchview":
+		k.SwitchView = binding(keyName, "switch view")
+	case "search":
+		k.Search = binding(keyName, "search")
+	case "togglepreview":
+		k.TogglePreview = binding(keyName, "preview")
+	case "pageup", "scrollup":
+		k.ScrollUp = binding(keyName, "scroll preview up")
+	case "pagedown", "scrolldown":
+		k.ScrollDown = binding(keyName, "scroll preview down")
+	case "summaryviewmore", "expand":
+		k.Expand = binding(keyName, "expand")
+	case "comment":
+		k.Comment = binding(keyName, "comment")
+	case "merge":
+		k.Merge = binding(keyName, "merge")
+	case "close":
+		k.Close = binding(keyName, "close")
+	case "reopen":
+		k.Reopen = binding(keyName, "reopen")
+	case "approve", "review":
+		k.Review = binding(keyName, "review")
+	case "diff":
+		k.ExternalDiff = binding(keyName, "external diff")
+	case "checkout":
+		k.Checkout = binding(keyName, "checkout")
+	case "rerun", "rerunrun":
+		k.RerunRun = binding(keyName, "rerun")
+	case "cancel", "cancelrun":
+		k.CancelRun = binding(keyName, "cancel run")
+	case "copyurl":
+		k.CopyURL = binding(keyName, "copy URL")
+	case "copynumber":
+		k.CopyNumber = binding(keyName, "copy number")
+	case "help":
+		k.Help = binding(keyName, "help")
+	case "markasread", "markread":
+		k.MarkRead = binding(keyName, "mark read")
+	case "markasunread", "markunread":
+		k.MarkUnread = binding(keyName, "mark unread")
+	case "markallasread", "markallread":
+		k.MarkAllRead = binding(keyName, "mark all read")
+	}
+}
+
+func binding(keyName, help string) key.Binding {
+	return key.NewBinding(key.WithKeys(keyName), key.WithHelp(keyName, help))
+}
+
+func normalizeBuiltin(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "-", "")
+	name = strings.ReplaceAll(name, "_", "")
+	return strings.ToLower(name)
 }


### PR DESCRIPTION
## Summary

Adds gh-dash-shaped configurable keybindings to tea-dash.

- Adds top-level `keybindings:` config buckets: `universal`, `prs`, `issues`, `notifications`, `actions`, and `branches`.
- Supports built-in rebinding for implemented tea-dash actions using gh-dash-compatible names like `openGithub`, `copyurl`, `summaryViewMore`, `markAsRead`, `rerun`, and `checkout`.
- Supports custom shell commands with selected-row template variables: `RepoName`, `RepoPath`, `PrIndex` / `PrNumber`, `IssueIndex` / `IssueNumber`, `RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `URL` / `Url`.
- Runs custom commands through Bubble Tea `ExecProcess`, so interactive tools like `lazygit` can temporarily take over the terminal and return to tea-dash.
- Documents the config shape in README, including the existing 1Password `tokenCommand` pattern.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- tmux smoke in `main:9.3`: app launched with `TEA_DASH_TOKEN=$(op read "op://Appic/tea-dash PAT/credential") ./bin/tea-dash` and rendered live PR/preview/CI data.
