### PR TITLE
Add label actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ tea-dash --help
 | `y` / `Y`       | copy row number / URL   |
 | `c`             | add comment             |
 | `a` / `A`       | assign / unassign yourself |
+| `L` / `U`       | add / remove labels     |
 | `m`             | merge PR                |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `x` / `X`       | close / reopen          |
@@ -184,6 +185,10 @@ keybindings:
       builtin: assign
     - key: A
       builtin: unassign
+    - key: L
+      builtin: addLabel
+    - key: U
+      builtin: removeLabel
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
@@ -192,6 +197,10 @@ keybindings:
       builtin: assign
     - key: A
       builtin: unassign
+    - key: L
+      builtin: addLabel
+    - key: U
+      builtin: removeLabel
     - key: i
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -31,6 +31,8 @@ type Client interface {
 	UnassignPullFromMe(owner, repo string, index int64) error
 	AssignIssueToMe(owner, repo string, index int64) error
 	UnassignIssueFromMe(owner, repo string, index int64) error
+	AddLabels(owner, repo string, index int64, names []string) error
+	RemoveLabels(owner, repo string, index int64, names []string) error
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
@@ -215,6 +217,26 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		return fmt.Sprintf("Unassigned you from %s#%d.", intent.Target.Repo, index), nil
 
+	case uiactions.KindAddLabel:
+		names, err := parseLabelNames(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		if err := r.setLabels(owner, repo, index, intent.Target.RowKind, names, true); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Added labels to %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindRemoveLabel:
+		names, err := parseLabelNames(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		if err := r.setLabels(owner, repo, index, intent.Target.RowKind, names, false); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Removed labels from %s#%d.", intent.Target.Repo, index), nil
+
 	case uiactions.KindMerge:
 		style, err := mergeStyle(intent.Prompt.Value)
 		if err != nil {
@@ -377,6 +399,36 @@ func (r Runner) setAssignment(owner, repo string, index int64, kind uiactions.Ro
 	}
 }
 
+func parseLabelNames(input string) ([]string, error) {
+	parts := strings.Split(input, ",")
+	out := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("label names cannot be empty")
+	}
+	return out, nil
+}
+
+func (r Runner) setLabels(owner, repo string, index int64, kind uiactions.RowKind, names []string, add bool) error {
+	switch kind {
+	case uiactions.RowKindPullRequest, uiactions.RowKindIssue:
+		if add {
+			return r.client.AddLabels(owner, repo, index, names)
+		}
+		return r.client.RemoveLabels(owner, repo, index, names)
+	default:
+		return fmt.Errorf("labels are only available for pull requests and issues")
+	}
+}
+
 func splitRepo(repoName string) (string, string, error) {
 	owner, repo, ok := data.SplitOwnerRepo(repoName)
 	if !ok {
@@ -423,6 +475,10 @@ func actionLabel(kind uiactions.Kind) string {
 		return "assign"
 	case uiactions.KindUnassign:
 		return "unassign"
+	case uiactions.KindAddLabel:
+		return "add label"
+	case uiactions.KindRemoveLabel:
+		return "remove label"
 	case uiactions.KindMerge:
 		return "merge"
 	case uiactions.KindClose:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -136,6 +136,52 @@ func TestDispatchAssignRejectsUnsupportedRows(t *testing.T) {
 	}
 }
 
+func TestDispatchAddAndRemoveLabels(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	add := pullIntent(uiactions.KindAddLabel)
+	add.Prompt.Value = "bug, urgent"
+	got := runDispatch(t, r, add)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("add label result = %+v", got)
+	}
+	if !reflect.DeepEqual(client.addLabels, []string{"bug", "urgent"}) || client.labelIndex != 7 {
+		t.Fatalf("add labels = %v index=%d, want [bug urgent] index 7", client.addLabels, client.labelIndex)
+	}
+
+	remove := issueIntent(uiactions.KindRemoveLabel)
+	remove.Prompt.Value = "stale"
+	got = runDispatch(t, r, remove)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("remove label result = %+v", got)
+	}
+	if !reflect.DeepEqual(client.removeLabels, []string{"stale"}) || client.labelIndex != 7 {
+		t.Fatalf("remove labels = %v index=%d, want [stale] index 7", client.removeLabels, client.labelIndex)
+	}
+}
+
+func TestDispatchLabelsRejectEmptyInput(t *testing.T) {
+	intent := pullIntent(uiactions.KindAddLabel)
+	intent.Prompt.Value = " , "
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "label names cannot be empty") {
+		t.Fatalf("empty label result = %+v", got)
+	}
+}
+
+func TestDispatchLabelsRejectUnsupportedRows(t *testing.T) {
+	intent := branchIntent(uiactions.KindAddLabel)
+	intent.Target.Repo = "acme/widgets"
+	intent.Prompt.Value = "bug"
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "only available for pull requests and issues") {
+		t.Fatalf("label branch result = %+v", got)
+	}
+}
+
 func TestDispatchMergeAndReview(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})
