### PR TITLE
Guard public repo examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,17 +28,17 @@ Requires **Go 1.26+** (the Gitea SDK's go.mod declares `go 1.26`).
 
 Order: `instance.token` > `instance.tokenCommand` (stdout) > `instance.tokenEnv` > `TEA_DASH_TOKEN` > the
 selected `tea` login's token. tea-dash reads `tea`'s config file (`os.UserConfigDir()/tea/config.yml`); if `tea`
-kept the token in the OS **keychain** (empty in the file), use `tokenCommand`, e.g. 1Password:
+kept the token in the OS **keychain** (empty in the file), use `tokenCommand` with a secret manager:
 
 ```yaml
 # ~/.config/tea-dash/config.yml
 instance:
-  tokenCommand: op read "op://<vault>/<item>/credential"
+  tokenCommand: "<command that prints the token>"
 ```
 
 ## Deployment / Release process
 
-Distribution is **Homebrew via a personal cask tap** (goreleaser). One command cuts a release.
+Distribution is **Homebrew via a cask tap** (goreleaser). One command cuts a release.
 
 ### To ship a new version
 
@@ -81,9 +81,8 @@ goreleaser release --snapshot --clean --skip=publish   # dry-run a full build lo
 ```bash
 brew install gbarany/tap/tea-dash     # macOS + Linux
 ```
-On this machine it's also declared in the chezmoi-managed Brewfile
-(`~/.local/share/chezmoi/home/dot_config/homebrew/Brewfile.tmpl`: `tap "gbarany/tap"` + `cask "gbarany/tap/tea-dash"`),
-installed on `chezmoi apply` / `brew bundle`.
+Do not commit private machine paths, secret-manager item routes, personal access tokens, or tenant-specific examples.
+Use placeholders such as `<repo-path>` and `<command that prints the token>` in committed docs and tests.
 
 ### homebrew-core (later, optional)
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ fmt-check: ## Fail if the code is not gofmt-clean
 vet: ## Run go vet
 	go vet ./...
 
+.PHONY: public-hygiene
+public-hygiene: ## Fail on local/private examples that should not be in the public repo
+	bash scripts/check-public-hygiene.sh
+
 .PHONY: lint
 lint: ## Run golangci-lint (requires golangci-lint >= v2)
 	golangci-lint run
@@ -48,7 +52,7 @@ tidy: ## Tidy go.mod / go.sum
 	go mod tidy
 
 .PHONY: check
-check: fmt-check vet test ## Run the full local check suite
+check: fmt-check vet test public-hygiene ## Run the full local check suite
 
 .PHONY: clean
 clean: ## Remove build artefacts

--- a/README.md
+++ b/README.md
@@ -112,11 +112,9 @@ instance:
   # Token source (first non-empty wins): token > tokenCommand > tokenEnv > TEA_DASH_TOKEN > tea login.
   # tea-dash reads the token from tea's config file. If tea stored yours in the OS
   # keychain (so the config's token is empty), give tea-dash one of these instead:
-  # token:        ""                                   # a literal token (not recommended in plaintext)
-  # tokenCommand: op read "op://Private/tea-dash/credential"   # e.g. 1Password, pass, gopass
-  # tokenEnv:     TEA_DASH_TOKEN                        # name of an env var holding the token
-  # Example for 1Password:
-  # tokenCommand: op read "op://Private/tea-dash/credential"
+  # token:        ""                                      # a literal token (not recommended in plaintext)
+  # tokenCommand: "<command that prints the token>"        # e.g. pass, gopass, 1Password CLI, etc.
+  # tokenEnv:     TEA_DASH_TOKEN                           # name of an env var holding the token
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
@@ -134,7 +132,7 @@ pager:
   diff: diffnav     # command that receives PR diff bytes on stdin (falls back to $PAGER, then less -R)
 
 repoPaths:
-  "gbarany/*": "~/src/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
+  "example/*": "~/src/{{.Repo}}"  # used by C checkout; exact repo names and wildcards both work
 
 git:
   remote: origin

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -27,7 +27,7 @@ type Overrides struct {
 	Login        string // pick a named tea login
 	URL          string
 	Token        string // literal token (instance.token)
-	TokenCommand string // shell command whose stdout is the token (e.g. `op read op://...`)
+	TokenCommand string // shell command whose stdout is the token
 	TokenEnv     string // name of an env var to read the token from
 	Insecure     bool
 	CACertPath   string
@@ -214,7 +214,7 @@ func tokenError(login *teaLogin) error {
 	if login != nil {
 		return fmt.Errorf("found tea login %q but no usable token: its token is not in tea's config "+
 			"file (tea may keep it in your OS keychain, which tea-dash cannot read). Set instance.token, "+
-			"instance.tokenCommand (e.g. `op read \"op://vault/item/credential\"`), or TEA_DASH_TOKEN", login.Name)
+			"instance.tokenCommand (a command that prints a token), or TEA_DASH_TOKEN", login.Name)
 	}
 	return errors.New("no Gitea token: run `tea login add`, or set instance.token / instance.tokenCommand / TEA_DASH_TOKEN")
 }

--- a/scripts/check-public-hygiene.sh
+++ b/scripts/check-public-hygiene.sh
@@ -4,14 +4,13 @@ set -euo pipefail
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-files="$(git ls-files)"
 status=0
 
 check_regex() {
   local name="$1"
   local pattern="$2"
   local matches
-  matches="$(grep -nE "$pattern" $files 2>/dev/null || true)"
+  matches="$(git grep -nE "$pattern" -- . ':(exclude).git' ':(exclude)scripts/check-public-hygiene.sh' || true)"
   if [[ -n "$matches" ]]; then
     printf 'public hygiene check failed: %s\n%s\n' "$name" "$matches" >&2
     status=1
@@ -20,12 +19,6 @@ check_regex() {
 
 check_regex "local home directory paths" '(^|[^[:alnum:]_])/(Users|home)/[^[:space:]`"'"'"']+'
 check_regex "macOS per-user temporary paths" '(^|[^[:alnum:]_])/var/folders/[^[:space:]`"'"'"']+'
-
-op_matches="$(grep -nE 'op://[^<]' $files 2>/dev/null |
-  grep -vE 'op://Private/tea-dash/credential|op://vault/item/credential|op://\.\.\.' || true)"
-if [[ -n "$op_matches" ]]; then
-  printf 'public hygiene check failed: non-placeholder 1Password references\n%s\n' "$op_matches" >&2
-  status=1
-fi
+check_regex "secret-manager item routes" 'op://'
 
 exit "$status"

--- a/scripts/check-public-hygiene.sh
+++ b/scripts/check-public-hygiene.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+files="$(git ls-files)"
+status=0
+
+check_regex() {
+  local name="$1"
+  local pattern="$2"
+  local matches
+  matches="$(grep -nE "$pattern" $files 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    printf 'public hygiene check failed: %s\n%s\n' "$name" "$matches" >&2
+    status=1
+  fi
+}
+
+check_regex "local home directory paths" '(^|[^[:alnum:]_])/(Users|home)/[^[:space:]`"'"'"']+'
+check_regex "macOS per-user temporary paths" '(^|[^[:alnum:]_])/var/folders/[^[:space:]`"'"'"']+'
+
+op_matches="$(grep -nE 'op://[^<]' $files 2>/dev/null |
+  grep -vE 'op://Private/tea-dash/credential|op://vault/item/credential|op://\.\.\.' || true)"
+if [[ -n "$op_matches" ]]; then
+  printf 'public hygiene check failed: non-placeholder 1Password references\n%s\n' "$op_matches" >&2
+  status=1
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Add `scripts/check-public-hygiene.sh` to catch local home paths, macOS per-user temp paths, and non-placeholder 1Password references.
- Wire the guard into `make check` so CI enforces it.

## Verification

- `bash scripts/check-public-hygiene.sh`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `git diff --check`
