### PR TITLE
Make section tabs mouse-clickable

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -886,6 +886,26 @@ func (m Model) tableDataStartY() int {
 	return y
 }
 
+func (m Model) tabBarY() int {
+	if len(m.currentViewSections()) < 2 {
+		return -1
+	}
+	return 2 // appStyle top padding + title line
+}
+
+func (m Model) switchSectionTo(id int) (Model, tea.Cmd) {
+	if id < 0 || id >= len(m.currentViewSections()) || id == m.currSectionId {
+		return m, nil
+	}
+	m.currSectionId = id
+	m.tabs.SetCurrSectionId(id)
+	if m.ctx.PreviewOpen {
+		m.syncSidebar()
+		return m, m.enrichCurrRow()
+	}
+	return m, nil
+}
+
 func (m Model) inMainListPane(x, y int) bool {
 	if x < 2 || y < m.tableDataStartY() {
 		return false
@@ -931,6 +951,11 @@ func (m Model) selectRowFromMouse(x, y int) (Model, tea.Cmd) {
 func (m Model) handleMouseClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
 	if msg.Button != tea.MouseLeft {
 		return m, nil
+	}
+	if msg.Y == m.tabBarY() {
+		if id, ok := m.tabs.TabAt(msg.X - 2); ok {
+			return m.switchSectionTo(id)
+		}
 	}
 	return m.selectRowFromMouse(msg.X, msg.Y)
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -161,6 +161,49 @@ func TestMouseClickInPreviewDoesNotChangeSelection(t *testing.T) {
 	}
 }
 
+func TestMouseClickOnSectionTabSwitchesSectionAndRefreshesPreview(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "Open row", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open"},
+	}))
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId:   1,
+		SectionType: pullsection.SectionType,
+		TaskId:      "p2",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: []data.PullRequest{{
+				Number: 2, Title: "Closed row", RepoNameWithOwner: "gitea/tea", Author: "me", State: "closed",
+			}},
+			TotalCount: 1,
+			TaskId:     "p2",
+		},
+	})
+	firstKey := m.selKey()
+	m = update(t, m, enrichedMsg{
+		key:  firstKey,
+		pull: &data.PullDetail{Body: "open-detail-token", BaseRef: "main", HeadRef: "open"},
+	})
+
+	firstWidth := m.tabs.TabWidth(0)
+	next, _ := m.Update(tea.MouseClickMsg{X: 2 + firstWidth + 1, Y: m.tabBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+
+	if m.currSectionId != 1 {
+		t.Fatalf("clicked tab currSectionId = %d, want 1", m.currSectionId)
+	}
+	if got := m.getCurrRowData().GetTitle(); got != "Closed row" {
+		t.Fatalf("clicked tab selected row = %q, want closed section row", got)
+	}
+	view := m.View().Content
+	if strings.Contains(view, "open-detail-token") {
+		t.Fatalf("tab click should refresh preview away from previous section detail:\n%s", view)
+	}
+	if !strings.Contains(view, "Closed row") || !strings.Contains(view, "Loading") {
+		t.Fatalf("tab click should render the clicked section preview loading state:\n%s", view)
+	}
+}
+
 func TestMouseWheelMovesSelectionInList(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/internal/ui/components/tabs/tabs.go
+++ b/internal/ui/components/tabs/tabs.go
@@ -42,20 +42,54 @@ func (m Model) CurrSectionId() int { return m.cursor }
 // UpdateProgramContext recaches the shared context.
 func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) { m.ctx = ctx }
 
+func (m Model) labelAt(i int) string {
+	s := m.sections[i]
+	return fmt.Sprintf("%s (%d)", s.GetTitle(), s.GetTotalCount())
+}
+
+func (m Model) renderedTabAt(i int) string {
+	label := m.labelAt(i)
+	if i == m.cursor {
+		return m.ctx.Styles.ActiveTab.Render(label)
+	}
+	return m.ctx.Styles.Tab.Render(label)
+}
+
+// TabWidth returns the rendered cell width of tab i. It returns 0 for out of
+// range tabs.
+func (m Model) TabWidth(i int) int {
+	if i < 0 || i >= len(m.sections) {
+		return 0
+	}
+	return lipgloss.Width(m.renderedTabAt(i))
+}
+
+// TabAt maps a cell offset relative to the tab bar's left edge to a section
+// index. It returns false when the tab bar is hidden or the offset is outside
+// all rendered tabs.
+func (m Model) TabAt(x int) (int, bool) {
+	if len(m.sections) < 2 || x < 0 {
+		return 0, false
+	}
+	pos := 0
+	for i := range m.sections {
+		w := m.TabWidth(i)
+		if x >= pos && x < pos+w {
+			return i, true
+		}
+		pos += w
+	}
+	return 0, false
+}
+
 // View renders the tab bar, or "" when there are fewer than two sections.
 func (m Model) View() string {
 	if len(m.sections) < 2 {
 		return ""
 	}
-	st := m.ctx.Styles
-	tabs := make([]string, len(m.sections))
-	for i, s := range m.sections {
-		label := fmt.Sprintf("%s (%d)", s.GetTitle(), s.GetTotalCount())
-		if i == m.cursor {
-			tabs[i] = st.ActiveTab.Render(label)
-		} else {
-			tabs[i] = st.Tab.Render(label)
-		}
+	rendered := make([]string, len(m.sections))
+	for i := range m.sections {
+		rendered[i] = m.renderedTabAt(i)
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, tabs...)
+	return lipgloss.JoinHorizontal(lipgloss.Top, rendered...)
 }

--- a/internal/ui/components/tabs/tabs_test.go
+++ b/internal/ui/components/tabs/tabs_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/ui/components/pullsection"
 	"github.com/gbarany/tea-dash/internal/ui/context"
@@ -28,5 +30,36 @@ func TestTabBarShowsTwoSections(t *testing.T) {
 	v := tb.View()
 	if !strings.Contains(v, "PRs") || !strings.Contains(v, "Issues") {
 		t.Fatalf("two-section tab bar = %q", v)
+	}
+}
+
+func TestTabAtMapsRenderedCellsToSections(t *testing.T) {
+	ctx := &context.ProgramContext{Styles: context.DefaultStyles()}
+	tb := New(ctx)
+	tb.SetSections([]Sectioner{
+		pullsection.NewModel(0, ctx, config.SectionConfig{Title: "Open Pull Requests"}),
+		pullsection.NewModel(1, ctx, config.SectionConfig{Title: "Closed Pull Requests"}),
+	})
+
+	firstWidth := lipgloss.Width(ctx.Styles.ActiveTab.Render("Open Pull Requests (0)"))
+	secondWidth := lipgloss.Width(ctx.Styles.Tab.Render("Closed Pull Requests (0)"))
+
+	if idx, ok := tb.TabAt(1); !ok || idx != 0 {
+		t.Fatalf("TabAt(first tab cell) = %d, %v; want 0, true", idx, ok)
+	}
+	if idx, ok := tb.TabAt(firstWidth + 1); !ok || idx != 1 {
+		t.Fatalf("TabAt(second tab cell) = %d, %v; want 1, true", idx, ok)
+	}
+	if idx, ok := tb.TabAt(firstWidth + secondWidth); ok {
+		t.Fatalf("TabAt(after tabs) = %d, %v; want no tab", idx, ok)
+	}
+}
+
+func TestTabAtIgnoresHiddenSingleSectionBar(t *testing.T) {
+	ctx := &context.ProgramContext{Styles: context.DefaultStyles()}
+	tb := New(ctx)
+	tb.SetSections([]Sectioner{pullsection.NewModel(0, ctx, config.SectionConfig{Title: "Only"})})
+	if idx, ok := tb.TabAt(1); ok {
+		t.Fatalf("TabAt(single-section bar) = %d, %v; want no tab", idx, ok)
 	}
 }


### PR DESCRIPTION
## Summary

- Add hit-testing to the section tab bar so rendered tab cells map back to section indexes.
- Route left-clicks on the tab line through the same section-switch behavior as keyboard navigation.
- Keep preview state in sync when a clicked tab changes the selected section.

## Verification

- GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui/components/tabs ./internal/ui -run 'TestTabAt|TestMouseClickOnSectionTab'
- GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build
- public hygiene scan for private paths and secret item routes