### PR TITLE
Scope sections to current git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ tea-dash --help
 | `s`             | switch view (PRs/issues/notifications/actions/branches)|
 | `h` / `l`       | prev / next section     |
 | `/`             | search by keyword       |
+| `t`             | toggle current-repo smart filtering (when launched from a matching git checkout) |
 | `p`             | show / hide preview panel |
 | `e`             | expand / fold preview body |
 | `ctrl+u` / `ctrl+d` | scroll preview       |
@@ -117,6 +118,8 @@ instance:
   # token:        ""                                      # a literal token (not recommended in plaintext)
   # tokenCommand: "<command that prints the token>"        # e.g. pass, gopass, 1Password CLI, etc.
   # tokenEnv:     TEA_DASH_TOKEN                           # name of an env var holding the token
+
+smartFilteringAtLaunch: true # when launched inside a matching git checkout, blank PR/issue sections scope to that repo
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
@@ -237,6 +240,13 @@ tea-dash uses the instance-wide cross-repo search endpoint. `reviewRequested`
 is the one exception: Gitea exposes it only on instance-wide PR search, so those
 sections ignore `repos:` and stay cross-repo. The page size follows section
 `limit` -> per-view default -> 50.
+
+If `smartFilteringAtLaunch` is enabled (the default) and you start `tea-dash`
+from a local git checkout whose configured remote host matches the selected
+Gitea/Forgejo instance, PR and issue sections without an explicit `repo:` are
+scoped to that current repository. Press `t` to toggle between current-repo and
+all-repositories mode. Sections with explicit `repo:` always keep their
+configured repository.
 
 `keybindings` follows gh-dash's shape: each entry has a `key`, optional `name`,
 and exactly one of `builtin` or `command`. Built-ins remap implemented tea-dash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	// explicit Repo fans out across this list; with no Repos, it falls back to
 	// the instance-wide cross-repo search endpoint.
 	Repos []string `yaml:"repos"`
+	// SmartFilteringAtLaunch scopes PR/issue sections with no explicit repo to
+	// the git repository tea-dash was launched from, when that checkout's remote
+	// host matches the configured Gitea instance. Nil means enabled.
+	SmartFilteringAtLaunch *bool `yaml:"smartFilteringAtLaunch"`
 	// LocalRepos lists local git repository paths for read-only branch status.
 	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
 	// PRSections, IssuesSections, NotificationsSections, ActionsSections, and BranchSections
@@ -46,6 +50,15 @@ type Config struct {
 	Git Git `yaml:"git"`
 	// Keybindings overrides built-in keys and adds custom shell commands.
 	Keybindings Keybindings `yaml:"keybindings"`
+}
+
+// SmartFilteringEnabled reports whether cwd repository scoping is enabled at
+// startup. It defaults on, matching gh-dash's repo-aware launch behavior.
+func (c *Config) SmartFilteringEnabled() bool {
+	if c == nil || c.SmartFilteringAtLaunch == nil {
+		return true
+	}
+	return *c.SmartFilteringAtLaunch
 }
 
 // Defaults holds startup and limit defaults. Per-view limits set the row-fetch
@@ -317,6 +330,7 @@ func (k Keybindings) Validate() error {
 
 var universalBuiltins = builtinSet(
 	"refresh", "refreshAll", "openGithub", "open", "search", "togglePreview",
+	"toggleSmartFiltering", "toggleSmartFilter", "currentRepo",
 	"pageUp", "pageDown", "scrollUp", "scrollDown", "prevSection",
 	"previousSection", "nextSection", "switchView", "copyurl", "copyNumber",
 	"help", "quit", "expand", "summaryViewMore",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,6 +155,24 @@ localRepos:
 	}
 }
 
