### PR TITLE
Fix scoped keybinding rebinding

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -238,6 +238,35 @@ func (m Model) activeKeybindings() []config.Keybinding {
 	return out
 }
 
+func (m Model) scopedBuiltinOverridden(name string) bool {
+	want := normalizeBuiltin(name)
+	for _, b := range m.scopedKeybindings() {
+		if b.Builtin != "" && normalizeBuiltin(b.Builtin) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) scopedKeybindings() []config.Keybinding {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return nil
+	}
+	k := m.ctx.Config.Keybindings
+	switch m.ctx.View {
+	case context.IssuesView:
+		return k.Issues
+	case context.NotificationsView:
+		return k.Notifications
+	case context.ActionsView:
+		return k.Actions
+	case context.BranchesView:
+		return k.Branches
+	default:
+		return k.PRs
+	}
+}
+
 // Init starts the initial fetch for every section in the current view.
 func (m Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
@@ -360,36 +389,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		switch {
-		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
+		case !m.scopedBuiltinOverridden("markRead") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
 			return m.markSelectedNotificationRead()
-		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkUnread):
+		case !m.scopedBuiltinOverridden("markUnread") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkUnread):
 			return m.markSelectedNotificationUnread()
-		case m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
+		case !m.scopedBuiltinOverridden("markAllRead") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
 			return m.markAllNotificationsRead()
-		case m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.RerunRun):
+		case !m.scopedBuiltinOverridden("rerun") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.RerunRun):
 			return m, m.startAction(actions.KindRerunRun)
-		case m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.CancelRun):
+		case !m.scopedBuiltinOverridden("cancel") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.CancelRun):
 			return m, m.startAction(actions.KindCancelRun)
-		case key.Matches(msg, m.keys.Comment):
+		case !m.scopedBuiltinOverridden("comment") && key.Matches(msg, m.keys.Comment):
 			return m, m.startAction(actions.KindComment)
-		case key.Matches(msg, m.keys.Merge):
+		case !m.scopedBuiltinOverridden("merge") && key.Matches(msg, m.keys.Merge):
 			return m, m.startAction(actions.KindMerge)
-		case key.Matches(msg, m.keys.Close):
+		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
 			return m, m.startAction(actions.KindClose)
-		case key.Matches(msg, m.keys.Reopen):
+		case !m.scopedBuiltinOverridden("reopen") && key.Matches(msg, m.keys.Reopen):
 			return m, m.startAction(actions.KindReopen)
-		case key.Matches(msg, m.keys.Review):
+		case !m.scopedBuiltinOverridden("review") && key.Matches(msg, m.keys.Review):
 			return m, m.startAction(actions.KindReview)
-		case key.Matches(msg, m.keys.ExternalDiff):
+		case !m.scopedBuiltinOverridden("diff") && key.Matches(msg, m.keys.ExternalDiff):
 			return m, m.startAction(actions.KindExternalDiff)
-		case key.Matches(msg, m.keys.Checkout):
+		case !m.scopedBuiltinOverridden("checkout") && key.Matches(msg, m.keys.Checkout):
 			if m.ctx.View == context.BranchesView {
 				return m, m.startAction(actions.KindSwitchBranch)
 			}
 			return m, m.startAction(actions.KindCheckout)
-		case key.Matches(msg, m.keys.Quit):
+		case !m.scopedBuiltinOverridden("quit") && key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
-		case key.Matches(msg, m.keys.Refresh):
+		case !m.scopedBuiltinOverridden("refresh") && key.Matches(msg, m.keys.Refresh):
 			if s := m.getCurrSection(); s != nil && !s.GetIsLoading() {
 				if m.ctx.PreviewOpen {
 					m.clearSelectedPreviewCache()
@@ -398,18 +427,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, s.FetchRows()
 			}
 			return m, nil
-		case key.Matches(msg, m.keys.RefreshAll):
+		case !m.scopedBuiltinOverridden("refreshAll") && key.Matches(msg, m.keys.RefreshAll):
 			return m, m.refreshAllSections()
-		case key.Matches(msg, m.keys.Open):
+		case !m.scopedBuiltinOverridden("open") && key.Matches(msg, m.keys.Open):
 			return m, m.openSelected()
-		case key.Matches(msg, m.keys.CopyNumber):
+		case !m.scopedBuiltinOverridden("copyNumber") && key.Matches(msg, m.keys.CopyNumber):
 			return m, m.copySelectedNumber()
-		case key.Matches(msg, m.keys.CopyURL):
+		case !m.scopedBuiltinOverridden("copyurl") && key.Matches(msg, m.keys.CopyURL):
 			return m, m.copySelectedURL()
-		case key.Matches(msg, m.keys.Help):
+		case !m.scopedBuiltinOverridden("help") && key.Matches(msg, m.keys.Help):
 			m.showHelp = !m.showHelp
 			return m, nil
-		case key.Matches(msg, m.keys.NextSection):
+		case !m.scopedBuiltinOverridden("nextSection") && key.Matches(msg, m.keys.NextSection):
 			if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 				m.currSectionId++
 			}
