### PR TITLE
Add assign and unassign actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ tea-dash --help
 | `o` / `enter`   | open in browser         |
 | `y` / `Y`       | copy row number / URL   |
 | `c`             | add comment             |
+| `a` / `A`       | assign / unassign yourself |
 | `m`             | merge PR                |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `x` / `X`       | close / reopen          |
@@ -179,10 +180,18 @@ keybindings:
   prs:
     - key: O
       builtin: checkout
+    - key: a
+      builtin: assign
+    - key: A
+      builtin: unassign
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
   issues:
+    - key: a
+      builtin: assign
+    - key: A
+      builtin: unassign
     - key: i
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -27,6 +27,10 @@ type Client interface {
 	AddComment(owner, repo string, index int64, body string) (data.Comment, error)
 	SetIssueState(owner, repo string, index int64, state data.ItemState) error
 	SetPullState(owner, repo string, index int64, state data.ItemState) error
+	AssignPullToMe(owner, repo string, index int64) error
+	UnassignPullFromMe(owner, repo string, index int64) error
+	AssignIssueToMe(owner, repo string, index int64) error
+	UnassignIssueFromMe(owner, repo string, index int64) error
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
@@ -199,6 +203,18 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		return fmt.Sprintf("Reopened %s#%d.", intent.Target.Repo, index), nil
 
+	case uiactions.KindAssign:
+		if err := r.setAssignment(owner, repo, index, intent.Target.RowKind, true); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Assigned %s#%d to you.", intent.Target.Repo, index), nil
+
+	case uiactions.KindUnassign:
+		if err := r.setAssignment(owner, repo, index, intent.Target.RowKind, false); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Unassigned you from %s#%d.", intent.Target.Repo, index), nil
+
 	case uiactions.KindMerge:
 		style, err := mergeStyle(intent.Prompt.Value)
 		if err != nil {
@@ -344,6 +360,23 @@ func (r Runner) setState(owner, repo string, index int64, kind uiactions.RowKind
 	}
 }
 
+func (r Runner) setAssignment(owner, repo string, index int64, kind uiactions.RowKind, assign bool) error {
+	switch kind {
+	case uiactions.RowKindPullRequest:
+		if assign {
+			return r.client.AssignPullToMe(owner, repo, index)
+		}
+		return r.client.UnassignPullFromMe(owner, repo, index)
+	case uiactions.RowKindIssue:
+		if assign {
+			return r.client.AssignIssueToMe(owner, repo, index)
+		}
+		return r.client.UnassignIssueFromMe(owner, repo, index)
+	default:
+		return fmt.Errorf("assign is only available for pull requests and issues")
+	}
+}
+
 func splitRepo(repoName string) (string, string, error) {
 	owner, repo, ok := data.SplitOwnerRepo(repoName)
 	if !ok {
@@ -386,6 +419,10 @@ func actionLabel(kind uiactions.Kind) string {
 	switch kind {
 	case uiactions.KindComment:
 		return "comment"
+	case uiactions.KindAssign:
+		return "assign"
+	case uiactions.KindUnassign:
+		return "unassign"
 	case uiactions.KindMerge:
 		return "merge"
 	case uiactions.KindClose:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -105,6 +105,37 @@ func TestDispatchCommentAndClose(t *testing.T) {
 	}
 }
 
+func TestDispatchAssignAndUnassign(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	got := runDispatch(t, r, pullIntent(uiactions.KindAssign))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("assign pull result = %+v", got)
+	}
+	if client.assignPull != 7 {
+		t.Fatalf("assignPull = %d, want 7", client.assignPull)
+	}
+
+	got = runDispatch(t, r, issueIntent(uiactions.KindUnassign))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("unassign issue result = %+v", got)
+	}
+	if client.unassignIssue != 7 {
+		t.Fatalf("unassignIssue = %d, want 7", client.unassignIssue)
+	}
+}
+
+func TestDispatchAssignRejectsUnsupportedRows(t *testing.T) {
+	intent := branchIntent(uiactions.KindAssign)
+	intent.Target.Repo = "acme/widgets"
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "only available for pull requests and issues") {
+		t.Fatalf("assign branch result = %+v", got)
+	}
+}
+
 func TestDispatchMergeAndReview(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})
