### PR TITLE
Add repos fan-out and clickable action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ defaults:
   actionsLimit: 50       # rows fetched per Actions section (0 -> 50)
   branchesLimit: 0       # local branches shown (0 -> all)
 
+repos:
+  - acme/widgets         # PR/issue sections without repo: fan out across these repos
+  - acme/api             # omit repos to use the instance-wide cross-repo search endpoint
+
 localRepos:
   - name: tea-dash
     path: ~/src/tea-dash
@@ -138,9 +142,10 @@ git:
   remote: origin
   prBranchTemplate: "pr-{{.PrIndex}}"
 
-# Each section becomes a tab you page through with h/l. Omit prSections to get
-# two "@me"-authored PR defaults: open and closed pull requests. Omit
-# issuesSections to get one open "@me"-authored issues section.
+# Each section becomes a tab you page through with h/l. A section-level repo:
+# overrides global repos: for that tab. Omit prSections to get two
+# "@me"-authored PR defaults: open and closed pull requests. Omit issuesSections
+# to get one open "@me"-authored issues section.
 prSections:
   - title: Open PRs
     filter:
@@ -221,7 +226,13 @@ keybindings:
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),
 `sort`. PR and issue sections fetch one page at a time; reaching the loaded
 bottom automatically requests the next page until the server total is loaded.
-The page size follows section `limit` -> per-view default -> 50.
+When `repos:` is configured, sections without their own `repo:` use the
+repo-scoped endpoint for each listed repo and merge the results by updated time;
+sections with `repo:` query only that repo. With neither `repos:` nor `repo:`,
+tea-dash uses the instance-wide cross-repo search endpoint. `reviewRequested`
+is the one exception: Gitea exposes it only on instance-wide PR search, so those
+sections ignore `repos:` and stay cross-repo. The page size follows section
+`limit` -> per-view default -> 50.
 
 `keybindings` follows gh-dash's shape: each entry has a `key`, optional `name`,
 and exactly one of `builtin` or `command`. Built-ins remap implemented tea-dash
