### PR TITLE
Support repo-scoped PR and issue sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ prSections:
     filter:
       reviewRequested: "@me"
     limit: 25              # per-section page size; overrides defaults.prsLimit
+  - title: Alice in Widgets
+    repo: acme/widgets     # repo-scoped sections can use plain login filters
+    filter:
+      state: open
+      createdBy: alice
 
 issuesSections:
   - title: My Issues
@@ -225,9 +230,9 @@ actions; commands run through your shell with row template fields such as
 `RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `Url`/`URL`.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
-> `reviewRequested`) support the sentinel `"@me"` only — a plain login is
-> rejected at load, because Gitea's cross-repo search endpoint has no per-login
-> author filter.
+> `reviewRequested`) support the sentinel `"@me"` on cross-repo sections.
+> Plain login filters such as `createdBy: alice` require `repo: owner/name`,
+> because Gitea's cross-repo search endpoint has no per-login author filter.
 
 With or without a config file, tea-dash shows the pull requests and issues you
 authored, plus unread notifications, across every repo you can access on your

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,12 +44,16 @@ an actionable message.
   raw escape hatch,
 - caches the authenticated user's login via `GetMyUserInfo` (exposed as `Me()`).
 
-Most reads go through the typed SDK. The one exception is the **me-scoped,
-cross-repo pull-request search**, which the typed SDK cannot express: it is
-served by a small raw HTTP escape hatch (`rawGet`) that calls
+Most reads go through the typed SDK. The exception is the **me-scoped,
+cross-repo pull-request/issue search**, whose `created=true` / `assigned=true`
+booleans are not expressible through the SDK's per-repo option structs. That
+path is served by a small raw HTTP escape hatch (`rawGet`) calling
 `GET /repos/issues/search?type=pulls&created=true&state=…` and tolerantly
-decodes the rows (unknown fields ignored). Results are mapped into the domain
-model, never leaking SDK/REST types past the transport boundary.
+decoding rows (unknown fields ignored). When a section declares
+`repo: owner/name`, tea-dash uses the typed repo issues endpoint instead, so
+plain login filters such as `createdBy: alice` can be honored. Results are
+mapped into the domain model, never leaking SDK/REST types past the transport
+boundary.
 
 ## Domain model
 
@@ -64,7 +68,7 @@ is denormalized — each row from the cross-repo search carries its own
 | ----------------- | ------------------------------------------------------------------------- |
 | `main`            | entrypoint, `--version`/`--help`; loads config, resolves auth, builds the client, starts the Bubble Tea program |
 | `internal/ui`     | root model, table, keybindings, Lipgloss styles, loading/error states     |
-| `internal/gitea`  | Gitea SDK wrapper + raw HTTP escape hatch (me-scoped cross-repo PR search) |
+| `internal/gitea`  | Gitea SDK wrapper + raw HTTP escape hatch (me-scoped cross-repo search)    |
 | `internal/auth`   | resolves the instance URL + token from overrides, env, and `tea`'s config |
 | `internal/data`   | TUI-agnostic domain model (`PullRequest`, `Label`, …)                     |
 | `internal/config` | loads `~/.config/tea-dash/config.yml` (instance block, repos)             |
@@ -72,7 +76,6 @@ is denormalized — each row from the cross-repo search carries its own
 
 ## Roadmap (next steps)
 
-1. Add config-driven, per-repo sections and per-section filters (à la `gh-dash`).
-2. Issue and notification sections.
-3. A detail pane (PR/issue body via the SDK, rendered with `glamour`).
-4. Actions (checkout, merge, comment, close, …) through the SDK.
+1. Multi-repo fan-out from `repos:` and smart cwd repo detection.
+2. Richer table columns / per-column layout configuration.
+3. Capability-probed fallbacks for version-sensitive Actions and review flows.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	Instance Instance `yaml:"instance"`
 	// Login is a deprecated alias for Instance.Login (tea login profile name).
 	Login string `yaml:"login"`
-	// Repos lists remote Gitea repositories to watch. Unused in M0; per-repo
-	// sections return in M1.
+	// Repos lists remote Gitea repositories to watch. Section-level Repo is the
+	// active per-repo path; multi-repo fan-out through Repos is still reserved.
 	Repos []string `yaml:"repos"`
 	// LocalRepos lists local git repository paths for read-only branch status.
 	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
@@ -175,10 +175,21 @@ type PrIssueFilter struct {
 	Actor   string `yaml:"actor"`
 }
 
-// Validate rejects unsupported me-scoped author values. The cross-repo search
+// Validate rejects unsupported cross-repo author values. The cross-repo search
 // endpoint has no per-login author filter, so CreatedBy/AssignedBy/Mentioned/
 // ReviewRequested may only be empty or the "@me" sentinel.
 func (f PrIssueFilter) Validate() error {
+	return f.validate(false)
+}
+
+// ValidateForRepo validates a filter in the context of a section's optional
+// repo. Repo-scoped sections can use per-login CreatedBy/AssignedBy/Mentioned
+// filters because the repo issues endpoint supports them.
+func (f PrIssueFilter) ValidateForRepo(repo string) error {
+	return f.validate(strings.TrimSpace(repo) != "")
+}
+
+func (f PrIssueFilter) validate(repoScoped bool) error {
 	for _, field := range []struct {
 		name string
 		val  string
@@ -186,11 +197,28 @@ func (f PrIssueFilter) Validate() error {
 		{"createdBy", f.CreatedBy},
 		{"assignedBy", f.AssignedBy},
 		{"mentioned", f.Mentioned},
-		{"reviewRequested", f.ReviewRequested},
 	} {
-		if field.val != "" && field.val != "@me" {
+		if field.val != "" && field.val != "@me" && !repoScoped {
 			return fmt.Errorf("filter.%s = %q: only \"@me\" is supported (the cross-repo search endpoint has no per-login author filter)", field.name, field.val)
 		}
+	}
+	if repoScoped && f.ReviewRequested != "" {
+		return fmt.Errorf("filter.reviewRequested is only supported on cross-repo sections")
+	}
+	if !repoScoped && f.ReviewRequested != "" && f.ReviewRequested != "@me" {
+		return fmt.Errorf("filter.reviewRequested = %q: only \"@me\" is supported", f.ReviewRequested)
+	}
+	return nil
+}
+
+func validatePrIssueSection(kind string, s SectionConfig) error {
+	if strings.TrimSpace(s.Repo) != "" {
+		if _, err := ParseRepo(s.Repo); err != nil {
+			return fmt.Errorf("%s.repo: %w", kind, err)
+		}
+	}
+	if err := s.Filter.ValidateForRepo(s.Repo); err != nil {
+		return err
 	}
 	return nil
 }
@@ -199,12 +227,12 @@ func (f PrIssueFilter) Validate() error {
 // default view, returning the first error found.
 func (c *Config) Validate() error {
 	for _, s := range c.PRSections {
-		if err := s.Filter.Validate(); err != nil {
+		if err := validatePrIssueSection("prSections", s); err != nil {
 			return err
 		}
 	}
 	for _, s := range c.IssuesSections {
-		if err := s.Filter.Validate(); err != nil {
+		if err := validatePrIssueSection("issuesSections", s); err != nil {
 			return err
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -373,6 +373,42 @@ func TestConfigValidateRejectsBadSectionFilter(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAllowsRepoScopedLoginFilters(t *testing.T) {
+	cfg := &Config{
+		IssuesSections: []SectionConfig{
+			{Title: "Alice bugs", Repo: "acme/widgets", Filter: PrIssueFilter{CreatedBy: "alice"}},
+		},
+		PRSections: []SectionConfig{
+			{Title: "Assigned PRs", Repo: "acme/widgets", Filter: PrIssueFilter{AssignedBy: "alice"}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() should allow plain login filters on repo-scoped sections: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsBadRepoScopedRepo(t *testing.T) {
+	cfg := &Config{
+		PRSections: []SectionConfig{
+			{Title: "Bad repo", Repo: "owner/repo/extra"},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should reject malformed prSections.repo")
+	}
+}
+
+func TestConfigValidateRejectsRepoScopedReviewRequested(t *testing.T) {
+	cfg := &Config{
+		PRSections: []SectionConfig{
+			{Title: "Needs review", Repo: "acme/widgets", Filter: PrIssueFilter{ReviewRequested: "@me"}},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() should reject repo-scoped reviewRequested because the repo endpoint cannot express it")
+	}
+}
+
 func TestConfigValidateRejectsBadActionRepo(t *testing.T) {
 	if err := (&Config{ActionsSections: []SectionConfig{{
 		Title: "Actions",

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	sdk "code.gitea.io/sdk/gitea"
+
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
 )
@@ -159,6 +161,113 @@ func (c *Client) SearchIssuesPage(ctx context.Context, f config.PrIssueFilter, l
 	return issues, total, nil
 }
 
+// ListRepoPullsPage returns pull requests from one repository using the repo
+// issues endpoint with type=pulls. That endpoint supports the richer issue-style
+// filters (labels, milestones, keyword, created_by/assigned_by/mentioned_by)
+// that the typed pull-list endpoint lacks.
+func (c *Client) ListRepoPullsPage(ctx context.Context, repoFull string, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
+	f = f.WithDefaults("pulls")
+	rows, total, err := c.listRepoIssueRowsPage(ctx, repoFull, f, sdk.IssueTypePull, limit, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	prs := make([]data.PullRequest, 0, len(rows))
+	for _, it := range rows {
+		if it != nil {
+			prs = append(prs, mapSDKIssueToPull(repoFull, it))
+		}
+	}
+	return prs, total, nil
+}
+
+// ListRepoIssuesPage returns issues from one repository through the typed SDK,
+// preserving repo-scoped login filters that cross-repo search cannot express.
+func (c *Client) ListRepoIssuesPage(ctx context.Context, repoFull string, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
+	f = f.WithDefaults("issues")
+	rows, total, err := c.listRepoIssueRowsPage(ctx, repoFull, f, sdk.IssueTypeIssue, limit, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	issues := make([]data.Issue, 0, len(rows))
+	for _, it := range rows {
+		if it != nil {
+			issues = append(issues, mapSDKIssue(repoFull, it))
+		}
+	}
+	return issues, total, nil
+}
+
+func (c *Client) listRepoIssueRowsPage(ctx context.Context, repoFull string, f config.PrIssueFilter, typ sdk.IssueType, limit, page int) ([]*sdk.Issue, int, error) {
+	_ = ctx // The SDK context is pinned at client construction; raw calls use per-request contexts.
+	repo, err := config.ParseRepo(repoFull)
+	if err != nil {
+		return nil, 0, err
+	}
+	opt, err := c.repoIssueListOptions(f, typ, limit, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	var rows []*sdk.Issue
+	var resp *sdk.Response
+	if err := c.call(func() error {
+		var e error
+		rows, resp, e = c.sdk.ListRepoIssues(repo.Owner, repo.Name, opt)
+		return e
+	}); err != nil {
+		return nil, 0, fmt.Errorf("list repo issues %s: %w", repoFull, err)
+	}
+	return rows, totalFromSDKResponse(resp, len(rows)), nil
+}
+
+func (c *Client) repoIssueListOptions(f config.PrIssueFilter, typ sdk.IssueType, limit, page int) (sdk.ListIssueOption, error) {
+	opt := sdk.ListIssueOption{
+		ListOptions: sdk.ListOptions{Page: page, PageSize: normalizeLimit(limit)},
+		State:       sdk.StateType(f.State),
+		Type:        typ,
+		Labels:      f.Labels,
+		KeyWord:     f.Q,
+		CreatedBy:   repoLoginFilter(f.CreatedBy, c.me),
+		AssignedBy:  repoLoginFilter(f.AssignedBy, c.me),
+		MentionedBy: repoLoginFilter(f.Mentioned, c.me),
+	}
+	if f.Milestone != "" {
+		opt.Milestones = []string{f.Milestone}
+	}
+	if f.Since != "" {
+		since, err := time.Parse(time.RFC3339, f.Since)
+		if err != nil {
+			return sdk.ListIssueOption{}, fmt.Errorf("parse filter.since %q: %w", f.Since, err)
+		}
+		opt.Since = since
+	}
+	return opt, nil
+}
+
+func repoLoginFilter(v, me string) string {
+	if v == "@me" {
+		return me
+	}
+	return v
+}
+
+func normalizeLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	return limit
+}
+
+func totalFromSDKResponse(resp *sdk.Response, fallback int) int {
+	if resp != nil && resp.Response != nil {
+		if v := resp.Header.Get("X-Total-Count"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				return n
+			}
+		}
+	}
+	return fallback
+}
+
 func mapSearchIssue(it searchIssue) data.PullRequest {
 	pr := data.PullRequest{
 		Number:    it.Number,
@@ -186,6 +295,29 @@ func mapSearchIssue(it searchIssue) data.PullRequest {
 	return pr
 }
 
+func mapSDKIssueToPull(repoFull string, it *sdk.Issue) data.PullRequest {
+	pr := data.PullRequest{
+		Number:            it.Index,
+		Title:             it.Title,
+		State:             string(it.State),
+		HTMLURL:           it.HTMLURL,
+		RepoNameWithOwner: repoFull,
+		CreatedAt:         it.Created,
+		UpdatedAt:         it.Updated,
+		Labels:            mapSDKLabels(it.Labels),
+	}
+	if it.Poster != nil {
+		pr.Author = it.Poster.UserName
+	}
+	if it.Repository != nil && it.Repository.FullName != "" {
+		pr.RepoNameWithOwner = it.Repository.FullName
+	}
+	if it.PullRequest != nil && it.PullRequest.HasMerged {
+		pr.State = "merged"
+	}
+	return pr
+}
+
 // mapSearchIssueToIssue maps a search row into the issue domain type. Unlike
 // mapSearchIssue it carries no Draft/Merged; State is used as returned.
 func mapSearchIssueToIssue(it searchIssue) data.Issue {
@@ -207,6 +339,36 @@ func mapSearchIssueToIssue(it searchIssue) data.Issue {
 		issue.Labels = append(issue.Labels, data.Label{Name: l.Name, Color: l.Color})
 	}
 	return issue
+}
+
+func mapSDKIssue(repoFull string, it *sdk.Issue) data.Issue {
+	issue := data.Issue{
+		Number:            it.Index,
+		Title:             it.Title,
+		State:             string(it.State),
+		HTMLURL:           it.HTMLURL,
+		RepoNameWithOwner: repoFull,
+		CreatedAt:         it.Created,
+		UpdatedAt:         it.Updated,
+		Labels:            mapSDKLabels(it.Labels),
+	}
+	if it.Poster != nil {
+		issue.Author = it.Poster.UserName
+	}
+	if it.Repository != nil && it.Repository.FullName != "" {
+		issue.RepoNameWithOwner = it.Repository.FullName
+	}
+	return issue
+}
+
+func mapSDKLabels(labels []*sdk.Label) []data.Label {
+	out := make([]data.Label, 0, len(labels))
+	for _, l := range labels {
+		if l != nil {
+			out = append(out, data.Label{Name: l.Name, Color: l.Color})
+		}
+	}
+	return out
 }
 
 // rawGet issues an authenticated GET against {baseURL}/api/v1{path} using the

--- a/internal/gitea/search_test.go
+++ b/internal/gitea/search_test.go
@@ -223,6 +223,104 @@ func TestSearchIssues(t *testing.T) {
 	}
 }
 
+func TestListRepoIssuesUsesRepoEndpointAndPlainLoginFilters(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := repoSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("X-Total-Count", "9")
+		fmt.Fprint(w, issueJSON)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	issues, total, err := c.ListRepoIssuesPage(context.Background(), "acme/widgets", config.PrIssueFilter{
+		State:      "closed",
+		Labels:     []string{"bug", "urgent"},
+		Milestone:  "v1",
+		CreatedBy:  "alice",
+		AssignedBy: "@me",
+		Mentioned:  "bob",
+		Q:          "login",
+		Sort:       "recentupdate",
+	}, 25, 3)
+	if err != nil {
+		t.Fatalf("ListRepoIssuesPage: %v", err)
+	}
+	if total != 9 || len(issues) != 1 {
+		t.Fatalf("got total=%d len=%d, want total=9 len=1", total, len(issues))
+	}
+	if gotPath != "/api/v1/repos/acme/widgets/issues" {
+		t.Fatalf("path = %q, want repo issues endpoint", gotPath)
+	}
+	for _, want := range []string{
+		"type=issues",
+		"state=closed",
+		"labels=bug%2Curgent",
+		"milestones=v1",
+		"created_by=alice",
+		"assigned_by=me",
+		"mentioned_by=bob",
+		"q=login",
+		"page=3",
+		"limit=25",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+	if issues[0].RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("repo = %q, want acme/widgets", issues[0].RepoNameWithOwner)
+	}
+}
+
+func TestListRepoPullsUsesRepoIssueEndpointForFilterablePRRows(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := repoSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("X-Total-Count", "3")
+		fmt.Fprint(w, `[
+		  {"number":8,"title":"Repo PR","state":"closed",
+		   "html_url":"https://git.example/acme/widgets/pulls/8",
+		   "user":{"login":"alice"},
+		   "pull_request":{"merged":true},
+		   "updated_at":"2026-06-02T00:00:00Z"}
+		]`)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	prs, total, err := c.ListRepoPullsPage(context.Background(), "acme/widgets", config.PrIssueFilter{
+		State:     "closed",
+		CreatedBy: "alice",
+	}, 10, 2)
+	if err != nil {
+		t.Fatalf("ListRepoPullsPage: %v", err)
+	}
+	if total != 3 || len(prs) != 1 {
+		t.Fatalf("got total=%d len=%d, want total=3 len=1", total, len(prs))
+	}
+	if gotPath != "/api/v1/repos/acme/widgets/issues" {
+		t.Fatalf("path = %q, want repo issues endpoint", gotPath)
+	}
+	for _, want := range []string{"type=pulls", "state=closed", "created_by=alice", "page=2", "limit=10"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+	if prs[0].Number != 8 || prs[0].RepoNameWithOwner != "acme/widgets" ||
+		prs[0].Author != "alice" || prs[0].State != "merged" {
+		t.Fatalf("mapped PR = %+v", prs[0])
+	}
+}
+
 // searchServer builds a fake Gitea that serves the version/user probes plus a
 // /repos/issues/search handler supplied by the caller.
 func searchServer(t *testing.T, search http.HandlerFunc) *httptest.Server {
@@ -235,6 +333,21 @@ func searchServer(t *testing.T, search http.HandlerFunc) *httptest.Server {
 		fmt.Fprint(w, `{"id":1,"login":"me"}`)
 	})
 	mux.HandleFunc("/api/v1/repos/issues/search", search)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func repoSearchServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -40,6 +40,9 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		Limit:        func(c *config.Config) int { return c.Defaults.IssuesLimit },
 		Pageable:     true,
 		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
+			if cfg.Repo != "" {
+				return c.ListRepoIssuesPage(ctx, cfg.Repo, f, limit, page)
+			}
 			return c.SearchIssuesPage(ctx, f, limit, page)
 		},
 		BuildRow: issueBuildRow,

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -40,6 +40,9 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
 		Pageable:     true,
 		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
+			if cfg.Repo != "" {
+				return c.ListRepoPullsPage(ctx, cfg.Repo, f, limit, page)
+			}
 			return c.SearchPullsPage(ctx, f, limit, page)
 		},
 		BuildRow: prBuildRow,


### PR DESCRIPTION
## Summary

- Allow PR/issue sections with `repo: owner/name` to use repo-scoped Gitea endpoints.
- Preserve cross-repo `@me` behavior while allowing plain login filters (`createdBy`, `assignedBy`, `mentioned`) on repo-scoped sections.
- Use the repo issues endpoint with `type=pulls|issues` so labels, milestones, keyword, and login filters stay expressible.
- Reject repo-scoped `reviewRequested` instead of silently ignoring it.
- Refresh README and architecture docs for the new section behavior.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/gitea -run 'TestConfigValidateAllowsRepoScopedLoginFilters|TestConfigValidateRejectsBadRepoScopedRepo|TestConfigValidateRejectsRepoScopedReviewRequested|TestListRepo'`
- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/gitea ./internal/ui/components/pullsection ./internal/ui/components/issuesection ./internal/ui/components/section ./internal/ui`
- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- Public hygiene scan for private paths and secret item routes.