@@ -335,6 +381,9 @@ type fakeClient struct {
 	assignIssue   int64
 	unassignPull  int64
 	unassignIssue int64
+	labelIndex    int64
+	addLabels     []string
+	removeLabels  []string
 }
 
 func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
@@ -369,6 +418,18 @@ func (f *fakeClient) AssignIssueToMe(_, _ string, index int64) error {
 
 func (f *fakeClient) UnassignIssueFromMe(_, _ string, index int64) error {
 	f.unassignIssue = index
+	return f.err
+}
+
+func (f *fakeClient) AddLabels(_, _ string, index int64, names []string) error {
+	f.labelIndex = index
+	f.addLabels = append([]string(nil), names...)
+	return f.err
+}
+
+func (f *fakeClient) RemoveLabels(_, _ string, index int64, names []string) error {
+	f.labelIndex = index
+	f.removeLabels = append([]string(nil), names...)
 	return f.err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,11 +284,14 @@ var universalBuiltins = builtinSet(
 )
 
 var prBuiltins = builtinSet(
-	"comment", "assign", "unassign", "merge", "close", "reopen", "diff",
-	"checkout", "approve", "review", "summaryViewMore", "expand",
+	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
+	"close", "reopen", "diff", "checkout", "approve", "review",
+	"summaryViewMore", "expand",
 )
 
-var issueBuiltins = builtinSet("comment", "assign", "unassign", "close", "reopen")
+var issueBuiltins = builtinSet(
+	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
+)
 
 var notificationBuiltins = builtinSet(
 	"openGithub", "open", "markAsRead", "markRead", "markAsUnread",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,8 +257,10 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "g", Command: "lazygit"},
 	}, PRs: []Keybinding{
 		{Key: "a", Builtin: "assign"},
+		{Key: "L", Builtin: "addLabel"},
 	}, Issues: []Keybinding{
 		{Key: "A", Builtin: "unassign"},
+		{Key: "U", Builtin: "removeLabel"},
 	}}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected valid keybindings: %v", err)

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -177,6 +177,74 @@ func updateAssigneeLogins(current []string, me string, assign bool) []string {
 	return out
 }
 