@@ -231,8 +242,9 @@ actions; commands run through your shell with row template fields such as
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` on cross-repo sections.
-> Plain login filters such as `createdBy: alice` require `repo: owner/name`,
-> because Gitea's cross-repo search endpoint has no per-login author filter.
+> Plain login filters such as `createdBy: alice` require either global `repos:`
+> or section-level `repo: owner/name`, because Gitea's cross-repo search
+> endpoint has no per-login author filter.
 
 With or without a config file, tea-dash shows the pull requests and issues you
 authored, plus unread notifications, across every repo you can access on your

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ tea-dash --help
 | --------------- | ----------------------- |
 | `↑`/`↓`, `j`/`k`| move selection          |
 | mouse click      | select row              |
+| action button click | run common row action |
 | mouse wheel      | move selection          |
 | `g` / `G`       | first / last row        |
 | `s`             | switch view (PRs/issues/notifications/actions/branches)|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,9 +51,13 @@ path is served by a small raw HTTP escape hatch (`rawGet`) calling
 `GET /repos/issues/search?type=pulls&created=true&state=…` and tolerantly
 decoding rows (unknown fields ignored). When a section declares
 `repo: owner/name`, tea-dash uses the typed repo issues endpoint instead, so
-plain login filters such as `createdBy: alice` can be honored. Results are
-mapped into the domain model, never leaking SDK/REST types past the transport
-boundary.
+plain login filters such as `createdBy: alice` can be honored. When global
+`repos:` is configured and a PR/issue section omits `repo:`, tea-dash fans out
+to that same repo-scoped endpoint for every listed repo, merges rows by updated
+time, and slices the requested global page for progressive loading. PR sections
+with `reviewRequested` stay on the cross-repo search endpoint because Gitea does
+not expose that filter on the repo issues endpoint. Results are mapped into the
+domain model, never leaking SDK/REST types past the transport boundary.
 
 ## Domain model
 
@@ -76,6 +80,6 @@ is denormalized — each row from the cross-repo search carries its own
 
 ## Roadmap (next steps)
 
-1. Multi-repo fan-out from `repos:` and smart cwd repo detection.
+1. Smart cwd repo detection to preselect or scaffold repo-scoped sections.
 2. Richer table columns / per-column layout configuration.
 3. Capability-probed fallbacks for version-sensitive Actions and review flows.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ type Config struct {
 	Instance Instance `yaml:"instance"`
 	// Login is a deprecated alias for Instance.Login (tea login profile name).
 	Login string `yaml:"login"`
-	// Repos lists remote Gitea repositories to watch. Section-level Repo is the
-	// active per-repo path; multi-repo fan-out through Repos is still reserved.
+	// Repos lists remote Gitea repositories to watch. A PR/issue section with no
+	// explicit Repo fans out across this list; with no Repos, it falls back to
+	// the instance-wide cross-repo search endpoint.
 	Repos []string `yaml:"repos"`
 	// LocalRepos lists local git repository paths for read-only branch status.
 	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
@@ -211,13 +212,18 @@ func (f PrIssueFilter) validate(repoScoped bool) error {
 	return nil
 }
 
-func validatePrIssueSection(kind string, s SectionConfig) error {
-	if strings.TrimSpace(s.Repo) != "" {
+func validatePrIssueSection(kind string, s SectionConfig, hasGlobalRepos bool) error {
+	if kind == "issuesSections" && strings.TrimSpace(s.Filter.ReviewRequested) != "" {
+		return fmt.Errorf("%s.filter.reviewRequested is only supported for PR sections", kind)
+	}
+	hasSectionRepo := strings.TrimSpace(s.Repo) != ""
+	if hasSectionRepo {
 		if _, err := ParseRepo(s.Repo); err != nil {
 			return fmt.Errorf("%s.repo: %w", kind, err)
 		}
 	}
-	if err := s.Filter.ValidateForRepo(s.Repo); err != nil {
+	repoScoped := hasSectionRepo || (hasGlobalRepos && strings.TrimSpace(s.Filter.ReviewRequested) == "")
+	if err := s.Filter.validate(repoScoped); err != nil {
 		return err
 	}
 	return nil
@@ -226,13 +232,18 @@ func validatePrIssueSection(kind string, s SectionConfig) error {
 // Validate checks the config for unsupported filter values and an invalid
 // default view, returning the first error found.
 func (c *Config) Validate() error {
+	for i, repo := range c.Repos {
+		if _, err := ParseRepo(repo); err != nil {
+			return fmt.Errorf("repos[%d]: %w", i, err)
+		}
+	}
 	for _, s := range c.PRSections {
-		if err := validatePrIssueSection("prSections", s); err != nil {
+		if err := validatePrIssueSection("prSections", s, len(c.Repos) > 0); err != nil {
 			return err
 		}
 	}
 	for _, s := range c.IssuesSections {
-		if err := validatePrIssueSection("issuesSections", s); err != nil {
+		if err := validatePrIssueSection("issuesSections", s, len(c.Repos) > 0); err != nil {
 			return err
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,17 @@ func TestParsedRepos(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsBadGlobalRepo(t *testing.T) {
+	cfg := &Config{Repos: []string{"acme/widgets", "owner/repo/extra"}}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() should reject malformed repos entries")
+	}
+	if !strings.Contains(err.Error(), "repos[1]") {
+		t.Fatalf("Validate() error = %v, want it to identify repos[1]", err)
+	}
+}
+
 func TestUnmarshalInstance(t *testing.T) {
 	const y = `
 instance:
