### PR TITLE
Support YAML theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ git:
   remote: origin
   prBranchTemplate: "pr-{{.PrIndex}}"
 
+theme:
+  colors:
+    text:
+      primary: "#CBE3E7"   # title, active tab, spinner, table header, action buttons
+      secondary: "#A1EFD3" # selected-row text
+      faint: "#8A889D"     # dim text, inactive tabs, help
+      warning: "#F48FB1"   # notices and errors
+    background:
+      selected: "#3E3859"  # selected-row background
+    border:
+      primary: "#585273"   # parsed for gh-dash theme compatibility; deeper border theming is future work
+
 # Each section becomes a tab you page through with h/l. A section-level repo:
 # overrides global repos: for that tab. Omit prSections to get two
 # "@me"-authored PR defaults: open and closed pull requests. Omit issuesSections

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	Git Git `yaml:"git"`
 	// Keybindings overrides built-in keys and adds custom shell commands.
 	Keybindings Keybindings `yaml:"keybindings"`
+	// Theme customizes core UI colors. The shape intentionally mirrors gh-dash's
+	// theme.colors block for portable terminal color schemes.
+	Theme Theme `yaml:"theme"`
 }
 
 // SmartFilteringEnabled reports whether cwd repository scoping is enabled at
@@ -76,6 +79,41 @@ type Defaults struct {
 // Pager configures external pager commands.
 type Pager struct {
 	Diff string `yaml:"diff"`
+}
+
+// Theme customizes tea-dash's visual styling.
+type Theme struct {
+	Colors ThemeColors `yaml:"colors"`
+}
+
+// ThemeColors groups text, background, and border color overrides.
+type ThemeColors struct {
+	Text       ThemeTextColors       `yaml:"text"`
+	Background ThemeBackgroundColors `yaml:"background"`
+	Border     ThemeBorderColors     `yaml:"border"`
+}
+
+// ThemeTextColors customizes foreground colors used by the TUI.
+type ThemeTextColors struct {
+	Primary   string `yaml:"primary"`
+	Secondary string `yaml:"secondary"`
+	Inverted  string `yaml:"inverted"`
+	Faint     string `yaml:"faint"`
+	Warning   string `yaml:"warning"`
+	Success   string `yaml:"success"`
+	Actor     string `yaml:"actor"`
+}
+
+// ThemeBackgroundColors customizes background colors used by the TUI.
+type ThemeBackgroundColors struct {
+	Selected string `yaml:"selected"`
+}
+
+// ThemeBorderColors customizes border colors used by the TUI.
+type ThemeBorderColors struct {
+	Primary   string `yaml:"primary"`
+	Secondary string `yaml:"secondary"`
+	Faint     string `yaml:"faint"`
 }
 
 // DiffCommand returns the configured diff pager command, then $PAGER, then the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -243,6 +243,44 @@ keybindings:
 	}
 }
 
