### PR TITLE
Add PR branch update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ tea-dash --help
 | `a` / `A`       | assign / unassign yourself |
 | `L` / `U`       | add / remove labels     |
 | `m`             | merge PR                |
+| `u`             | update PR branch from its base branch |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
@@ -192,6 +193,8 @@ keybindings:
       builtin: addLabel
     - key: U
       builtin: removeLabel
+    - key: u
+      builtin: update
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -34,6 +34,7 @@ type Client interface {
 	AddLabels(owner, repo string, index int64, names []string) error
 	RemoveLabels(owner, repo string, index int64, names []string) error
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
+	UpdatePullRequest(owner, repo string, index int64) error
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
 	RerunActionRun(ctx context.Context, owner, repo string, runID int64) error
@@ -261,6 +262,12 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		return fmt.Sprintf("Submitted review for %s#%d.", intent.Target.Repo, index), nil
 
+	case uiactions.KindUpdateBranch:
+		if err := r.client.UpdatePullRequest(owner, repo, index); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Updated %s#%d from its base branch.", intent.Target.Repo, index), nil
+
 	case uiactions.KindExternalDiff:
 		diff, err := r.client.GetPullDiff(owner, repo, index)
 		if err != nil {
@@ -481,6 +488,8 @@ func actionLabel(kind uiactions.Kind) string {
 		return "remove label"
 	case uiactions.KindMerge:
 		return "merge"
+	case uiactions.KindUpdateBranch:
+		return "update branch"
 	case uiactions.KindClose:
 		return "close"
 	case uiactions.KindReopen:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -215,6 +215,20 @@ func TestDispatchMergeAndReview(t *testing.T) {
 	}
 }
 
+func TestDispatchUpdatePullRequest(t *testing.T) {
+	client := &fakeClient{}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindUpdateBranch))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("update branch result = %+v", got)
+	}
+	if client.updatePull != 7 {
+		t.Fatalf("updatePull = %d, want 7", client.updatePull)
+	}
+	if !strings.Contains(got.Message, "Updated acme/widgets#7") {
+		t.Fatalf("message = %q, want update confirmation", got.Message)
+	}
+}
+
 func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
 	client := &fakeClient{diff: []byte("diff --git a/a b/a\n+hello\n")}
 	shellRunner := &fakeShellRunner{}
@@ -374,6 +388,7 @@ type fakeClient struct {
 	pullState     data.ItemState
 	merge         data.MergeOptions
 	review        data.PullReviewOptions
+	updatePull    int64
 	diff          []byte
 	rerunRunID    int64
 	cancelRunID   int64
@@ -441,6 +456,11 @@ func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOption
 func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewOptions) (data.Review, error) {
 	f.review = opt
 	return data.Review{State: data.ReviewState(opt.Event)}, f.err
+}
+
+func (f *fakeClient) UpdatePullRequest(_, _ string, index int64) error {
+	f.updatePull = index
+	return f.err
 }
 
 func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,7 +313,7 @@ var universalBuiltins = builtinSet(
 
 var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
-	"close", "reopen", "diff", "checkout", "approve", "review",
+	"update", "updateBranch", "close", "reopen", "diff", "checkout", "approve", "review",
 	"summaryViewMore", "expand",
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -258,6 +258,7 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 	}, PRs: []Keybinding{
 		{Key: "a", Builtin: "assign"},
 		{Key: "L", Builtin: "addLabel"},
+		{Key: "u", Builtin: "update"},
 	}, Issues: []Keybinding{
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -268,6 +268,19 @@ func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.Merg
 	return merged, nil
 }
 