+func TestSmartFilteringAtLaunchDefaultsToEnabled(t *testing.T) {
+	var c Config
+	if !c.SmartFilteringEnabled() {
+		t.Fatal("SmartFilteringEnabled should default to true when smartFilteringAtLaunch is omitted")
+	}
+}
+
+func TestSmartFilteringAtLaunchCanBeDisabled(t *testing.T) {
+	const y = `smartFilteringAtLaunch: false`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.SmartFilteringEnabled() {
+		t.Fatal("SmartFilteringEnabled should be false when smartFilteringAtLaunch is false")
+	}
+}
+
 func TestUnmarshalPagerRepoPathsAndGit(t *testing.T) {
 	const y = `
 pager:
@@ -265,6 +283,7 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 
 	ok := Config{Keybindings: Keybindings{Universal: []Keybinding{
 		{Key: "R", Builtin: "refreshAll"},
+		{Key: "t", Builtin: "toggleSmartFiltering"},
 		{Key: "g", Command: "lazygit"},
 	}, PRs: []Keybinding{
 		{Key: "a", Builtin: "assign"},

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -127,7 +127,34 @@ func ResolveRepoPath(repoName, cwd, instanceURL string, repoPaths map[string]str
 	return "", fmt.Errorf("no local checkout for %s; configure repoPaths", repoName)
 }
 
+// ResolveCurrentRepo returns the owner/repo identity for cwd's configured git
+// remote when that remote points at the selected Gitea/Forgejo instance. It is
+// intentionally best-effort: non-git directories, missing remotes, unparsable
+// remotes, and host mismatches return ok=false with no error so startup can fall
+// back to the global dashboard.
+func ResolveCurrentRepo(cwd, instanceURL, remoteName string) (RemoteRef, bool, error) {
+	remoteURL, err := remoteURL(cwd, (config.Git{Remote: remoteName}).RemoteName())
+	if err != nil {
+		return RemoteRef{}, false, nil
+	}
+	remote, err := ParseRemoteURL(remoteURL)
+	if err != nil {
+		return RemoteRef{}, false, nil
+	}
+	if instanceURL != "" && !remote.MatchesInstanceURL(instanceURL) {
+		return RemoteRef{}, false, nil
+	}
+	if remote.FullName() == "" {
+		return RemoteRef{}, false, nil
+	}
+	return remote, true, nil
+}
+
 func originRemoteURL(cwd string) (string, error) {
+	return remoteURL(cwd, "origin")
+}
+
+func remoteURL(cwd, remoteName string) (string, error) {
 	configPath, err := gitConfigPath(cwd)
 	if err != nil {
 		return "", err
@@ -138,10 +165,11 @@ func originRemoteURL(cwd string) (string, error) {
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	inOrigin := false
+	remoteName = (config.Git{Remote: remoteName}).RemoteName()
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "[") {
-			inOrigin = strings.Contains(line, `remote "origin"`) || strings.Contains(line, `remote 'origin'`)
+			inOrigin = strings.Contains(line, `remote "`+remoteName+`"`) || strings.Contains(line, `remote '`+remoteName+`'`)
 			continue
 		}
 		if !inOrigin {
@@ -155,7 +183,7 @@ func originRemoteURL(cwd string) (string, error) {
 	if err := scanner.Err(); err != nil {
 		return "", err
 	}
-	return "", errors.New("origin remote URL not found")
+	return "", fmt.Errorf("%s remote URL not found", remoteName)
 }
 
 func gitConfigPath(cwd string) (string, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -139,6 +139,53 @@ func TestResolveRepoPathRejectsCWDHostMismatch(t *testing.T) {
 	}
 }
 
+func TestResolveCurrentRepoMatchesConfiguredInstance(t *testing.T) {
+	cwd := makeGitDir(t, "https://gitea.example.com/acme/api.git")
+	got, ok, err := ResolveCurrentRepo(cwd, "https://gitea.example.com", "origin")
+	if err != nil {
+		t.Fatalf("ResolveCurrentRepo: %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveCurrentRepo should find the matching cwd remote")
+	}
+	if got.FullName() != "acme/api" {
+		t.Fatalf("ResolveCurrentRepo = %+v, want acme/api", got)
+	}
+}
+
+func TestResolveCurrentRepoUsesConfiguredRemote(t *testing.T) {
+	cwd := makeGitDirWithRemote(t, "upstream", "git@gitea.example.com:acme/widgets.git")
+	got, ok, err := ResolveCurrentRepo(cwd, "https://gitea.example.com", "upstream")
+	if err != nil {
+		t.Fatalf("ResolveCurrentRepo: %v", err)
+	}
+	if !ok || got.FullName() != "acme/widgets" {
+		t.Fatalf("ResolveCurrentRepo = %+v, ok=%v, want acme/widgets", got, ok)
+	}
+}
+
+func TestResolveCurrentRepoIsBestEffort(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cwd  string
+		url  string
+	}{
+		{name: "not a git repository", cwd: t.TempDir(), url: "https://gitea.example.com"},
+		{name: "host mismatch", cwd: makeGitDir(t, "https://other.example.com/acme/api.git"), url: "https://gitea.example.com"},
+		{name: "unparseable remote", cwd: makeGitDir(t, "not-a-remote"), url: "https://gitea.example.com"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := ResolveCurrentRepo(tt.cwd, tt.url, "origin")
+			if err != nil {
+				t.Fatalf("ResolveCurrentRepo should not fail startup: %v", err)
+			}
+			if ok || got.FullName() != "" {
+				t.Fatalf("ResolveCurrentRepo = %+v, ok=%v, want no detected repo", got, ok)
+			}
+		})
+	}
+}
+
 func TestBranchNameFromTemplate(t *testing.T) {
 	got, err := BranchNameFromTemplate("review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}", "acme/api", 42)
 	if err != nil {
@@ -330,13 +377,17 @@ func TestSwitchBranchWorktreeConflictFailureIsActionable(t *testing.T) {
 }
 
 func makeGitDir(t *testing.T, remoteURL string) string {
+	return makeGitDirWithRemote(t, "origin", remoteURL)
+}
+
+func makeGitDirWithRemote(t *testing.T, remoteName, remoteURL string) string {
 	t.Helper()
 	dir := t.TempDir()
 	gitDir := filepath.Join(dir, ".git")
 	if err := os.MkdirAll(gitDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	config := "[remote \"origin\"]\n\turl = " + remoteURL + "\n"
+	config := "[remote \"" + remoteName + "\"]\n\turl = " + remoteURL + "\n"
 	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -107,8 +107,20 @@ type notificationActionMsg struct {
 	err       error
 }
 
+// Options are runtime-only model settings resolved before the TUI starts.
+type Options struct {
+	CurrentRepo    string
+	SmartFiltering bool
+}
+
 // New builds the root model. client may be nil in tests (only FetchRows uses it).
 func New(cfg *config.Config, client *gitea.Client) Model {
+	return NewWithOptions(cfg, client, Options{SmartFiltering: cfg.SmartFilteringEnabled()})
+}
+
+// NewWithOptions builds the root model with runtime-only options such as the
+// current git repository detected from cwd.
+func NewWithOptions(cfg *config.Config, client *gitea.Client, opts Options) Model {
 	tasks := map[string]context.Task{}
 	user := ""
 	if client != nil {
@@ -128,12 +140,14 @@ func New(cfg *config.Config, client *gitea.Client) Model {
 		}
 	}
 	ctx := &context.ProgramContext{
-		Config:      cfg,
-		Client:      client,
-		User:        user,
-		View:        view,
-		PreviewOpen: true,
-		Styles:      context.DefaultStyles(),
+		Config:         cfg,
+		Client:         client,
+		User:           user,
+		View:           view,
+		PreviewOpen:    true,
+		Styles:         context.DefaultStyles(),
+		CurrentRepo:    opts.CurrentRepo,
+		SmartFiltering: opts.SmartFiltering,
 	}
 	ctx.StartTask = func(t context.Task) tea.Cmd {
 		tasks[t.Id] = t
@@ -491,6 +505,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.enrichCurrRow()
 			}
 			return m, nil
+		case !m.scopedBuiltinOverridden("toggleSmartFiltering") && key.Matches(msg, m.keys.ToggleSmart):
+			return m.toggleSmartFiltering()
 		case !m.scopedBuiltinOverridden("expand") && key.Matches(msg, m.keys.Expand):
 			if m.ctx.PreviewOpen {
 				m.expanded = !m.expanded
@@ -565,9 +581,15 @@ func (m Model) View() tea.View {
 func (m Model) helpLine() string {
 	if m.showHelp {
 		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
+		if m.ctx.CurrentRepo != "" {
+			text += " · t current repo"
+		}
 		switch m.ctx.View {
 		case context.ActionsView:
 			text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · ctrl+r refresh all · R rerun · ! cancel run · o/enter open · y copy number · Y copy URL"
+			if m.ctx.CurrentRepo != "" {
+				text += " · t current repo"
+			}
 		case context.NotificationsView:
 			text += " · m mark read · u mark unread · M mark all read"
 		case context.BranchesView:
@@ -578,9 +600,15 @@ func (m Model) helpLine() string {
 		return text + " · q quit"
 	}
 	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
+	if m.ctx.CurrentRepo != "" {
+		text += " · t current repo"
+	}
 	switch m.ctx.View {
 	case context.ActionsView:
 		text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r refresh · R rerun · ! cancel"
+		if m.ctx.CurrentRepo != "" {
+			text += " · t current repo"
+		}
 	case context.NotificationsView:
 		text += " · m read · u unread · M all read"
 	case context.BranchesView:
@@ -1202,6 +1230,39 @@ func (m *Model) refreshAllSections() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+func (m Model) toggleSmartFiltering() (Model, tea.Cmd) {
+	if m.ctx.CurrentRepo == "" {
+		m.notice = "No matching git remote detected for this Gitea instance."
+		return m, nil
+	}
+	m.ctx.SmartFiltering = !m.ctx.SmartFiltering
+	if m.ctx.SmartFiltering {
+		m.notice = fmt.Sprintf("Showing current repository: %s.", m.ctx.CurrentRepo)
+	} else {
+		m.notice = "Showing all repositories."
+	}
+	m.pullDetails = map[string]*data.PullDetail{}
+	m.pullEnrichErr = map[string]error{}
+	m.issueDetails = map[string]*data.IssueDetail{}
+	m.issueEnrichErr = map[string]error{}
+	m.prs = nil
+	m.issues = nil
+	switch m.ctx.View {
+	case context.PullsView, context.IssuesView:
+		m.currSectionId = 0
+		m.setCurrentViewSections(buildSections(m.ctx.View, m.ctx))
+		m.tabs.SetCurrSectionId(0)
+		m.syncProgramContext()
+		if m.ctx.PreviewOpen {
+			m.syncSidebar()
+		}
+		return m, m.refreshAllSections()
+	default:
+		m.syncProgramContext()
+		return m, nil
+	}
+}
+
 func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 	target, ok := m.selectedActionTarget()
 	if !ok {
@@ -1305,6 +1366,9 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 			return m, m.enrichCurrRow(), true
 		}
 		return m, nil, true
+	case "togglesmartfiltering", "togglesmartfilter", "currentrepo":
+		next, cmd := m.toggleSmartFiltering()
+		return next, cmd, true
 	case "summaryviewmore", "expand":
 		if m.ctx.PreviewOpen {
 			m.expanded = !m.expanded

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -116,6 +116,58 @@ func TestViewEnablesMouseCellMotion(t *testing.T) {
 	}
 }
 
+func TestNewWithOptionsSetsSmartFilteringContext(t *testing.T) {
+	m := NewWithOptions(&config.Config{}, nil, Options{CurrentRepo: "acme/widgets", SmartFiltering: true})
+	if m.ctx.CurrentRepo != "acme/widgets" {
+		t.Fatalf("CurrentRepo = %q, want acme/widgets", m.ctx.CurrentRepo)
+	}
+	if !m.ctx.SmartFiltering {
+		t.Fatal("SmartFiltering should be enabled from options")
+	}
+}
+
+func TestToggleSmartFilteringRefreshesCurrentView(t *testing.T) {
+	m := NewWithOptions(&config.Config{}, nil, Options{CurrentRepo: "acme/widgets", SmartFiltering: true})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "Current repo row", RepoNameWithOwner: "acme/widgets", Author: "me", State: "open",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	m = next.(Model)
+	if m.ctx.SmartFiltering {
+		t.Fatal("t should disable smart filtering when it starts enabled")
+	}
+	if cmd == nil {
+		t.Fatal("toggle should refetch the current view")
+	}
+	if s := m.getCurrSection(); s == nil || !s.GetIsLoading() {
+		t.Fatal("toggle should mark the rebuilt current section loading")
+	}
+	if !strings.Contains(m.notice, "all repositories") {
+		t.Fatalf("notice = %q, want all-repositories status", m.notice)
+	}
+}
+
+func TestToggleSmartFilteringWithoutDetectedRepoShowsNotice(t *testing.T) {
+	m := New(&config.Config{}, nil)
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("toggle without a detected repo should not refetch, got %v", cmd)
+	}
+	if !strings.Contains(m.notice, "No matching git remote") {
+		t.Fatalf("notice = %q, want missing-remote message", m.notice)
+	}
+}
+
+func TestHelpMentionsSmartFilteringWhenCurrentRepoDetected(t *testing.T) {
+	m := NewWithOptions(&config.Config{}, nil, Options{CurrentRepo: "acme/widgets", SmartFiltering: true})
+	if !strings.Contains(m.helpLine(), "t current repo") {
+		t.Fatalf("help line should mention the current-repo toggle:\n%s", m.helpLine())
+	}
+}
+
 func TestMouseClickSelectsVisibleRowAndRefreshesPreview(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -41,8 +41,8 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		Limit:        func(c *config.Config) int { return c.Defaults.IssuesLimit },
 		Pageable:     true,
 		Fetch: func(fetchCtx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.Issue, int, error) {
-			if cfg.Repo != "" {
-				return c.ListRepoIssuesPage(fetchCtx, cfg.Repo, f, limit, page)
+			if repo := effectiveRepo(ctx, cfg); repo != "" {
+				return c.ListRepoIssuesPage(fetchCtx, repo, f, limit, page)
 			}
 			if programCtx != nil && programCtx.Config != nil && len(programCtx.Config.Repos) > 0 {
 				return c.ListReposIssuesPage(fetchCtx, programCtx.Config.Repos, f, limit, page)
@@ -51,6 +51,16 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		},
 		BuildRow: issueBuildRow,
 	})
+}
+
+func effectiveRepo(ctx *appctx.ProgramContext, cfg config.SectionConfig) string {
+	if cfg.Repo != "" {
+		return cfg.Repo
+	}
+	if ctx == nil || !ctx.SmartFiltering {
+		return ""
+	}
+	return ctx.CurrentRepo
 }
 
 // issueBuildRow maps an issue into the table's 6-cell row.

--- a/internal/ui/components/issuesection/issuesection_test.go
+++ b/internal/ui/components/issuesection/issuesection_test.go
@@ -178,6 +178,55 @@ func TestFetchRowsUsesConfiguredReposFanoutWhenSectionRepoBlank(t *testing.T) {
 	}
 }
 
+func TestFetchUsesSmartCurrentRepoWhenSectionRepoBlank(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := smartFetchServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `[{
+				"number":42,"title":"Repo issue","state":"open",
+				"html_url":"https://git.example/acme/widgets/issues/42",
+				"user":{"login":"me"},
+				"updated_at":"2026-06-02T00:00:00Z"
+			}]`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("smart current-repo issue fetch should not call cross-repo search: %s?%s", r.URL.Path, r.URL.RawQuery)
+		},
+	)
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Client: client, Config: &config.Config{}, CurrentRepo: "acme/widgets", SmartFiltering: true,
+	}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title:  "Current Repo Issues",
+		Limit:  20,
+		Filter: config.PrIssueFilter{State: "open", CreatedBy: "@me"},
+	})
+
+	msg := runIssueFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionIssuesFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if gotPath != "/api/v1/repos/acme/widgets/issues" {
+		t.Fatalf("path = %q, want repo issues endpoint", gotPath)
+	}
+	for _, want := range []string{"type=issues", "created_by=me", "limit=20", "page=1"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+	if payload.TotalCount != 1 || len(payload.Rows) != 1 || payload.Rows[0].RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("rows=%+v total=%d, want one acme/widgets issue", payload.Rows, payload.TotalCount)
+	}
+}
+
 func issueFanoutServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -227,4 +276,20 @@ func containsFetchPathWith(paths []string, wantPath, wantQuery string) bool {
 		}
 	}
 	return false
+}
+
+func smartFetchServer(t *testing.T, repoIssues, search http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/issues/search", search)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -41,8 +41,8 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
 		Pageable:     true,
 		Fetch: func(fetchCtx stdctx.Context, c *gitea.Client, f config.PrIssueFilter, limit, page int) ([]data.PullRequest, int, error) {
-			if cfg.Repo != "" {
-				return c.ListRepoPullsPage(fetchCtx, cfg.Repo, f, limit, page)
+			if repo := effectiveRepo(ctx, cfg, f); repo != "" {
+				return c.ListRepoPullsPage(fetchCtx, repo, f, limit, page)
 			}
 			if f.ReviewRequested == "" && programCtx != nil && programCtx.Config != nil && len(programCtx.Config.Repos) > 0 {
 				return c.ListReposPullsPage(fetchCtx, programCtx.Config.Repos, f, limit, page)
@@ -51,6 +51,19 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		},
 		BuildRow: prBuildRow,
 	})
+}
+
+func effectiveRepo(ctx *appctx.ProgramContext, cfg config.SectionConfig, f config.PrIssueFilter) string {
+	if cfg.Repo != "" {
+		return cfg.Repo
+	}
+	if f.ReviewRequested != "" {
+		return ""
+	}
+	if ctx == nil || !ctx.SmartFiltering {
+		return ""
+	}
+	return ctx.CurrentRepo
 }
 
 // prState renders a draft PR's state as "draft" and otherwise the raw state.

--- a/internal/ui/components/pullsection/pullsection_test.go
+++ b/internal/ui/components/pullsection/pullsection_test.go
@@ -276,6 +276,101 @@ func TestFetchRowsWithReviewRequestedUsesCrossRepoSearchEvenWithConfiguredRepos(
 	}
 }
 
+func TestFetchUsesSmartCurrentRepoWhenSectionRepoBlank(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := smartFetchServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			fmt.Fprint(w, `[{
+				"number":8,"title":"Repo PR","state":"open",
+				"html_url":"https://git.example/acme/widgets/pulls/8",
+				"user":{"login":"me"},
+				"pull_request":{"merged":false},
+				"updated_at":"2026-06-02T00:00:00Z"
+			}]`)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("smart current-repo PR fetch should not call cross-repo search: %s?%s", r.URL.Path, r.URL.RawQuery)
+		},
+	)
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Client: client, Config: &config.Config{}, CurrentRepo: "acme/widgets", SmartFiltering: true,
+	}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title:  "Current Repo PRs",
+		Limit:  20,
+		Filter: config.PrIssueFilter{State: "open", CreatedBy: "@me"},
+	})
+
+	msg := runPullFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionPullRequestsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if gotPath != "/api/v1/repos/acme/widgets/issues" {
+		t.Fatalf("path = %q, want repo issues endpoint", gotPath)
+	}
+	for _, want := range []string{"type=pulls", "created_by=me", "limit=20", "page=1"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query %q missing %q", gotQuery, want)
+		}
+	}
+	if payload.TotalCount != 1 || len(payload.Rows) != 1 || payload.Rows[0].RepoNameWithOwner != "acme/widgets" {
+		t.Fatalf("rows=%+v total=%d, want one acme/widgets PR", payload.Rows, payload.TotalCount)
+	}
+}
+
+func TestFetchReviewRequestedIgnoresSmartCurrentRepo(t *testing.T) {
+	var searched bool
+	srv := smartFetchServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("review-requested PR sections must stay cross-repo, got repo endpoint: %s?%s", r.URL.Path, r.URL.RawQuery)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			searched = true
+			if !strings.Contains(r.URL.RawQuery, "review_requested=true") {
+				t.Fatalf("query %q missing review_requested=true", r.URL.RawQuery)
+			}
+			fmt.Fprint(w, `[{
+				"number":9,"title":"Needs review","state":"open",
+				"html_url":"https://git.example/acme/widgets/pulls/9",
+				"user":{"login":"alice"},
+				"repository":{"full_name":"acme/widgets"},
+				"pull_request":{"merged":false},
+				"updated_at":"2026-06-02T00:00:00Z"
+			}]`)
+		},
+	)
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := &context.ProgramContext{
+		Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20,
+		Client: client, Config: &config.Config{}, CurrentRepo: "acme/widgets", SmartFiltering: true,
+	}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title:  "Needs Review",
+		Limit:  20,
+		Filter: config.PrIssueFilter{State: "open", ReviewRequested: "@me"},
+	})
+
+	msg := runPullFetchCommand(t, m.FetchRows())
+	payload := msg.Msg.(SectionPullRequestsFetchedMsg)
+	if payload.Err != nil {
+		t.Fatalf("FetchRows payload error: %v", payload.Err)
+	}
+	if !searched {
+		t.Fatal("expected cross-repo search to be called")
+	}
+}
+
 func pullFanoutServer(t *testing.T, repoIssues http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -342,4 +437,20 @@ func containsFetchPathWith(paths []string, wantPath, wantQuery string) bool {
 		}
 	}
 	return false
+}
+
+func smartFetchServer(t *testing.T, repoIssues, search http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/widgets/issues", repoIssues)
+	mux.HandleFunc("/api/v1/repos/issues/search", search)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/internal/ui/context/context.go
+++ b/internal/ui/context/context.go
@@ -67,6 +67,12 @@ type ProgramContext struct {
 	Error  error
 	Styles Styles
 
+	// CurrentRepo is the owner/repo detected from the cwd git remote when it
+	// matches the selected Gitea instance. SmartFiltering scopes blank PR/issue
+	// sections to CurrentRepo; explicit section repo config still wins.
+	CurrentRepo    string
+	SmartFiltering bool
+
 	// StartTask registers an async task; the root assigns it. Returns nil in M1a.
 	StartTask func(task Task) tea.Cmd
 }

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -20,6 +20,7 @@ type keyMap struct {
 	SwitchView    key.Binding
 	Search        key.Binding
 	TogglePreview key.Binding
+	ToggleSmart   key.Binding
 	ScrollUp      key.Binding
 	ScrollDown    key.Binding
 	Expand        key.Binding
@@ -82,6 +83,10 @@ func defaultKeyMap() keyMap {
 		TogglePreview: key.NewBinding(
 			key.WithKeys("p"),
 			key.WithHelp("p", "preview"),
+		),
+		ToggleSmart: key.NewBinding(
+			key.WithKeys("t"),
+			key.WithHelp("t", "current repo"),
 		),
 		ScrollUp: key.NewBinding(
 			key.WithKeys("ctrl+u"),
@@ -214,6 +219,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Search = binding(keyName, "search")
 	case "togglepreview":
 		k.TogglePreview = binding(keyName, "preview")
+	case "togglesmartfiltering", "togglesmartfilter", "currentrepo":
+		k.ToggleSmart = binding(keyName, "current repo")
 	case "pageup", "scrollup":
 		k.ScrollUp = binding(keyName, "scroll preview up")
 	case "pagedown", "scrolldown":

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gbarany/tea-dash/internal/auth"
 	"github.com/gbarany/tea-dash/internal/build"
 	"github.com/gbarany/tea-dash/internal/config"
+	localgit "github.com/gbarany/tea-dash/internal/git"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui"
 )
@@ -64,8 +65,8 @@ func run() error {
 		return fmt.Errorf("connecting to %s: %w", authCfg.URL, err)
 	}
 
-	model := ui.New(cfg, client)
 	cwd, _ := os.Getwd()
+	model := ui.NewWithOptions(cfg, client, launchOptions(cfg, authCfg.URL, cwd))
 	runner := actionrunner.New(actionrunner.Options{
 		Client:      client,
 		Config:      cfg,
@@ -77,6 +78,21 @@ func run() error {
 	p := tea.NewProgram(model)
 	_, err = p.Run()
 	return err
+}
+
+func launchOptions(cfg *config.Config, instanceURL, cwd string) ui.Options {
+	opts := ui.Options{SmartFiltering: cfg.SmartFilteringEnabled()}
+	if !opts.SmartFiltering {
+		return opts
+	}
+	remote, ok, err := localgit.ResolveCurrentRepo(cwd, instanceURL, cfg.Git.Remote)
+	if err != nil || !ok {
+		opts.SmartFiltering = false
+		return opts
+	}
+	opts.CurrentRepo = remote.FullName()
+	opts.SmartFiltering = opts.CurrentRepo != ""
+	return opts
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gbarany/tea-dash/internal/config"
+)
+
+func TestLaunchOptionsDetectsMatchingCurrentRepo(t *testing.T) {
+	cwd := makeGitDir(t, "origin", "https://gitea.example.com/acme/widgets.git")
+	got := launchOptions(&config.Config{}, "https://gitea.example.com", cwd)
+	if got.CurrentRepo != "acme/widgets" {
+		t.Fatalf("CurrentRepo = %q, want acme/widgets", got.CurrentRepo)
+	}
+	if !got.SmartFiltering {
+		t.Fatal("SmartFiltering should be enabled for a matching cwd repo")
+	}
+}
+
+func TestLaunchOptionsHonorsSmartFilteringDisabled(t *testing.T) {
+	cwd := makeGitDir(t, "origin", "https://gitea.example.com/acme/widgets.git")
+	disabled := false
+	got := launchOptions(&config.Config{SmartFilteringAtLaunch: &disabled}, "https://gitea.example.com", cwd)
+	if got.CurrentRepo != "" {
+		t.Fatalf("CurrentRepo = %q, want empty when smart filtering is disabled", got.CurrentRepo)
+	}
+	if got.SmartFiltering {
+		t.Fatal("SmartFiltering should be disabled by config")
+	}
+}
+
+func makeGitDir(t *testing.T, remoteName, remoteURL string) string {
+	t.Helper()
+	cwd := t.TempDir()
+	gitDir := filepath.Join(cwd, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `[remote "` + remoteName + `"]
+	url = ` + remoteURL + `
+`
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cwd
+}


### PR DESCRIPTION
## Summary

- Detect the current git repository at startup when its configured remote host matches the selected Gitea/Forgejo instance.
- Scope PR/issue sections without explicit `repo:` to that current repository by default, with explicit `repo:` still taking precedence.
- Add `smartFilteringAtLaunch` and a `t` toggle to switch between current-repo and all-repositories mode.

## Testing

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