+func TestUnmarshalThemeColors(t *testing.T) {
+	const y = `
+theme:
+  colors:
+    text:
+      primary: "#CBE3E7"
+      secondary: "#A1EFD3"
+      inverted: "#1E1C31"
+      faint: "#8A889D"
+      warning: "#F48FB1"
+      success: "#A1EFD3"
+      actor: "#D4BFFF"
+    background:
+      selected: "#3E3859"
+    border:
+      primary: "#585273"
+      secondary: "#c0c0c0"
+      faint: "#2D2B40"
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Theme.Colors.Text.Primary != "#CBE3E7" ||
+		c.Theme.Colors.Text.Secondary != "#A1EFD3" ||
+		c.Theme.Colors.Text.Inverted != "#1E1C31" ||
+		c.Theme.Colors.Text.Faint != "#8A889D" ||
+		c.Theme.Colors.Text.Warning != "#F48FB1" ||
+		c.Theme.Colors.Text.Success != "#A1EFD3" ||
+		c.Theme.Colors.Text.Actor != "#D4BFFF" ||
+		c.Theme.Colors.Background.Selected != "#3E3859" ||
+		c.Theme.Colors.Border.Primary != "#585273" ||
+		c.Theme.Colors.Border.Secondary != "#c0c0c0" ||
+		c.Theme.Colors.Border.Faint != "#2D2B40" {
+		t.Fatalf("theme = %+v", c.Theme)
+	}
+}
+
 func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -145,7 +145,7 @@ func NewWithOptions(cfg *config.Config, client *gitea.Client, opts Options) Mode
 		User:           user,
 		View:           view,
 		PreviewOpen:    true,
-		Styles:         context.DefaultStyles(),
+		Styles:         context.StylesForConfig(cfg),
 		CurrentRepo:    opts.CurrentRepo,
 		SmartFiltering: opts.SmartFiltering,
 	}
@@ -547,7 +547,7 @@ func (m Model) View() tea.View {
 	case context.BranchesView:
 		subtitle = "  local branches"
 	}
-	title := titleStyle.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
+	title := m.ctx.Styles.Title.Render("tea-dash") + m.ctx.Styles.DimText.Render(subtitle)
 
 	parts := []string{title}
 	if tv := m.tabs.View(); tv != "" {
@@ -572,7 +572,7 @@ func (m Model) View() tea.View {
 	if bar := m.actionBarView(); bar != "" {
 		parts = append(parts, bar)
 	}
-	parts = append(parts, status, helpStyle.Render(m.helpLine()))
+	parts = append(parts, status, m.ctx.Styles.HelpText.Render(m.helpLine()))
 
 	content := appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	return tea.View{Content: content, AltScreen: true, MouseMode: tea.MouseModeCellMotion}
@@ -712,13 +712,13 @@ func (m Model) actionBarView() string {
 		if i > 0 {
 			rendered = append(rendered, " ")
 		}
-		rendered = append(rendered, renderActionButton(b))
+		rendered = append(rendered, m.renderActionButton(b))
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Left, rendered...)
 }
 
-func renderActionButton(b actionButton) string {
-	return actionButtonStyle.Render("[" + b.Label + "]")
+func (m Model) renderActionButton(b actionButton) string {
+	return m.ctx.Styles.ActionButton.Render("[" + b.Label + "]")
 }
 
 func (m Model) actionBarY() int {
@@ -738,7 +738,7 @@ func (m Model) actionButtonAt(x int) (actionButton, bool) {
 	}
 	pos := 0
 	for _, b := range m.actionButtons() {
-		w := lipgloss.Width(renderActionButton(b))
+		w := lipgloss.Width(m.renderActionButton(b))
 		if rel >= pos && rel < pos+w {
 			return b, true
 		}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -168,6 +168,17 @@ func TestHelpMentionsSmartFilteringWhenCurrentRepoDetected(t *testing.T) {
 	}
 }
 
+func TestNewAppliesThemeColors(t *testing.T) {
+	m := New(&config.Config{
+		Theme: config.Theme{Colors: config.ThemeColors{Text: config.ThemeTextColors{Primary: "#CBE3E7"}}},
+	}, nil)
+	gotR, gotG, gotB, gotA := m.ctx.Styles.Title.GetForeground().RGBA()
+	wantR, wantG, wantB, wantA := lipgloss.Color("#CBE3E7").RGBA()
+	if gotR != wantR || gotG != wantG || gotB != wantB || gotA != wantA {
+		t.Fatalf("title color = rgba(%d,%d,%d,%d), want rgba(%d,%d,%d,%d)", gotR, gotG, gotB, gotA, wantR, wantG, wantB, wantA)
+	}
+}
+
 func TestMouseClickSelectsVisibleRowAndRefreshesPreview(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -331,7 +342,7 @@ func actionButtonClickX(t *testing.T, m Model, label string) int {
 	t.Helper()
 	x := 2
 	for _, b := range m.actionButtons() {
-		rendered := renderActionButton(b)
+		rendered := m.renderActionButton(b)
 		w := lipgloss.Width(rendered)
 		if b.Label == label {
 			return x + w/2

--- a/internal/ui/context/context_test.go
+++ b/internal/ui/context/context_test.go
@@ -1,7 +1,10 @@
 package context
 
 import (
+	"image/color"
 	"testing"
+
+	"charm.land/lipgloss/v2"
 
 	"github.com/gbarany/tea-dash/internal/config"
 )
@@ -12,6 +15,44 @@ func TestDefaultStylesNonZero(t *testing.T) {
 	_ = s.Spinner.Render("x")
 	_ = s.DimText.Render("x")
 	_ = s.ErrorText.Render("x")
+}
+
+func TestStylesForConfigAppliesThemeColors(t *testing.T) {
+	s := StylesForConfig(&config.Config{
+		Theme: config.Theme{
+			Colors: config.ThemeColors{
+				Text: config.ThemeTextColors{
+					Primary: "#CBE3E7",
+					Faint:   "#8A889D",
+					Warning: "#F48FB1",
+				},
+				Background: config.ThemeBackgroundColors{
+					Selected: "#3E3859",
+				},
+			},
+		},
+	})
+
+	assertColor(t, s.Title.GetForeground(), lipgloss.Color("#CBE3E7"), "title foreground")
+	assertColor(t, s.Spinner.GetForeground(), lipgloss.Color("#CBE3E7"), "spinner foreground")
+	assertColor(t, s.ActionButton.GetForeground(), lipgloss.Color("#CBE3E7"), "action button foreground")
+	assertColor(t, s.Table.Header.GetForeground(), lipgloss.Color("#CBE3E7"), "table header foreground")
+	assertColor(t, s.ActiveTab.GetForeground(), lipgloss.Color("#CBE3E7"), "active tab foreground")
+	assertColor(t, s.DimText.GetForeground(), lipgloss.Color("#8A889D"), "dim text foreground")
+	assertColor(t, s.HelpText.GetForeground(), lipgloss.Color("#8A889D"), "help foreground")
+	assertColor(t, s.Tab.GetForeground(), lipgloss.Color("#8A889D"), "tab foreground")
+	assertColor(t, s.TabSeparator.GetForeground(), lipgloss.Color("#8A889D"), "tab separator foreground")
+	assertColor(t, s.ErrorText.GetForeground(), lipgloss.Color("#F48FB1"), "error foreground")
+	assertColor(t, s.Table.Selected.GetBackground(), lipgloss.Color("#3E3859"), "selected row background")
+}
+
+func assertColor(t *testing.T, got, want color.Color, label string) {
+	t.Helper()
+	gr, gg, gb, ga := got.RGBA()
+	wr, wg, wb, wa := want.RGBA()
+	if gr != wr || gg != wg || gb != wb || ga != wa {
+		t.Fatalf("%s color = rgba(%d,%d,%d,%d), want rgba(%d,%d,%d,%d)", label, gr, gg, gb, ga, wr, wg, wb, wa)
+	}
 }
 
 func TestGetViewSectionsConfig(t *testing.T) {

--- a/internal/ui/context/styles.go
+++ b/internal/ui/context/styles.go
@@ -1,14 +1,20 @@
 package context
 
 import (
+	"image/color"
+
 	"charm.land/bubbles/v2/table"
 	"charm.land/lipgloss/v2"
+
+	"github.com/gbarany/tea-dash/internal/config"
 )
 
 // Styles holds the precomputed lipgloss styles shared across components.
-// M1a hardcodes the same colors the app used before the refactor.
 type Styles struct {
 	Table        table.Styles
+	Title        lipgloss.Style
+	HelpText     lipgloss.Style
+	ActionButton lipgloss.Style
 	Spinner      lipgloss.Style
 	DimText      lipgloss.Style
 	ErrorText    lipgloss.Style
@@ -17,18 +23,68 @@ type Styles struct {
 	TabSeparator lipgloss.Style
 }
 
-// DefaultStyles returns the built-in styles (no theme parsing in M1a).
+const (
+	defaultPrimary      = "#00ADD8"
+	defaultDim          = "240"
+	defaultHelp         = "241"
+	defaultError        = "196"
+	defaultSelectedText = "229"
+	defaultSelectedBg   = "57"
+)
+
+// DefaultStyles returns the built-in styles.
 func DefaultStyles() Styles {
+	return stylesFromColors(
+		lipgloss.Color(defaultPrimary),
+		lipgloss.Color(defaultDim),
+		lipgloss.Color(defaultHelp),
+		lipgloss.Color(defaultError),
+		lipgloss.Color(defaultSelectedText),
+		lipgloss.Color(defaultSelectedBg),
+	)
+}
+
+// StylesForConfig returns the default styles with any configured theme colors
+// applied. The config shape mirrors gh-dash's theme.colors block, while this
+// first pass applies only the colors tea-dash currently renders.
+func StylesForConfig(cfg *config.Config) Styles {
+	if cfg == nil {
+		return DefaultStyles()
+	}
+	colors := cfg.Theme.Colors
+	primary := colorOrDefault(colors.Text.Primary, lipgloss.Color(defaultPrimary))
+	dim := colorOrDefault(colors.Text.Faint, lipgloss.Color(defaultDim))
+	help := dim
+	if colors.Text.Faint == "" {
+		help = lipgloss.Color(defaultHelp)
+	}
+	warning := colorOrDefault(colors.Text.Warning, lipgloss.Color(defaultError))
+	selectedText := colorOrDefault(colors.Text.Secondary, lipgloss.Color(defaultSelectedText))
+	selectedBg := colorOrDefault(colors.Background.Selected, lipgloss.Color(defaultSelectedBg))
+	return stylesFromColors(primary, dim, help, warning, selectedText, selectedBg)
+}
+
+func stylesFromColors(primary, dim, help, warning, selectedText, selectedBg color.Color) Styles {
 	tbl := table.DefaultStyles()
-	tbl.Header = tbl.Header.Bold(true).Foreground(lipgloss.Color("#00ADD8")).BorderBottom(true)
-	tbl.Selected = tbl.Selected.Bold(true).Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57"))
+	tbl.Header = tbl.Header.Bold(true).Foreground(primary).BorderBottom(true)
+	tbl.Selected = tbl.Selected.Bold(true).Foreground(selectedText).Background(selectedBg)
 	return Styles{
 		Table:        tbl,
-		Spinner:      lipgloss.NewStyle().Foreground(lipgloss.Color("#00ADD8")),
-		DimText:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
-		ErrorText:    lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-		Tab:          lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Padding(0, 1),
-		ActiveTab:    lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#00ADD8")).Padding(0, 1),
-		TabSeparator: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Title:        lipgloss.NewStyle().Bold(true).Foreground(primary),
+		HelpText:     lipgloss.NewStyle().MarginTop(1).Foreground(help),
+		ActionButton: lipgloss.NewStyle().Foreground(primary),
+		Spinner:      lipgloss.NewStyle().Foreground(primary),
+		DimText:      lipgloss.NewStyle().Foreground(dim),
+		ErrorText:    lipgloss.NewStyle().Foreground(warning),
+		Tab:          lipgloss.NewStyle().Foreground(dim).Padding(0, 1),
+		ActiveTab:    lipgloss.NewStyle().Bold(true).Foreground(primary).Padding(0, 1),
+		TabSeparator: lipgloss.NewStyle().Foreground(dim),
 	}
+}
+
+func colorOrDefault(value string, fallback color.Color) color.Color {
+	if value == "" {
+		return fallback
+	}
+	return lipgloss.Color(value)
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -3,8 +3,5 @@ package ui
 import "charm.land/lipgloss/v2"
 
 var (
-	appStyle          = lipgloss.NewStyle().Padding(1, 2)
-	titleStyle        = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#00ADD8"))
-	actionButtonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ADD8"))
-	helpStyle         = lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.Color("241"))
+	appStyle = lipgloss.NewStyle().Padding(1, 2)
 )


### PR DESCRIPTION
## Summary
- Add a gh-dash-shaped `theme.colors` config block for core tea-dash UI colors.
- Apply configured colors to the title, active tabs, spinner, table header, selected row, help text, notices, and clickable action buttons.
- Document a generic theme example in the README.

## Test Plan
- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/ui/context ./internal/ui -run 'TestUnmarshalThemeColors|TestStylesForConfigAppliesThemeColors|TestActionBarRendersCommonPullRequestButtons|TestMouseClickActionButtonStartsPromptAction' -v`\n- `git diff --check`\n- public hygiene scan: only `scripts/check-public-hygiene.sh` contains the `op://` regex pattern\n- `GOCACHE=/tmp/tea-dash-go-cache make check`\n- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`