### PR TITLE
Scrub local personal examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Gabor Barany
+Copyright (c) 2026 tea-dash contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ instance:
   # tokenCommand: op read "op://Private/tea-dash/credential"   # e.g. 1Password, pass, gopass
   # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
   # Example for 1Password:
-  # tokenCommand: op read "op://Appic/tea-dash PAT/credential"
+  # tokenCommand: op read "op://Private/tea-dash/credential"
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
@@ -127,13 +127,13 @@ defaults:
 
 localRepos:
   - name: tea-dash
-    path: /Users/gaborbarany/dev/sandbox/tea-dash
+    path: ~/src/tea-dash
 
 pager:
   diff: diffnav     # command that receives PR diff bytes on stdin (falls back to $PAGER, then less -R)
 
 repoPaths:
-  "gbarany/*": "~/dev/sandbox/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
+  "gbarany/*": "~/src/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
 
 git:
   remote: origin

--- a/docs/superpowers/plans/2026-07-01-tea-dash-m0-sdk-pivot.md
+++ b/docs/superpowers/plans/2026-07-01-tea-dash-m0-sdk-pivot.md
@@ -52,7 +52,7 @@
 
 Run:
 ```bash
-cd /Users/gaborbarany/dev/sandbox/tea-dash
+cd /path/to/tea-dash
 go get code.gitea.io/sdk/gitea@latest
 ```
 Expected: `go.mod` gains `require code.gitea.io/sdk/gitea v0.25.1` (or newer). The `NewClient`/`SetToken`/`GetMyUserInfo`/`ServerVersion` API used here is verified against v0.25.1. If `@latest` ever regresses, pin it: `go get code.gitea.io/sdk/gitea@v0.25.1`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	Defaults Defaults `yaml:"defaults"`
 	// Pager configures external pager commands.
 	Pager Pager `yaml:"pager"`
-	// RepoPaths maps repo names or wildcard patterns (for example "fcmb/*")
+	// RepoPaths maps repo names or wildcard patterns (for example "acme/*")
 	// to local checkout paths.
 	RepoPaths map[string]string `yaml:"repoPaths"`
 	// Git configures local git checkout behavior.
@@ -362,7 +362,7 @@ func ExpandPath(p string) (string, error) {
 }
 
 // MatchRepoPath returns the path mapped for repoName, preferring an exact key
-// before evaluating wildcard patterns such as "fcmb/*". Mapped paths may use
+// before evaluating wildcard patterns such as "acme/*". Mapped paths may use
 // {{.Owner}}, {{.Repo}}, and {{.RepoName}} template variables, and are expanded
 // through ExpandPath before being returned.
 func MatchRepoPath(repoName string, repoPaths map[string]string) (string, bool, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -103,7 +103,7 @@ branchSections:
     limit: 25
 localRepos:
   - name: tea-dash
-    path: /Users/gaborbarany/dev/sandbox/tea-dash
+    path: /path/to/tea-dash
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
@@ -139,7 +139,7 @@ localRepos:
 		t.Fatalf("branchSections = %+v", c.BranchSections)
 	}
 	if len(c.LocalRepos) != 1 || c.LocalRepos[0].Name != "tea-dash" ||
-		c.LocalRepos[0].Path != "/Users/gaborbarany/dev/sandbox/tea-dash" {
+		c.LocalRepos[0].Path != "/path/to/tea-dash" {
 		t.Fatalf("localRepos = %+v", c.LocalRepos)
 	}
 }