+// UpdatePullRequest asks the server to update a PR branch with commits from its
+// base branch.
+func (c *Client) UpdatePullRequest(owner, repo string, index int64) error {
+	err := c.call(func() error {
+		_, e := c.sdk.UpdatePullRequest(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("update pull request %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return nil
+}
+
 // SubmitPullReview creates a submitted pull-request review.
 func (c *Client) SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error) {
 	event, err := mapPullReviewEvent(opt.Event)

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -295,6 +295,22 @@ func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	}
 }
 
+func TestUpdatePullRequestPostsUpdateEndpoint(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44/update" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := c.UpdatePullRequest("acme", "widgets", 44); err != nil {
+		t.Fatalf("UpdatePullRequest: %v", err)
+	}
+}
+
 func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -12,6 +12,7 @@ const (
 	KindAddLabel      Kind = "add_label"
 	KindRemoveLabel   Kind = "remove_label"
 	KindMerge         Kind = "merge"
+	KindUpdateBranch  Kind = "update_branch"
 	KindClose         Kind = "close"
 	KindReopen        Kind = "reopen"
 	KindReview        Kind = "review"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -8,6 +8,7 @@ func TestKindConstants(t *testing.T) {
 		KindAddLabel:     "add_label",
 		KindRemoveLabel:  "remove_label",
 		KindMerge:        "merge",
+		KindUpdateBranch: "update_branch",
 		KindClose:        "close",
 		KindReopen:       "reopen",
 		KindReview:       "review",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -411,6 +411,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindRemoveLabel)
 		case !m.scopedBuiltinOverridden("merge") && key.Matches(msg, m.keys.Merge):
 			return m, m.startAction(actions.KindMerge)
+		case !m.scopedBuiltinOverridden("update") && key.Matches(msg, m.keys.UpdateBranch):
+			return m, m.startAction(actions.KindUpdateBranch)
 		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
 			return m, m.startAction(actions.KindClose)
 		case !m.scopedBuiltinOverridden("reopen") && key.Matches(msg, m.keys.Reopen):
@@ -563,7 +565,7 @@ func (m Model) helpLine() string {
 		case context.BranchesView:
 			text += " · C/space switch"
 		default:
-			text += " · c comment · a/A assign/unassign · L/U labels · m merge · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
@@ -576,7 +578,7 @@ func (m Model) helpLine() string {
 	case context.BranchesView:
 		text += " · C/space switch"
 	default:
-		text += " · c comment · a/A assign · L/U labels · m merge · d/ctrl+t diff · C/space checkout"
+		text += " · c comment · a/A assign · L/U labels · m merge · u update · d/ctrl+t diff · C/space checkout"
 	}
 	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
 }
@@ -1209,6 +1211,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindRemoveLabel), true
 	case "merge":
 		return m, m.startAction(actions.KindMerge), true
+	case "update", "updatebranch":
+		return m, m.startAction(actions.KindUpdateBranch), true
 	case "close":
 		return m, m.startAction(actions.KindClose), true
 	case "reopen":
@@ -1320,7 +1324,7 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 
 func validateActionTarget(kind actions.Kind, target actions.Target) error {
 	switch kind {
-	case actions.KindMerge, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
+	case actions.KindMerge, actions.KindUpdateBranch, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
 		}
@@ -1436,6 +1440,8 @@ func actionLabel(kind actions.Kind) string {
 		return "Remove label"
 	case actions.KindMerge:
 		return "Merge"
+	case actions.KindUpdateBranch:
+		return "Update branch"
 	case actions.KindClose:
 		return "Close"
 	case actions.KindReopen:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1327,6 +1327,7 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		},
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
+		{name: "update branch", key: tea.KeyPressMsg{Code: 'u', Text: "u"}, kind: actions.KindUpdateBranch},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
 		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
 		{name: "external diff ctrl-t alias", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, kind: actions.KindExternalDiff},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,6 +29,7 @@ type keyMap struct {
 	AddLabel      key.Binding
 	RemoveLabel   key.Binding
 	Merge         key.Binding
+	UpdateBranch  key.Binding
 	Close         key.Binding
 	Reopen        key.Binding
 	Review        key.Binding
@@ -117,6 +118,10 @@ func defaultKeyMap() keyMap {
 		Merge: key.NewBinding(
 			key.WithKeys("m"),
 			key.WithHelp("m", "merge"),
+		),
+		UpdateBranch: key.NewBinding(
+			key.WithKeys("u"),
+			key.WithHelp("u", "update branch"),
 		),
 		Close: key.NewBinding(
 			key.WithKeys("x"),
@@ -227,6 +232,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.RemoveLabel = binding(keyName, "remove label")
 	case "merge":
 		k.Merge = binding(keyName, "merge")
+	case "update", "updatebranch":
+		k.UpdateBranch = binding(keyName, "update branch")
 	case "close":
 		k.Close = binding(keyName, "close")
 	case "reopen":


### PR DESCRIPTION
## Summary

- Add a PR-only `update_branch` action backed by Gitea's `UpdatePullRequest` API.
- Bind `u` in the PR view to update the selected PR branch from its base branch, matching gh-dash's selected-PR update key.
- Allow `builtin: update` / `updateBranch` in PR keybindings and document the key.

## Testing

- `GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
- `git diff --check`