@@ -384,6 +395,21 @@ func TestConfigValidateAllowsRepoScopedLoginFilters(t *testing.T) {
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() should allow plain login filters on repo-scoped sections: %v", err)
+	}
+}
+
+func TestConfigValidateAllowsGlobalReposLoginFilters(t *testing.T) {
+	cfg := &Config{
+		Repos: []string{"acme/widgets", "acme/api"},
+		IssuesSections: []SectionConfig{
+			{Title: "Alice bugs", Filter: PrIssueFilter{CreatedBy: "alice"}},
+		},
+		PRSections: []SectionConfig{
+			{Title: "Assigned PRs", Filter: PrIssueFilter{AssignedBy: "alice"}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() should allow plain login filters when global repos fan-out is configured: %v", err)
 	}
 }
 

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -197,6 +198,60 @@ func (c *Client) ListRepoIssuesPage(ctx context.Context, repoFull string, f conf
 	return issues, total, nil
 }
 
+// ListReposPullsPage returns one global page of pull requests fanned out across
+// a fixed repo list. It fetches enough per-repo pages to build the global prefix
+// for page, sorts by updated time, then slices the requested page. This preserves
+// progressive loading without duplicate rows while keeping the section API
+// stateless.
+func (c *Client) ListReposPullsPage(ctx context.Context, repos []string, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
+	limit, page = normalizedLimitPage(limit, page)
+	var all []data.PullRequest
+	total := 0
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			continue
+		}
+		for p := 1; p <= page; p++ {
+			rows, repoTotal, err := c.ListRepoPullsPage(ctx, repo, f, limit, p)
+			if err != nil {
+				return nil, 0, err
+			}
+			if p == 1 {
+				total += repoTotal
+			}
+			all = append(all, rows...)
+		}
+	}
+	sortRowsByUpdatedDesc(all)
+	return pageSlice(all, limit, page), total, nil
+}
+
+// ListReposIssuesPage is the issue equivalent of ListReposPullsPage.
+func (c *Client) ListReposIssuesPage(ctx context.Context, repos []string, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
+	limit, page = normalizedLimitPage(limit, page)
+	var all []data.Issue
+	total := 0
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			continue
+		}
+		for p := 1; p <= page; p++ {
+			rows, repoTotal, err := c.ListRepoIssuesPage(ctx, repo, f, limit, p)
+			if err != nil {
+				return nil, 0, err
+			}
+			if p == 1 {
+				total += repoTotal
+			}
+			all = append(all, rows...)
+		}
+	}
+	sortRowsByUpdatedDesc(all)
+	return pageSlice(all, limit, page), total, nil
+}
+
 func (c *Client) listRepoIssueRowsPage(ctx context.Context, repoFull string, f config.PrIssueFilter, typ sdk.IssueType, limit, page int) ([]*sdk.Issue, int, error) {
 	_ = ctx // The SDK context is pinned at client construction; raw calls use per-request contexts.
 	repo, err := config.ParseRepo(repoFull)
@@ -255,6 +310,38 @@ func normalizeLimit(limit int) int {
 		return 50
 	}
 	return limit
+}
+
+func normalizedLimitPage(limit, page int) (int, int) {
+	limit = normalizeLimit(limit)
+	if page <= 0 {
+		page = 1
+	}
+	return limit, page
+}
+
+func sortRowsByUpdatedDesc[T data.RowData](rows []T) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].GetUpdatedAt().Equal(rows[j].GetUpdatedAt()) {
+			if rows[i].GetRepoNameWithOwner() == rows[j].GetRepoNameWithOwner() {
+				return rows[i].GetNumber() > rows[j].GetNumber()
+			}
+			return rows[i].GetRepoNameWithOwner() < rows[j].GetRepoNameWithOwner()
+		}
+		return rows[i].GetUpdatedAt().After(rows[j].GetUpdatedAt())
+	})
+}
+
+func pageSlice[T data.RowData](rows []T, limit, page int) []T {
+	start := (page - 1) * limit
+	if start >= len(rows) {
+		return nil
+	}
+	end := start + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[start:end]
 }
 
 func totalFromSDKResponse(resp *sdk.Response, fallback int) int {

--- a/internal/gitea/search_test.go
+++ b/internal/gitea/search_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
+	"github.com/gbarany/tea-dash/internal/data"
 )
 
 const searchJSON = `[
@@ -321,6 +322,101 @@ func TestListRepoPullsUsesRepoIssueEndpointForFilterablePRRows(t *testing.T) {
 	}
 }
 
+func TestListReposPullsPageFansOutAndSlicesGlobalPages(t *testing.T) {
+	var paths []string
+	srv := multiRepoSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/issues":
+			w.Header().Set("X-Total-Count", "3")
+			switch r.URL.Query().Get("page") {
+			case "2":
+				fmt.Fprint(w, `[{"number":11,"title":"widgets old","state":"open","updated_at":"2026-06-01T00:00:00Z","user":{"login":"alice"},"pull_request":{}}]`)
+			default:
+				fmt.Fprint(w, `[
+					{"number":12,"title":"widgets newest","state":"open","updated_at":"2026-06-05T00:00:00Z","user":{"login":"alice"},"pull_request":{}},
+					{"number":10,"title":"widgets middle","state":"open","updated_at":"2026-06-03T00:00:00Z","user":{"login":"alice"},"pull_request":{}}
+				]`)
+			}
+		case "/api/v1/repos/acme/api/issues":
+			w.Header().Set("X-Total-Count", "1")
+			if r.URL.Query().Get("page") == "2" {
+				fmt.Fprint(w, `[]`)
+				return
+			}
+			fmt.Fprint(w, `[{"number":21,"title":"api second","state":"open","updated_at":"2026-06-04T00:00:00Z","user":{"login":"bob"},"pull_request":{}}]`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	repos := []string{"acme/widgets", "acme/api"}
+
+	first, total, err := c.ListReposPullsPage(context.Background(), repos, config.PrIssueFilter{State: "open"}, 2, 1)
+	if err != nil {
+		t.Fatalf("ListReposPullsPage page 1: %v", err)
+	}
+	if total != 4 {
+		t.Fatalf("page 1 total = %d, want summed total 4", total)
+	}
+	if got := pullTitles(first); strings.Join(got, "|") != "widgets newest|api second" {
+		t.Fatalf("page 1 titles = %v, want globally newest first two", got)
+	}
+
+	second, total, err := c.ListReposPullsPage(context.Background(), repos, config.PrIssueFilter{State: "open"}, 2, 2)
+	if err != nil {
+		t.Fatalf("ListReposPullsPage page 2: %v", err)
+	}
+	if total != 4 {
+		t.Fatalf("page 2 total = %d, want summed total 4", total)
+	}
+	if got := pullTitles(second); strings.Join(got, "|") != "widgets middle|widgets old" {
+		t.Fatalf("page 2 titles = %v, want non-duplicated global second page", got)
+	}
+
+	if !containsPathWith(paths, "/api/v1/repos/acme/widgets/issues", "type=pulls") ||
+		!containsPathWith(paths, "/api/v1/repos/acme/api/issues", "type=pulls") {
+		t.Fatalf("paths = %v, want both repo issue endpoints with type=pulls", paths)
+	}
+}
+
+func TestListReposIssuesPageFansOutAndSlicesGlobalPages(t *testing.T) {
+	srv := multiRepoSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/issues":
+			w.Header().Set("X-Total-Count", "2")
+			fmt.Fprint(w, `[
+				{"number":7,"title":"widgets issue","state":"open","updated_at":"2026-06-05T00:00:00Z","user":{"login":"alice"}},
+				{"number":6,"title":"widgets older","state":"open","updated_at":"2026-06-03T00:00:00Z","user":{"login":"alice"}}
+			]`)
+		case "/api/v1/repos/acme/api/issues":
+			w.Header().Set("X-Total-Count", "1")
+			fmt.Fprint(w, `[{"number":9,"title":"api issue","state":"open","updated_at":"2026-06-04T00:00:00Z","user":{"login":"bob"}}]`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	issues, total, err := c.ListReposIssuesPage(context.Background(), []string{"acme/widgets", "acme/api"}, config.PrIssueFilter{State: "open"}, 2, 1)
+	if err != nil {
+		t.Fatalf("ListReposIssuesPage: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if got := issueTitles(issues); strings.Join(got, "|") != "widgets issue|api issue" {
+		t.Fatalf("issue titles = %v, want globally sorted first page", got)
+	}
+}
+
 // searchServer builds a fake Gitea that serves the version/user probes plus a
 // /repos/issues/search handler supplied by the caller.
 func searchServer(t *testing.T, search http.HandlerFunc) *httptest.Server {
@@ -351,6 +447,47 @@ func repoSearchServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Serve
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func multiRepoSearchServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/acme/api/issues", repoIssues)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func pullTitles(prs []data.PullRequest) []string {
+	out := make([]string, len(prs))
+	for i, pr := range prs {
+		out[i] = pr.Title
+	}
+	return out
+}
+
+func issueTitles(issues []data.Issue) []string {
+	out := make([]string, len(issues))
+	for i, issue := range issues {
+		out[i] = issue.Title
+	}
+	return out
+}
+
+func containsPathWith(paths []string, path, queryPart string) bool {
+	for _, got := range paths {
+		if strings.Contains(got, path) && strings.Contains(got, queryPart) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSearchPullsNon2xx(t *testing.T) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -71,6 +71,11 @@ type Model struct {
 	expanded bool
 }
 
+type actionButton struct {
+	Label   string
+	Builtin string
+}
+
 // openFailedMsg reports that opening a URL in the browser failed, so the UI can
 // surface the error (and the URL, to copy) instead of failing silently.
 type openFailedMsg struct {
@@ -545,8 +550,11 @@ func (m Model) View() tea.View {
 	if m.ctx.PreviewOpen {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, body, m.sidebar.View())
 	}
-	parts = append(parts, body, status,
-		helpStyle.Render(m.helpLine()))
+	parts = append(parts, body)
+	if bar := m.actionBarView(); bar != "" {
+		parts = append(parts, bar)
+	}
+	parts = append(parts, status, helpStyle.Render(m.helpLine()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true, MouseMode: tea.MouseModeCellMotion}
@@ -590,6 +598,123 @@ func keyHelp(binding key.Binding, fallback string) string {
 		return keys[0]
 	}
 	return fallback
+}
+
+func (m Model) actionButtons() []actionButton {
+	buttons := []actionButton{
+		{Label: "Open", Builtin: "open"},
+		{Label: "Refresh", Builtin: "refresh"},
+	}
+	row := m.getCurrRowData()
+	switch m.ctx.View {
+	case context.NotificationsView:
+		if n, ok := row.(data.Notification); ok {
+			if n.Unread {
+				buttons = append(buttons, actionButton{Label: "Mark read", Builtin: "markRead"})
+			} else {
+				buttons = append(buttons, actionButton{Label: "Mark unread", Builtin: "markUnread"})
+			}
+		}
+		buttons = append(buttons, actionButton{Label: "All read", Builtin: "markAllRead"})
+	case context.ActionsView:
+		buttons = append(buttons,
+			actionButton{Label: "Rerun", Builtin: "rerun"},
+			actionButton{Label: "Cancel", Builtin: "cancel"},
+		)
+	case context.BranchesView:
+		buttons = []actionButton{
+			{Label: "Refresh", Builtin: "refresh"},
+			{Label: "Checkout", Builtin: "checkout"},
+		}
+	case context.IssuesView:
+		buttons = append(buttons, actionButton{Label: "Comment", Builtin: "comment"})
+		switch rowState(row) {
+		case "closed":
+			buttons = append(buttons, actionButton{Label: "Reopen", Builtin: "reopen"})
+		default:
+			buttons = append(buttons, actionButton{Label: "Close", Builtin: "close"})
+		}
+	default:
+		buttons = append(buttons,
+			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Diff", Builtin: "diff"},
+			actionButton{Label: "Checkout", Builtin: "checkout"},
+		)
+		switch rowState(row) {
+		case "closed":
+			buttons = append(buttons, actionButton{Label: "Reopen", Builtin: "reopen"})
+		case "merged":
+			// A merged PR cannot be closed or reopened through the normal issue
+			// state transition, so keep only non-state-changing actions visible.
+		default:
+			buttons = append(buttons,
+				actionButton{Label: "Merge", Builtin: "merge"},
+				actionButton{Label: "Close", Builtin: "close"},
+			)
+		}
+	}
+	return buttons
+}
+
+func rowState(row data.RowData) string {
+	switch r := row.(type) {
+	case data.PullRequest:
+		return r.State
+	case data.Issue:
+		return r.State
+	case data.Notification:
+		return r.SubjectState
+	default:
+		return ""
+	}
+}
+
+func (m Model) actionBarView() string {
+	if m.actionPrompt.Active() {
+		return ""
+	}
+	buttons := m.actionButtons()
+	if len(buttons) == 0 {
+		return ""
+	}
+	rendered := make([]string, 0, len(buttons)*2-1)
+	for i, b := range buttons {
+		if i > 0 {
+			rendered = append(rendered, " ")
+		}
+		rendered = append(rendered, renderActionButton(b))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, rendered...)
+}
+
+func renderActionButton(b actionButton) string {
+	return actionButtonStyle.Render("[" + b.Label + "]")
+}
+
+func (m Model) actionBarY() int {
+	y := 1 // appStyle top padding
+	y++    // title
+	if len(m.currentViewSections()) > 1 {
+		y++ // tabs
+	}
+	y += m.ctx.MainContentHeight
+	return y
+}
+
+func (m Model) actionButtonAt(x int) (actionButton, bool) {
+	rel := x - 2 // appStyle left padding
+	if rel < 0 || m.actionPrompt.Active() {
+		return actionButton{}, false
+	}
+	pos := 0
+	for _, b := range m.actionButtons() {
+		w := lipgloss.Width(renderActionButton(b))
+		if rel >= pos && rel < pos+w {
+			return b, true
+		}
+		pos += w + 1
+	}
+	return actionButton{}, false
 }
 
 // currentViewSections returns the section slice for the active view.
@@ -952,12 +1077,29 @@ func (m Model) handleMouseClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
+	if m.actionPrompt.Active() {
+		return m, nil
+	}
 	if msg.Y == m.tabBarY() {
 		if id, ok := m.tabs.TabAt(msg.X - 2); ok {
 			return m.switchSectionTo(id)
 		}
 	}
+	if msg.Y == m.actionBarY() {
+		if button, ok := m.actionButtonAt(msg.X); ok {
+			return m.handleActionButton(button)
+		}
+	}
 	return m.selectRowFromMouse(msg.X, msg.Y)
+}
+
+func (m Model) handleActionButton(button actionButton) (Model, tea.Cmd) {
+	next, cmd, ok := m.handleBuiltinKeybinding(config.Keybinding{Builtin: button.Builtin})
+	if ok {
+		return next, cmd
+	}
+	m.notice = fmt.Sprintf("Action button %q is not wired.", button.Label)
+	return m, nil
 }
 
 func (m Model) handleMouseWheel(msg tea.MouseWheelMsg) (Model, tea.Cmd) {
@@ -1658,7 +1800,7 @@ func (m *Model) syncProgramContext() {
 // preview capped at 80 columns, with a 2-column gutter between the panes); when
 // it is closed the table gets the full width and the preview collapses to zero.
 func (m *Model) syncMainContentDimensions() {
-	h := m.ctx.ScreenHeight - 6
+	h := m.ctx.ScreenHeight - 7
 	if h < 3 {
 		h = 3
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
@@ -161,6 +162,76 @@ func TestMouseClickInPreviewDoesNotChangeSelection(t *testing.T) {
 	}
 }
 
+func TestActionBarRendersCommonPullRequestButtons(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"[Open]", "[Refresh]", "[Comment]", "[Diff]", "[Checkout]", "[Merge]", "[Close]"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("action bar missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestMouseClickActionButtonStartsPromptAction(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+
+	x := actionButtonClickX(t, m, "Comment")
+	next, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.actionBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("comment button should open the prompt synchronously, got cmd %v", cmd)
+	}
+	if !m.actionPrompt.Active() || m.pendingAction.Kind != actions.KindComment {
+		t.Fatalf("comment button prompt active=%v pending=%s, want comment prompt", m.actionPrompt.Active(), m.pendingAction.Kind)
+	}
+}
+
+func TestMouseClickRefreshActionButtonRefreshesCurrentSection(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+
+	x := actionButtonClickX(t, m, "Refresh")
+	next, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.actionBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("refresh action button should return a fetch command")
+	}
+	if s := m.getCurrSection(); s == nil || !s.GetIsLoading() {
+		t.Fatal("refresh action button should mark the current section loading")
+	}
+}
+
+func TestMouseClickNotificationActionButtonUsesNotificationFlow(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, notificationFetchedMsg([]data.Notification{{
+		ID: 8, Number: 42, SubjectTitle: "Review notification", SubjectType: "Pull",
+		RepoNameWithOwner: "gitea/tea", Unread: true,
+	}}))
+
+	x := actionButtonClickX(t, m, "Mark read")
+	next, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.actionBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("nil-client mark-read button should not return a command, got %v", cmd)
+	}
+	if !strings.Contains(m.notice, "No Gitea client available") {
+		t.Fatalf("notice = %q, want nil-client notification message", m.notice)
+	}
+}
+
 func TestMouseClickOnSectionTabSwitchesSectionAndRefreshesPreview(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -202,6 +273,21 @@ func TestMouseClickOnSectionTabSwitchesSectionAndRefreshesPreview(t *testing.T) 
 	if !strings.Contains(view, "Closed row") || !strings.Contains(view, "Loading") {
 		t.Fatalf("tab click should render the clicked section preview loading state:\n%s", view)
 	}
+}
+
+func actionButtonClickX(t *testing.T, m Model, label string) int {
+	t.Helper()
+	x := 2
+	for _, b := range m.actionButtons() {
+		rendered := renderActionButton(b)
+		w := lipgloss.Width(rendered)
+		if b.Label == label {
+			return x + w/2
+		}
+		x += w + 1
+	}
+	t.Fatalf("button %q not found in %+v", label, m.actionButtons())
+	return 0
 }
 
 func TestMouseWheelMovesSelectionInList(t *testing.T) {

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -26,6 +26,7 @@ type SectionIssuesFetchedMsg = section.RowsFetchedMsg[data.Issue]
 
 // NewModel builds an issues section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	programCtx := ctx
 	return section.New(section.Options[data.Issue]{
 		Id:           id,
 		Ctx:          ctx,
@@ -39,11 +40,14 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		PluralForm:   "issues",
 		Limit:        func(c *config.Config) int { return c.Defaults.IssuesLimit },
 		Pageable:     true,
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
+		Fetch: func(fetchCtx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
 			if cfg.Repo != "" {
-				return c.ListRepoIssuesPage(ctx, cfg.Repo, f, limit, page)
+				return c.ListRepoIssuesPage(fetchCtx, cfg.Repo, f, limit, page)
 			}
-			return c.SearchIssuesPage(ctx, f, limit, page)
+			if programCtx != nil && programCtx.Config != nil && len(programCtx.Config.Repos) > 0 {
+				return c.ListReposIssuesPage(fetchCtx, programCtx.Config.Repos, f, limit, page)
+			}
+			return c.SearchIssuesPage(fetchCtx, f, limit, page)
 		},
 		BuildRow: issueBuildRow,
 	})

--- a/internal/ui/components/issuesection/issuesection_test.go
+++ b/internal/ui/components/issuesection/issuesection_test.go
@@ -1,14 +1,20 @@
 package issuesection
 
 import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/section"
 	"github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -123,4 +129,102 @@ func TestGetCurrRowNilBeforeFetch(t *testing.T) {
 	if m.GetCurrRow() != nil {
 		t.Fatalf("GetCurrRow() = %+v, want nil before any fetch", m.GetCurrRow())
 	}
+}
+
+func TestFetchRowsUsesConfiguredReposFanoutWhenSectionRepoBlank(t *testing.T) {
+	var paths []string
+	srv := issueFanoutServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+		w.Header().Set("X-Total-Count", "1")
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/issues":
+			fmt.Fprint(w, `[{"number":1,"title":"Widgets issue","state":"open","updated_at":"2026-06-02T00:00:00Z","user":{"login":"alice"}}]`)
+		case "/api/v1/repos/acme/api/issues":
+			fmt.Fprint(w, `[{"number":2,"title":"API issue","state":"open","updated_at":"2026-06-03T00:00:00Z","user":{"login":"bob"}}]`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{
+			Repos:    []string{"acme/widgets", "acme/api"},
+			Defaults: config.Defaults{IssuesLimit: 10},
+		},
+		Client:    client,
+		StartTask: func(context.Task) tea.Cmd { return nil },
+	}
+	m := NewModel(0, ctx, config.SectionConfig{Title: "All Issues"})
+
+	msg := runIssueFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionIssuesFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if payload.TotalCount != 2 || len(payload.Rows) != 2 {
+		t.Fatalf("payload total=%d rows=%+v, want two fanned-out issues", payload.TotalCount, payload.Rows)
+	}
+	if payload.Rows[0].Title != "API issue" || payload.Rows[1].Title != "Widgets issue" {
+		t.Fatalf("rows = %+v, want globally sorted by updated time", payload.Rows)
+	}
+	for _, want := range []string{"/api/v1/repos/acme/widgets/issues", "/api/v1/repos/acme/api/issues"} {
+		if !containsFetchPathWith(paths, want, "type=issues") {
+			t.Fatalf("paths = %v, missing %q with type=issues", paths, want)
+		}
+	}
+}
+
+func issueFanoutServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/acme/api/issues", repoIssues)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runIssueFetchCommand(t *testing.T, cmd tea.Cmd) context.TaskFinishedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("FetchRows returned nil command")
+	}
+	msg := cmd()
+	if finished, ok := msg.(context.TaskFinishedMsg); ok {
+		return finished
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("FetchRows command returned %T, want TaskFinishedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		if nested == nil {
+			continue
+		}
+		got := nested()
+		if finished, ok := got.(context.TaskFinishedMsg); ok {
+			return finished
+		}
+	}
+	t.Fatal("FetchRows batch did not contain a TaskFinishedMsg")
+	return context.TaskFinishedMsg{}
+}
+
+func containsFetchPathWith(paths []string, wantPath, wantQuery string) bool {
+	for _, got := range paths {
+		if strings.Contains(got, wantPath) && strings.Contains(got, wantQuery) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -26,6 +26,7 @@ type SectionPullRequestsFetchedMsg = section.RowsFetchedMsg[data.PullRequest]
 
 // NewModel builds a pull-requests section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
+	programCtx := ctx
 	return section.New(section.Options[data.PullRequest]{
 		Id:           id,
 		Ctx:          ctx,
@@ -39,11 +40,14 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		PluralForm:   "pull requests",
 		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
 		Pageable:     true,
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
+		Fetch: func(fetchCtx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
 			if cfg.Repo != "" {
-				return c.ListRepoPullsPage(ctx, cfg.Repo, f, limit, page)
+				return c.ListRepoPullsPage(fetchCtx, cfg.Repo, f, limit, page)
 			}
-			return c.SearchPullsPage(ctx, f, limit, page)
+			if f.ReviewRequested == "" && programCtx != nil && programCtx.Config != nil && len(programCtx.Config.Repos) > 0 {
+				return c.ListReposPullsPage(fetchCtx, programCtx.Config.Repos, f, limit, page)
+			}
+			return c.SearchPullsPage(fetchCtx, f, limit, page)
 		},
 		BuildRow: prBuildRow,
 	})

--- a/internal/ui/components/pullsection/pullsection_test.go
+++ b/internal/ui/components/pullsection/pullsection_test.go
@@ -1,14 +1,20 @@
 package pullsection
 
 import (
+	stdctx "context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/config"
 	"github.com/gbarany/tea-dash/internal/data"
+	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/components/section"
 	"github.com/gbarany/tea-dash/internal/ui/context"
 )
@@ -172,4 +178,168 @@ func TestStaleFetchIgnored(t *testing.T) {
 	if m.NumRows() != 0 {
 		t.Fatalf("stale fetch was applied: rows=%d", m.NumRows())
 	}
+}
+
+func TestFetchRowsUsesConfiguredReposFanoutWhenSectionRepoBlank(t *testing.T) {
+	var paths []string
+	srv := pullFanoutServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+		w.Header().Set("X-Total-Count", "1")
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/issues":
+			fmt.Fprint(w, `[{"number":1,"title":"Widgets PR","state":"open","updated_at":"2026-06-02T00:00:00Z","user":{"login":"alice"},"pull_request":{}}]`)
+		case "/api/v1/repos/acme/api/issues":
+			fmt.Fprint(w, `[{"number":2,"title":"API PR","state":"open","updated_at":"2026-06-03T00:00:00Z","user":{"login":"bob"},"pull_request":{}}]`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config: &config.Config{
+			Repos:    []string{"acme/widgets", "acme/api"},
+			Defaults: config.Defaults{PRsLimit: 10},
+		},
+		Client:    client,
+		StartTask: func(context.Task) tea.Cmd { return nil },
+	}
+	m := NewModel(0, ctx, config.SectionConfig{Title: "All PRs"})
+
+	msg := runPullFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionPullRequestsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if payload.TotalCount != 2 || len(payload.Rows) != 2 {
+		t.Fatalf("payload total=%d rows=%+v, want two fanned-out PRs", payload.TotalCount, payload.Rows)
+	}
+	if payload.Rows[0].Title != "API PR" || payload.Rows[1].Title != "Widgets PR" {
+		t.Fatalf("rows = %+v, want globally sorted by updated time", payload.Rows)
+	}
+	for _, want := range []string{"/api/v1/repos/acme/widgets/issues", "/api/v1/repos/acme/api/issues"} {
+		if !containsFetchPathWith(paths, want, "type=pulls") {
+			t.Fatalf("paths = %v, missing %q with type=pulls", paths, want)
+		}
+	}
+}
+
+func TestFetchRowsWithReviewRequestedUsesCrossRepoSearchEvenWithConfiguredRepos(t *testing.T) {
+	var paths []string
+	srv := pullSearchAndFanoutServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+			w.Header().Set("X-Total-Count", "1")
+			fmt.Fprint(w, `[{
+				"number":3,
+				"title":"Review me",
+				"state":"open",
+				"updated_at":"2026-06-04T00:00:00Z",
+				"repository":{"full_name":"acme/widgets"},
+				"user":{"login":"alice"},
+				"pull_request":{}
+			}]`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path+"?"+r.URL.RawQuery)
+			t.Fatalf("reviewRequested is not expressible on repo issues endpoint; got %s", r.URL.Path)
+		},
+	)
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Config:    &config.Config{Repos: []string{"acme/widgets", "acme/api"}},
+		Client:    client,
+		StartTask: func(context.Task) tea.Cmd { return nil },
+	}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title:  "Needs Review",
+		Filter: config.PrIssueFilter{ReviewRequested: "@me"},
+	})
+
+	msg := runPullFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionPullRequestsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if payload.TotalCount != 1 || len(payload.Rows) != 1 || payload.Rows[0].Title != "Review me" {
+		t.Fatalf("payload total=%d rows=%+v, want cross-repo review row", payload.TotalCount, payload.Rows)
+	}
+	if !containsFetchPathWith(paths, "/api/v1/repos/issues/search", "review_requested=true") {
+		t.Fatalf("paths = %v, want cross-repo review_requested search", paths)
+	}
+}
+
+func pullFanoutServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/acme/api/issues", repoIssues)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func pullSearchAndFanoutServer(t *testing.T, search, repoIssues http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/issues/search", search)
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/acme/api/issues", repoIssues)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runPullFetchCommand(t *testing.T, cmd tea.Cmd) context.TaskFinishedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("FetchRows returned nil command")
+	}
+	msg := cmd()
+	if finished, ok := msg.(context.TaskFinishedMsg); ok {
+		return finished
+	}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("FetchRows command returned %T, want TaskFinishedMsg or BatchMsg", msg)
+	}
+	for _, nested := range batch {
+		if nested == nil {
+			continue
+		}
+		got := nested()
+		if finished, ok := got.(context.TaskFinishedMsg); ok {
+			return finished
+		}
+	}
+	t.Fatal("FetchRows batch did not contain a TaskFinishedMsg")
+	return context.TaskFinishedMsg{}
+}
+
+func containsFetchPathWith(paths []string, wantPath, wantQuery string) bool {
+	for _, got := range paths {
+		if strings.Contains(got, wantPath) && strings.Contains(got, wantQuery) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -3,7 +3,8 @@ package ui
 import "charm.land/lipgloss/v2"
 
 var (
-	appStyle   = lipgloss.NewStyle().Padding(1, 2)
-	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#00ADD8"))
-	helpStyle  = lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.Color("241"))
+	appStyle          = lipgloss.NewStyle().Padding(1, 2)
+	titleStyle        = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#00ADD8"))
+	actionButtonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ADD8"))
+	helpStyle         = lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.Color("241"))
 )


### PR DESCRIPTION
## Summary
- make global `repos:` active for PR/issue sections without a section-level `repo:`, using repo-scoped endpoints and global page slicing for progressive loading
- keep `reviewRequested` PR sections on cross-repo search because Gitea does not expose that filter on repo endpoints
- add a mouse-clickable action bar for common existing actions across PRs, issues, notifications, Actions runs, and branches

## Verification
- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
- public-repo hygiene scan for local paths / secret-manager refs / private patterns