@@ -149,8 +149,8 @@ func TestUnmarshalPagerRepoPathsAndGit(t *testing.T) {
 pager:
   diff: delta --paging=always
 repoPaths:
-  fcmb/api: ~/src/fcmb-api
-  fcmb/*: ~/src/fcmb/{{.Repo}}
+  acme/api: ~/src/acme-api
+  acme/*: ~/src/acme/{{.Repo}}
 git:
   remote: upstream
   prBranchTemplate: review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}
@@ -162,7 +162,7 @@ git:
 	if c.Pager.Diff != "delta --paging=always" {
 		t.Fatalf("pager.diff = %q", c.Pager.Diff)
 	}
-	if c.RepoPaths["fcmb/api"] != "~/src/fcmb-api" || c.RepoPaths["fcmb/*"] != "~/src/fcmb/{{.Repo}}" {
+	if c.RepoPaths["acme/api"] != "~/src/acme-api" || c.RepoPaths["acme/*"] != "~/src/acme/{{.Repo}}" {
 		t.Fatalf("repoPaths = %+v", c.RepoPaths)
 	}
 	if c.Git.Remote != "upstream" || c.Git.PRBranchTemplate != "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}" {
@@ -300,10 +300,10 @@ func TestMatchRepoPathExactBeforeWildcardAndExpandsHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	paths := map[string]string{
-		"fcmb/*":   "~/src/fcmb/{{.Repo}}",
-		"fcmb/api": "~/src/exact",
+		"acme/*":   "~/src/acme/{{.Repo}}",
+		"acme/api": "~/src/exact",
 	}
-	got, ok, err := MatchRepoPath("fcmb/api", paths)
+	got, ok, err := MatchRepoPath("acme/api", paths)
 	if err != nil {
 		t.Fatalf("MatchRepoPath exact: %v", err)
 	}
@@ -314,21 +314,21 @@ func TestMatchRepoPathExactBeforeWildcardAndExpandsHome(t *testing.T) {
 		t.Fatalf("MatchRepoPath exact = %q, want %q", got, want)
 	}
 
-	got, ok, err = MatchRepoPath("fcmb/web", paths)
+	got, ok, err = MatchRepoPath("acme/web", paths)
 	if err != nil {
 		t.Fatalf("MatchRepoPath wildcard: %v", err)
 	}
 	if !ok {
 		t.Fatal("MatchRepoPath wildcard did not match")
 	}
-	if want := filepath.Join(home, "src", "fcmb", "web"); got != want {
+	if want := filepath.Join(home, "src", "acme", "web"); got != want {
 		t.Fatalf("MatchRepoPath wildcard = %q, want %q", got, want)
 	}
 }
 
 func TestMatchRepoPathRejectsBadWildcard(t *testing.T) {
-	_, _, err := MatchRepoPath("fcmb/api", map[string]string{"fcmb/[": "/tmp/repo"})
-	if err == nil || !strings.Contains(err.Error(), "fcmb/[") {
+	_, _, err := MatchRepoPath("acme/api", map[string]string{"acme/[": "/tmp/repo"})
+	if err == nil || !strings.Contains(err.Error(), "acme/[") {
 		t.Fatalf("MatchRepoPath bad wildcard error = %v", err)
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -74,7 +74,7 @@ func TestParseRemoteURL(t *testing.T) {
 }
 
 func TestRemoteMatchesInstanceURL(t *testing.T) {
-	remote, err := ParseRemoteURL("git@gitea.example.com:fcmb/api.git")
+	remote, err := ParseRemoteURL("git@gitea.example.com:acme/api.git")
 	if err != nil {
 		t.Fatalf("ParseRemoteURL: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestRemoteMatchesInstanceURL(t *testing.T) {
 		t.Fatal("remote should not match a different instance host")
 	}
 
-	withPort, err := ParseRemoteURL("ssh://git@gitea.example.com:2222/fcmb/api.git")
+	withPort, err := ParseRemoteURL("ssh://git@gitea.example.com:2222/acme/api.git")
 	if err != nil {
 		t.Fatalf("ParseRemoteURL with port: %v", err)
 	}
@@ -101,11 +101,11 @@ func TestResolveRepoPathExactWildcardAndCWD(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	paths := map[string]string{
-		"fcmb/*":   "~/work/fcmb/{{.Repo}}",
-		"fcmb/api": "~/work/exact-api",
+		"acme/*":   "~/work/acme/{{.Repo}}",
+		"acme/api": "~/work/exact-api",
 	}
 
-	got, err := ResolveRepoPath("fcmb/api", "/not/used", "https://gitea.example.com", paths)
+	got, err := ResolveRepoPath("acme/api", "/not/used", "https://gitea.example.com", paths)
 	if err != nil {
 		t.Fatalf("ResolveRepoPath exact: %v", err)
 	}
@@ -113,16 +113,16 @@ func TestResolveRepoPathExactWildcardAndCWD(t *testing.T) {
 		t.Fatalf("ResolveRepoPath exact = %q, want %q", got, want)
 	}
 
-	got, err = ResolveRepoPath("fcmb/web", "/not/used", "https://gitea.example.com", paths)
+	got, err = ResolveRepoPath("acme/web", "/not/used", "https://gitea.example.com", paths)
 	if err != nil {
 		t.Fatalf("ResolveRepoPath wildcard: %v", err)
 	}
-	if want := filepath.Join(home, "work", "fcmb", "web"); got != want {
+	if want := filepath.Join(home, "work", "acme", "web"); got != want {
 		t.Fatalf("ResolveRepoPath wildcard = %q, want %q", got, want)
 	}
 
-	cwd := makeGitDir(t, "https://gitea.example.com/fcmb/api.git")
-	got, err = ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	cwd := makeGitDir(t, "https://gitea.example.com/acme/api.git")
+	got, err = ResolveRepoPath("acme/api", cwd, "https://gitea.example.com", nil)
 	if err != nil {
 		t.Fatalf("ResolveRepoPath cwd: %v", err)
 	}
@@ -132,23 +132,23 @@ func TestResolveRepoPathExactWildcardAndCWD(t *testing.T) {
 }
 
 func TestResolveRepoPathRejectsCWDHostMismatch(t *testing.T) {
-	cwd := makeGitDir(t, "https://other.example.com/fcmb/api.git")
-	_, err := ResolveRepoPath("fcmb/api", cwd, "https://gitea.example.com", nil)
+	cwd := makeGitDir(t, "https://other.example.com/acme/api.git")
+	_, err := ResolveRepoPath("acme/api", cwd, "https://gitea.example.com", nil)
 	if err == nil || !strings.Contains(err.Error(), "no local checkout") {
 		t.Fatalf("ResolveRepoPath host mismatch error = %v", err)
 	}
 }
 
 func TestBranchNameFromTemplate(t *testing.T) {
-	got, err := BranchNameFromTemplate("review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}", "fcmb/api", 42)
+	got, err := BranchNameFromTemplate("review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}", "acme/api", 42)
 	if err != nil {
 		t.Fatalf("BranchNameFromTemplate: %v", err)
 	}
-	if got != "review/fcmb-api-42" {
+	if got != "review/acme-api-42" {
 		t.Fatalf("BranchNameFromTemplate = %q", got)
 	}
 
-	got, err = BranchNameFromTemplate("", "fcmb/api", 42)
+	got, err = BranchNameFromTemplate("", "acme/api", 42)
 	if err != nil {
 		t.Fatalf("BranchNameFromTemplate default: %v", err)
 	}
@@ -162,8 +162,8 @@ func TestRunCheckoutDirtyTreeRefusal(t *testing.T) {
 	runner := &fakeRunner{results: []Result{{Stdout: " M file.txt\n", ExitCode: 0}}}
 
 	_, err := RunCheckout(context.Background(), CheckoutOptions{
-		RepoName:  "fcmb/api",
-		RepoPaths: map[string]string{"fcmb/api": repo},
+		RepoName:  "acme/api",
+		RepoPaths: map[string]string{"acme/api": repo},
 		PrIndex:   42,
 		Runner:    runner,
 	})
@@ -185,8 +185,8 @@ func TestRunCheckoutFetchesAndCreatesMissingBranch(t *testing.T) {
 	}}
 
 	plan, err := RunCheckout(context.Background(), CheckoutOptions{
-		RepoName:       "fcmb/api",
-		RepoPaths:      map[string]string{"fcmb/api": repo},
+		RepoName:       "acme/api",
+		RepoPaths:      map[string]string{"acme/api": repo},
 		Remote:         "upstream",
 		BranchTemplate: "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}",
 		PrIndex:        42,
@@ -195,7 +195,7 @@ func TestRunCheckoutFetchesAndCreatesMissingBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunCheckout: %v", err)
 	}
-	if plan.Branch != "review/fcmb-api-42" {
+	if plan.Branch != "review/acme-api-42" {
 		t.Fatalf("Branch = %q", plan.Branch)
 	}
 	if plan.FetchRefspec != "+refs/pull/42/head:refs/remotes/upstream/pull/42/head" {
@@ -204,8 +204,8 @@ func TestRunCheckoutFetchesAndCreatesMissingBranch(t *testing.T) {
 	assertCommands(t, runner.commands, []Command{
 		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
 		{Dir: repo, Name: "git", Args: []string{"fetch", "upstream", "+refs/pull/42/head:refs/remotes/upstream/pull/42/head"}},
-		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/review/fcmb-api-42"}},
-		{Dir: repo, Name: "git", Args: []string{"switch", "-c", "review/fcmb-api-42", "refs/remotes/upstream/pull/42/head"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/review/acme-api-42"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "-c", "review/acme-api-42", "refs/remotes/upstream/pull/42/head"}},
 	})
 }
 
@@ -220,8 +220,8 @@ func TestRunCheckoutExistingBranchFastForwardOnly(t *testing.T) {
 	}}
 
 	_, err := RunCheckout(context.Background(), CheckoutOptions{
-		RepoName:  "fcmb/api",
-		RepoPaths: map[string]string{"fcmb/api": repo},
+		RepoName:  "acme/api",
+		RepoPaths: map[string]string{"acme/api": repo},
 		PrIndex:   7,
 		Runner:    runner,
 	})
@@ -240,7 +240,7 @@ func TestRunCheckoutExistingBranchFastForwardOnly(t *testing.T) {
 func TestRunCheckoutMissingRepoPath(t *testing.T) {
 	runner := &fakeRunner{}
 	_, err := RunCheckout(context.Background(), CheckoutOptions{
-		RepoName:    "fcmb/api",
+		RepoName:    "acme/api",
 		CWD:         t.TempDir(),
 		InstanceURL: "https://gitea.example.com",
 		PrIndex:     7,


### PR DESCRIPTION
## Summary

- Replace local machine paths and private 1Password example references with generic placeholders.
- Neutralize example organization/repo names in config and git tests.
- Change the license copyright holder to a generic contributors line.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `git diff --check`
- `git grep -n -E '(Gabor Barany|gaborbarany@|barany\\.gabor|/Users/|op://Appic|tea-dash PAT|fcmb|debian13|tailcd|tailnet)' -- . ':(exclude).git' || true`