@@ -291,15 +322,19 @@ func TestDispatchReturnsErrorResult(t *testing.T) {
 }
 
 type fakeClient struct {
-	err         error
-	commentBody string
-	issueState  data.ItemState
-	pullState   data.ItemState
-	merge       data.MergeOptions
-	review      data.PullReviewOptions
-	diff        []byte
-	rerunRunID  int64
-	cancelRunID int64
+	err           error
+	commentBody   string
+	issueState    data.ItemState
+	pullState     data.ItemState
+	merge         data.MergeOptions
+	review        data.PullReviewOptions
+	diff          []byte
+	rerunRunID    int64
+	cancelRunID   int64
+	assignPull    int64
+	assignIssue   int64
+	unassignPull  int64
+	unassignIssue int64
 }
 
 func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
@@ -314,6 +349,26 @@ func (f *fakeClient) SetIssueState(_, _ string, _ int64, state data.ItemState) e
 
 func (f *fakeClient) SetPullState(_, _ string, _ int64, state data.ItemState) error {
 	f.pullState = state
+	return f.err
+}
+
+func (f *fakeClient) AssignPullToMe(_, _ string, index int64) error {
+	f.assignPull = index
+	return f.err
+}
+
+func (f *fakeClient) UnassignPullFromMe(_, _ string, index int64) error {
+	f.unassignPull = index
+	return f.err
+}
+
+func (f *fakeClient) AssignIssueToMe(_, _ string, index int64) error {
+	f.assignIssue = index
+	return f.err
+}
+
+func (f *fakeClient) UnassignIssueFromMe(_, _ string, index int64) error {
+	f.unassignIssue = index
 	return f.err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,11 +284,11 @@ var universalBuiltins = builtinSet(
 )
 
 var prBuiltins = builtinSet(
-	"comment", "merge", "close", "reopen", "diff", "checkout", "approve",
-	"review", "summaryViewMore", "expand",
+	"comment", "assign", "unassign", "merge", "close", "reopen", "diff",
+	"checkout", "approve", "review", "summaryViewMore", "expand",
 )
 
-var issueBuiltins = builtinSet("comment", "close", "reopen")
+var issueBuiltins = builtinSet("comment", "assign", "unassign", "close", "reopen")
 
 var notificationBuiltins = builtinSet(
 	"openGithub", "open", "markAsRead", "markRead", "markAsUnread",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -255,6 +255,10 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 	ok := Config{Keybindings: Keybindings{Universal: []Keybinding{
 		{Key: "R", Builtin: "refreshAll"},
 		{Key: "g", Command: "lazygit"},
+	}, PRs: []Keybinding{
+		{Key: "a", Builtin: "assign"},
+	}, Issues: []Keybinding{
+		{Key: "A", Builtin: "unassign"},
 	}}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected valid keybindings: %v", err)

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -55,6 +55,128 @@ func (c *Client) SetPullState(owner, repo string, index int64, state data.ItemSt
 	return nil
 }
 
+// AssignIssueToMe assigns the authenticated user to an issue while preserving
+// existing assignees.
+func (c *Client) AssignIssueToMe(owner, repo string, index int64) error {
+	return c.setIssueAssignee(owner, repo, index, true)
+}
+
+// UnassignIssueFromMe removes the authenticated user from an issue while
+// preserving every other assignee.
+func (c *Client) UnassignIssueFromMe(owner, repo string, index int64) error {
+	return c.setIssueAssignee(owner, repo, index, false)
+}
+
+func (c *Client) setIssueAssignee(owner, repo string, index int64, assign bool) error {
+	var current *sdk.Issue
+	err := c.call(func() error {
+		var e error
+		current, _, e = c.sdk.GetIssue(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("get issue assignees %s/%s#%d: %w", owner, repo, index, err)
+	}
+	assignees := updateAssigneeLogins(issueAssigneeLogins(current), c.me, assign)
+	err = c.call(func() error {
+		_, _, e := c.sdk.EditIssue(owner, repo, index, sdk.EditIssueOption{Assignees: assignees})
+		return e
+	})
+	if err != nil {
+		action := "assign"
+		if !assign {
+			action = "unassign"
+		}
+		return fmt.Errorf("%s issue %s/%s#%d to %s: %w", action, owner, repo, index, c.me, err)
+	}
+	return nil
+}
+
+// AssignPullToMe assigns the authenticated user to a pull request while
+// preserving existing assignees.
+func (c *Client) AssignPullToMe(owner, repo string, index int64) error {
+	return c.setPullAssignee(owner, repo, index, true)
+}
+
+// UnassignPullFromMe removes the authenticated user from a pull request while
+// preserving every other assignee.
+func (c *Client) UnassignPullFromMe(owner, repo string, index int64) error {
+	return c.setPullAssignee(owner, repo, index, false)
+}
+
+func (c *Client) setPullAssignee(owner, repo string, index int64, assign bool) error {
+	var current *sdk.PullRequest
+	err := c.call(func() error {
+		var e error
+		current, _, e = c.sdk.GetPullRequest(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("get pull assignees %s/%s#%d: %w", owner, repo, index, err)
+	}
+	assignees := updateAssigneeLogins(pullAssigneeLogins(current), c.me, assign)
+	err = c.call(func() error {
+		_, _, e := c.sdk.EditPullRequest(owner, repo, index, sdk.EditPullRequestOption{Assignees: assignees})
+		return e
+	})
+	if err != nil {
+		action := "assign"
+		if !assign {
+			action = "unassign"
+		}
+		return fmt.Errorf("%s pull %s/%s#%d to %s: %w", action, owner, repo, index, c.me, err)
+	}
+	return nil
+}
+
+func issueAssigneeLogins(issue *sdk.Issue) []string {
+	if issue == nil {
+		return nil
+	}
+	out := make([]string, 0, len(issue.Assignees))
+	for _, user := range issue.Assignees {
+		if user != nil && user.UserName != "" {
+			out = append(out, user.UserName)
+		}
+	}
+	return out
+}
+
+func pullAssigneeLogins(pr *sdk.PullRequest) []string {
+	if pr == nil {
+		return nil
+	}
+	out := make([]string, 0, len(pr.Assignees))
+	for _, user := range pr.Assignees {
+		if user != nil && user.UserName != "" {
+			out = append(out, user.UserName)
+		}
+	}
+	return out
+}
+
+func updateAssigneeLogins(current []string, me string, assign bool) []string {
+	if me == "" {
+		return current
+	}
+	seen := make(map[string]bool, len(current)+1)
+	out := make([]string, 0, len(current)+1)
+	for _, login := range current {
+		if login == "" || seen[login] {
+			continue
+		}
+		seen[login] = true
+		if !assign && login == me {
+			continue
+		}
+		out = append(out, login)
+	}
+	if assign && !seen[me] {
+		out = append(out, me)
+	}
+	return out
+}
+
 // MergePullRequest merges a pull request with the requested strategy and
 // optional server-side controls.
 func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -122,6 +122,73 @@ func TestSetPullStatePatchesPullState(t *testing.T) {
 	}
 }
 
+func TestAssignAndUnassignIssuePreservesOtherAssignees(t *testing.T) {
+	var patched [][]string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/42" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"number":42,"assignees":[{"login":"alice"}]}`)
+		case http.MethodPatch:
+			body := decodeMutationBody(t, r)
+			raw, ok := body["assignees"].([]any)
+			if !ok {
+				t.Fatalf("assignees body = %#v", body)
+			}
+			got := make([]string, 0, len(raw))
+			for _, v := range raw {
+				got = append(got, v.(string))
+			}
+			patched = append(patched, got)
+			fmt.Fprint(w, `{"number":42}`)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	if err := c.AssignIssueToMe("acme", "widgets", 42); err != nil {
+		t.Fatalf("AssignIssueToMe: %v", err)
+	}
+	if len(patched) != 1 || strings.Join(patched[0], ",") != "alice,me" {
+		t.Fatalf("assign patch = %#v, want alice,me", patched)
+	}
+}
+
+func TestUnassignPullPreservesOtherAssignees(t *testing.T) {
+	var patched []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/43" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"number":43,"assignees":[{"login":"me"},{"login":"alice"}]}`)
+		case http.MethodPatch:
+			body := decodeMutationBody(t, r)
+			raw, ok := body["assignees"].([]any)
+			if !ok {
+				t.Fatalf("assignees body = %#v", body)
+			}
+			patched = patched[:0]
+			for _, v := range raw {
+				patched = append(patched, v.(string))
+			}
+			fmt.Fprint(w, `{"number":43}`)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	if err := c.UnassignPullFromMe("acme", "widgets", 43); err != nil {
+		t.Fatalf("UnassignPullFromMe: %v", err)
+	}
+	if len(patched) != 1 || patched[0] != "alice" {
+		t.Fatalf("unassign patch = %#v, want alice only", patched)
+	}
+}
+
 func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -7,6 +7,8 @@ type Kind string
 
 const (
 	KindComment       Kind = "comment"
+	KindAssign        Kind = "assign"
+	KindUnassign      Kind = "unassign"
 	KindMerge         Kind = "merge"
 	KindClose         Kind = "close"
 	KindReopen        Kind = "reopen"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -401,6 +401,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindCancelRun)
 		case !m.scopedBuiltinOverridden("comment") && key.Matches(msg, m.keys.Comment):
 			return m, m.startAction(actions.KindComment)
+		case !m.scopedBuiltinOverridden("assign") && key.Matches(msg, m.keys.Assign):
+			return m, m.startAction(actions.KindAssign)
+		case !m.scopedBuiltinOverridden("unassign") && key.Matches(msg, m.keys.Unassign):
+			return m, m.startAction(actions.KindUnassign)
 		case !m.scopedBuiltinOverridden("merge") && key.Matches(msg, m.keys.Merge):
 			return m, m.startAction(actions.KindMerge)
 		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
@@ -555,7 +559,7 @@ func (m Model) helpLine() string {
 		case context.BranchesView:
 			text += " · C/space switch"
 		default:
-			text += " · c comment · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+			text += " · c comment · a/A assign/unassign · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
@@ -568,7 +572,7 @@ func (m Model) helpLine() string {
 	case context.BranchesView:
 		text += " · C/space switch"
 	default:
-		text += " · c comment · m merge · d/ctrl+t diff · C/space checkout"
+		text += " · c comment · a/A assign · m merge · d/ctrl+t diff · C/space checkout"
 	}
 	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
 }
@@ -1166,6 +1170,10 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return next, cmd, true
 	case "comment":
 		return m, m.startAction(actions.KindComment), true
+	case "assign":
+		return m, m.startAction(actions.KindAssign), true
+	case "unassign":
+		return m, m.startAction(actions.KindUnassign), true
 	case "merge":
 		return m, m.startAction(actions.KindMerge), true
 	case "close":
@@ -1283,7 +1291,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
 		}
-	case actions.KindComment, actions.KindClose, actions.KindReopen:
+	case actions.KindComment, actions.KindAssign, actions.KindUnassign, actions.KindClose, actions.KindReopen:
 		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
 		}
@@ -1369,6 +1377,10 @@ func actionLabel(kind actions.Kind) string {
 	switch kind {
 	case actions.KindComment:
 		return "Comment"
+	case actions.KindAssign:
+		return "Assign"
+	case actions.KindUnassign:
+		return "Unassign"
 	case actions.KindMerge:
 		return "Merge"
 	case actions.KindClose:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1259,6 +1259,8 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				Label: "Squash",
 			},
 		},
+		{name: "assign", key: tea.KeyPressMsg{Code: 'a', Text: "a"}, kind: actions.KindAssign},
+		{name: "unassign", key: tea.KeyPressMsg{Code: 'A', Text: "A"}, kind: actions.KindUnassign},
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -24,6 +24,8 @@ type keyMap struct {
 	ScrollDown    key.Binding
 	Expand        key.Binding
 	Comment       key.Binding
+	Assign        key.Binding
+	Unassign      key.Binding
 	Merge         key.Binding
 	Close         key.Binding
 	Reopen        key.Binding
@@ -93,6 +95,14 @@ func defaultKeyMap() keyMap {
 		Comment: key.NewBinding(
 			key.WithKeys("c"),
 			key.WithHelp("c", "comment"),
+		),
+		Assign: key.NewBinding(
+			key.WithKeys("a"),
+			key.WithHelp("a", "assign"),
+		),
+		Unassign: key.NewBinding(
+			key.WithKeys("A"),
+			key.WithHelp("A", "unassign"),
 		),
 		Merge: key.NewBinding(
 			key.WithKeys("m"),
@@ -197,6 +207,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Expand = binding(keyName, "expand")
 	case "comment":
 		k.Comment = binding(keyName, "comment")
+	case "assign":
+		k.Assign = binding(keyName, "assign")
+	case "unassign":
+		k.Unassign = binding(keyName, "unassign")
 	case "merge":
 		k.Merge = binding(keyName, "merge")
 	case "close":


### PR DESCRIPTION
## Summary

- Add `a` / `A` actions to assign or unassign the authenticated user on selected PRs and issues.
- Preserve existing assignees by fetching the current item before patching the updated assignee list.
- Expose `assign` and `unassign` as PR/issue scoped configurable keybinding built-ins.

## Test Plan

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