+// AddLabels adds repository labels, by exact name, to an issue or pull request.
+func (c *Client) AddLabels(owner, repo string, index int64, names []string) error {
+	ids, err := c.resolveLabelIDs(owner, repo, names)
+	if err != nil {
+		return err
+	}
+	err = c.call(func() error {
+		_, _, e := c.sdk.AddIssueLabels(owner, repo, index, sdk.IssueLabelsOption{Labels: ids})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("add labels to %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return nil
+}
+
+// RemoveLabels removes repository labels, by exact name, from an issue or pull
+// request. Gitea models PR labels through the issue-label API.
+func (c *Client) RemoveLabels(owner, repo string, index int64, names []string) error {
+	ids, err := c.resolveLabelIDs(owner, repo, names)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		labelID := id
+		err = c.call(func() error {
+			_, e := c.sdk.DeleteIssueLabel(owner, repo, index, labelID)
+			return e
+		})
+		if err != nil {
+			return fmt.Errorf("remove label %d from %s/%s#%d: %w", labelID, owner, repo, index, err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) resolveLabelIDs(owner, repo string, names []string) ([]int64, error) {
+	if len(names) == 0 {
+		return nil, fmt.Errorf("label names cannot be empty")
+	}
+	var labels []*sdk.Label
+	err := c.call(func() error {
+		var e error
+		labels, _, e = c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{
+			ListOptions: sdk.ListOptions{Page: -1},
+		})
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list labels for %s/%s: %w", owner, repo, err)
+	}
+	byName := make(map[string]int64, len(labels))
+	for _, label := range labels {
+		if label != nil {
+			byName[label.Name] = label.ID
+		}
+	}
+	ids := make([]int64, 0, len(names))
+	for _, name := range names {
+		id, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown label %q in %s/%s", name, owner, repo)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 // MergePullRequest merges a pull request with the requested strategy and
 // optional server-side controls.
 func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -189,6 +189,71 @@ func TestUnassignPullPreservesOtherAssignees(t *testing.T) {
 	}
 }
 
+func TestAddLabelsResolvesNamesAndPostsIDs(t *testing.T) {
+	var posted []int64
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/widgets/labels":
+			fmt.Fprint(w, `[{"id":1,"name":"bug"},{"id":2,"name":"urgent"}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/repos/acme/widgets/issues/42/labels":
+			body := decodeMutationBody(t, r)
+			raw, ok := body["labels"].([]any)
+			if !ok {
+				t.Fatalf("labels body = %#v", body)
+			}
+			for _, v := range raw {
+				posted = append(posted, int64(v.(float64)))
+			}
+			fmt.Fprint(w, `[{"id":1,"name":"bug"},{"id":2,"name":"urgent"}]`)
+		default:
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+	})
+
+	if err := c.AddLabels("acme", "widgets", 42, []string{"bug", "urgent"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+	if len(posted) != 2 || posted[0] != 1 || posted[1] != 2 {
+		t.Fatalf("posted label IDs = %v, want [1 2]", posted)
+	}
+}
+
+func TestRemoveLabelsResolvesNamesAndDeletesIDs(t *testing.T) {
+	var deleted []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/widgets/labels":
+			fmt.Fprint(w, `[{"id":1,"name":"bug"},{"id":2,"name":"stale"}]`)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/repos/acme/widgets/issues/42/labels/"):
+			deleted = append(deleted, strings.TrimPrefix(r.URL.Path, "/api/v1/repos/acme/widgets/issues/42/labels/"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+	})
+
+	if err := c.RemoveLabels("acme", "widgets", 42, []string{"bug", "stale"}); err != nil {
+		t.Fatalf("RemoveLabels: %v", err)
+	}
+	if strings.Join(deleted, ",") != "1,2" {
+		t.Fatalf("deleted label IDs = %v, want [1 2]", deleted)
+	}
+}
+
+func TestAddLabelsUnknownNameErrors(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/repos/acme/widgets/labels" {
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+		fmt.Fprint(w, `[{"id":1,"name":"bug"}]`)
+	})
+
+	err := c.AddLabels("acme", "widgets", 42, []string{"missing"})
+	if err == nil || !strings.Contains(err.Error(), `unknown label "missing"`) {
+		t.Fatalf("AddLabels unknown error = %v", err)
+	}
+}
+
 func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -9,6 +9,8 @@ const (
 	KindComment       Kind = "comment"
 	KindAssign        Kind = "assign"
 	KindUnassign      Kind = "unassign"
+	KindAddLabel      Kind = "add_label"
+	KindRemoveLabel   Kind = "remove_label"
 	KindMerge         Kind = "merge"
 	KindClose         Kind = "close"
 	KindReopen        Kind = "reopen"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -5,6 +5,8 @@ import "testing"
 func TestKindConstants(t *testing.T) {
 	tests := map[Kind]string{
 		KindComment:      "comment",
+		KindAddLabel:     "add_label",
+		KindRemoveLabel:  "remove_label",
 		KindMerge:        "merge",
 		KindClose:        "close",
 		KindReopen:       "reopen",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -405,6 +405,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindAssign)
 		case !m.scopedBuiltinOverridden("unassign") && key.Matches(msg, m.keys.Unassign):
 			return m, m.startAction(actions.KindUnassign)
+		case !m.scopedBuiltinOverridden("addlabel") && key.Matches(msg, m.keys.AddLabel):
+			return m, m.startAction(actions.KindAddLabel)
+		case !m.scopedBuiltinOverridden("removelabel") && key.Matches(msg, m.keys.RemoveLabel):
+			return m, m.startAction(actions.KindRemoveLabel)
 		case !m.scopedBuiltinOverridden("merge") && key.Matches(msg, m.keys.Merge):
 			return m, m.startAction(actions.KindMerge)
 		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
@@ -559,7 +563,7 @@ func (m Model) helpLine() string {
 		case context.BranchesView:
 			text += " · C/space switch"
 		default:
-			text += " · c comment · a/A assign/unassign · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+			text += " · c comment · a/A assign/unassign · L/U labels · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
@@ -572,7 +576,7 @@ func (m Model) helpLine() string {
 	case context.BranchesView:
 		text += " · C/space switch"
 	default:
-		text += " · c comment · a/A assign · m merge · d/ctrl+t diff · C/space checkout"
+		text += " · c comment · a/A assign · L/U labels · m merge · d/ctrl+t diff · C/space checkout"
 	}
 	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
 }
@@ -1174,6 +1178,10 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindAssign), true
 	case "unassign":
 		return m, m.startAction(actions.KindUnassign), true
+	case "addlabel":
+		return m, m.startAction(actions.KindAddLabel), true
+	case "removelabel":
+		return m, m.startAction(actions.KindRemoveLabel), true
 	case "merge":
 		return m, m.startAction(actions.KindMerge), true
 	case "close":
@@ -1291,7 +1299,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
 		}
-	case actions.KindComment, actions.KindAssign, actions.KindUnassign, actions.KindClose, actions.KindReopen:
+	case actions.KindComment, actions.KindAssign, actions.KindUnassign, actions.KindAddLabel, actions.KindRemoveLabel, actions.KindClose, actions.KindReopen:
 		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
 		}
@@ -1313,6 +1321,8 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 	switch kind {
 	case actions.KindComment:
 		return actions.PromptText
+	case actions.KindAddLabel, actions.KindRemoveLabel:
+		return actions.PromptText
 	case actions.KindMerge, actions.KindReview:
 		return actions.PromptPicker
 	default:
@@ -1333,6 +1343,20 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 			Title:       title,
 			Message:     message,
 			Placeholder: "Write a comment",
+		}
+	case actions.KindAddLabel:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Label names, comma-separated",
+		}
+	case actions.KindRemoveLabel:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Label names to remove, comma-separated",
 		}
 	case actions.KindReview:
 		return actionprompt.Config{
@@ -1381,6 +1405,10 @@ func actionLabel(kind actions.Kind) string {
 		return "Assign"
 	case actions.KindUnassign:
 		return "Unassign"
+	case actions.KindAddLabel:
+		return "Add label"
+	case actions.KindRemoveLabel:
+		return "Remove label"
 	case actions.KindMerge:
 		return "Merge"
 	case actions.KindClose:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1245,6 +1245,7 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		key         tea.KeyPressMsg
 		kind        actions.Kind
 		beforeEnter []tea.KeyPressMsg
+		textInput   []tea.KeyPressMsg
 		wantPrompt  actions.Prompt
 	}{
 		{name: "comment", key: tea.KeyPressMsg{Code: 'c', Text: "c"}, kind: actions.KindComment},
@@ -1261,6 +1262,26 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		},
 		{name: "assign", key: tea.KeyPressMsg{Code: 'a', Text: "a"}, kind: actions.KindAssign},
 		{name: "unassign", key: tea.KeyPressMsg{Code: 'A', Text: "A"}, kind: actions.KindUnassign},
+		{
+			name:      "add label",
+			key:       tea.KeyPressMsg{Code: 'L', Text: "L"},
+			kind:      actions.KindAddLabel,
+			textInput: []tea.KeyPressMsg{{Code: 'b', Text: "b"}, {Code: 'u', Text: "u"}, {Code: 'g', Text: "g"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptText,
+				Value: "bug",
+			},
+		},
+		{
+			name:      "remove label",
+			key:       tea.KeyPressMsg{Code: 'U', Text: "U"},
+			kind:      actions.KindRemoveLabel,
+			textInput: []tea.KeyPressMsg{{Code: 's', Text: "s"}, {Code: 't', Text: "t"}, {Code: 'a', Text: "a"}, {Code: 'l', Text: "l"}, {Code: 'e', Text: "e"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptText,
+				Value: "stale",
+			},
+		},
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
@@ -1291,6 +1312,9 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 			if tt.kind == actions.KindComment {
 				m = update(t, m, tea.KeyPressMsg{Code: 'o', Text: "o"})
 				m = update(t, m, tea.KeyPressMsg{Code: 'k', Text: "k"})
+			}
+			for _, key := range tt.textInput {
+				m = update(t, m, key)
 			}
 			for _, key := range tt.beforeEnter {
 				m = update(t, m, key)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -26,6 +26,8 @@ type keyMap struct {
 	Comment       key.Binding
 	Assign        key.Binding
 	Unassign      key.Binding
+	AddLabel      key.Binding
+	RemoveLabel   key.Binding
 	Merge         key.Binding
 	Close         key.Binding
 	Reopen        key.Binding
@@ -103,6 +105,14 @@ func defaultKeyMap() keyMap {
 		Unassign: key.NewBinding(
 			key.WithKeys("A"),
 			key.WithHelp("A", "unassign"),
+		),
+		AddLabel: key.NewBinding(
+			key.WithKeys("L"),
+			key.WithHelp("L", "add label"),
+		),
+		RemoveLabel: key.NewBinding(
+			key.WithKeys("U"),
+			key.WithHelp("U", "remove label"),
 		),
 		Merge: key.NewBinding(
 			key.WithKeys("m"),
@@ -211,6 +221,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Assign = binding(keyName, "assign")
 	case "unassign":
 		k.Unassign = binding(keyName, "unassign")
+	case "addlabel":
+		k.AddLabel = binding(keyName, "add label")
+	case "removelabel":
+		k.RemoveLabel = binding(keyName, "remove label")
 	case "merge":
 		k.Merge = binding(keyName, "merge")
 	case "close":


### PR DESCRIPTION
## Summary

- Add `L` / `U` PR and issue actions for adding/removing labels by comma-separated label names.
- Resolve exact label names to repository label IDs before mutating through Gitea's issue-label API.
- Expose `addLabel` and `removeLabel` as PR/issue scoped configurable keybinding built-ins.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
- `git grep -n -E '(Gabor Barany|gaborbarany@|barany\\.gabor|/Users/|op://Appic|tea-dash PAT|fcmb|debian13|tailcd|tailnet)' -- . ':(exclude).git' || true`

## Review

- Independent review agent found no P0/P1/P2 issues.