@@ -419,7 +448,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.enrichCurrRow()
 			}
 			return m, nil
-		case key.Matches(msg, m.keys.PrevSection):
+		case !m.scopedBuiltinOverridden("prevSection") && key.Matches(msg, m.keys.PrevSection):
 			if m.currSectionId > 0 {
 				m.currSectionId--
 			}
@@ -429,15 +458,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.enrichCurrRow()
 			}
 			return m, nil
-		case key.Matches(msg, m.keys.SwitchView):
+		case !m.scopedBuiltinOverridden("switchView") && key.Matches(msg, m.keys.SwitchView):
 			cmd := m.switchView()
 			return m, cmd
-		case key.Matches(msg, m.keys.Search):
+		case !m.scopedBuiltinOverridden("search") && key.Matches(msg, m.keys.Search):
 			if s := m.getCurrSection(); s != nil {
 				return m, s.SetIsSearching(true)
 			}
 			return m, nil
-		case key.Matches(msg, m.keys.TogglePreview):
+		case !m.scopedBuiltinOverridden("togglePreview") && key.Matches(msg, m.keys.TogglePreview):
 			m.ctx.PreviewOpen = !m.ctx.PreviewOpen
 			m.syncMainContentDimensions()
 			m.syncProgramContext()
@@ -447,13 +476,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.enrichCurrRow()
 			}
 			return m, nil
-		case key.Matches(msg, m.keys.Expand):
+		case !m.scopedBuiltinOverridden("expand") && key.Matches(msg, m.keys.Expand):
 			if m.ctx.PreviewOpen {
 				m.expanded = !m.expanded
 				m.syncSidebar()
 			}
 			return m, nil
-		case (key.Matches(msg, m.keys.ScrollUp) || key.Matches(msg, m.keys.ScrollDown)) && m.ctx.PreviewOpen:
+		case (!m.scopedBuiltinOverridden("scrollUp") && key.Matches(msg, m.keys.ScrollUp) ||
+			!m.scopedBuiltinOverridden("scrollDown") && key.Matches(msg, m.keys.ScrollDown)) && m.ctx.PreviewOpen:
 			var cmd tea.Cmd
 			m.sidebar, cmd = m.sidebar.Update(msg)
 			return m, cmd
@@ -540,7 +570,18 @@ func (m Model) helpLine() string {
 	default:
 		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
 	}
-	return text + " · ? help · q quit"
+	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
+}
+
+func keyHelp(binding key.Binding, fallback string) string {
+	if h := binding.Help(); h.Key != "" {
+		return h.Key
+	}
+	keys := binding.Keys()
+	if len(keys) > 0 {
+		return keys[0]
+	}
+	return fallback
 }
 
 // currentViewSections returns the section slice for the active view.

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1511,6 +1511,11 @@ func TestConfigKeybindingRebindsBuiltin(t *testing.T) {
 	if !strings.Contains(m.View().Content, "R refresh all") {
 		t.Fatal("configured 'H' key should toggle full help")
 	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'H', Text: "H"})
+	view := m.View().Content
+	if !strings.Contains(view, "H help") || strings.Contains(view, "? help") {
+		t.Fatalf("compact help should show configured help key and hide the old key:\n%s", view)
+	}
 }
 
 func TestConfigCustomKeybindingDispatchesSelectedRowCommand(t *testing.T) {
@@ -1578,6 +1583,29 @@ func TestScopedBuiltinKeybindingRunsInActiveView(t *testing.T) {
 	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
 	if got.Kind != actions.KindClose {
 		t.Fatalf("scoped issue builtin dispatched %+v, want close", got)
+	}
+}
+
+func TestScopedBuiltinKeybindingReplacesDefaultInActiveView(t *testing.T) {
+	cfg := &config.Config{
+		Keybindings: config.Keybindings{
+			PRs: []config.Keybinding{{Key: "M", Builtin: "merge"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 8, Title: "PR row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if m.actionPrompt.Active() {
+		t.Fatal("old PR merge key should be replaced by the scoped keybinding, not kept as an alias")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'M', Text: "M"})
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Merge") {
+		t.Fatalf("configured 'M' key should open the merge prompt, got:\n%s", m.actionPrompt.View(120))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the keybindings review finding from PR #24.

- Scoped built-in bindings now replace the default key in that active view instead of adding an alias.
- Example: `keybindings.prs: [{ key: M, builtin: merge }]` makes `M` merge and old `m` inert in the PR view.
- Universal built-ins still mutate the global key map as before.
- Compact help now reads the configured help/quit key labels instead of always advertising `? help · q quit`.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
