### PR TITLE
Configure preview defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ smartFilteringAtLaunch: true # when launched inside a matching git checkout, bla
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
   refetchIntervalMinutes: 0 # auto-refresh current view every N minutes (0/omitted -> manual only)
+  preview:
+    open: true           # initial preview pane state (omit to default true)
+    width: 84            # preview pane width in columns (0 or omit -> automatic, capped at 80)
   prsLimit: 50           # PR page size; more rows load when you reach the bottom (0 -> 50)
   issuesLimit: 50        # issue page size; more rows load when you reach the bottom (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,13 +69,39 @@ func (c *Config) SmartFilteringEnabled() bool {
 // cap used when a section omits its own Limit. Precedence: section Limit ->
 // per-view default -> 50.
 type Defaults struct {
-	View                   string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
-	RefetchIntervalMinutes int    `yaml:"refetchIntervalMinutes"`
-	PRsLimit               int    `yaml:"prsLimit"`
-	IssuesLimit            int    `yaml:"issuesLimit"`
-	NotificationsLimit     int    `yaml:"notificationsLimit"`
-	ActionsLimit           int    `yaml:"actionsLimit"`
-	BranchesLimit          int    `yaml:"branchesLimit"`
+	View                   string        `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
+	Preview                PreviewConfig `yaml:"preview"`
+	RefetchIntervalMinutes int           `yaml:"refetchIntervalMinutes"`
+	PRsLimit               int           `yaml:"prsLimit"`
+	IssuesLimit            int           `yaml:"issuesLimit"`
+	NotificationsLimit     int           `yaml:"notificationsLimit"`
+	ActionsLimit           int           `yaml:"actionsLimit"`
+	BranchesLimit          int           `yaml:"branchesLimit"`
+}
+
+// PreviewConfig controls the side preview pane. Open is a pointer so an omitted
+// value can preserve tea-dash's default-open behavior while open: false remains
+// expressible.
+type PreviewConfig struct {
+	Open  *bool `yaml:"open"`
+	Width int   `yaml:"width"`
+}
+
+// PreviewOpen returns the configured initial preview state. Omitted open
+// defaults to true.
+func (p PreviewConfig) PreviewOpen() bool {
+	if p.Open == nil {
+		return true
+	}
+	return *p.Open
+}
+
+// PreviewWidth returns the configured preview width. 0 means automatic width.
+func (p PreviewConfig) PreviewWidth() int {
+	if p.Width < 0 {
+		return 0
+	}
+	return p.Width
 }
 
 // RefetchInterval returns the configured automatic refetch interval. A zero or

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,9 @@ func TestUnmarshalSectionsAndDefaults(t *testing.T) {
 defaults:
   view: notifications
   refetchIntervalMinutes: 3
+  preview:
+    open: false
+    width: 72
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
@@ -126,6 +129,9 @@ localRepos:
 		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 || c.Defaults.BranchesLimit != 100 ||
 		c.Defaults.RefetchIntervalMinutes != 3 {
 		t.Fatalf("defaults = %+v", c.Defaults)
+	}
+	if c.Defaults.Preview.Open == nil || *c.Defaults.Preview.Open || c.Defaults.Preview.Width != 72 {
+		t.Fatalf("defaults.preview = %+v, want open=false width=72", c.Defaults.Preview)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
 		c.PRSections[1].Filter.ReviewRequested != "@me" {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -132,6 +132,7 @@ func NewWithOptions(cfg *config.Config, client *gitea.Client, opts Options) Mode
 		user = client.Me()
 	}
 	view := context.PullsView
+	previewOpen := true
 	if cfg != nil {
 		switch cfg.Defaults.View {
 		case "issues":
@@ -143,13 +144,14 @@ func NewWithOptions(cfg *config.Config, client *gitea.Client, opts Options) Mode
 		case "branches":
 			view = context.BranchesView
 		}
+		previewOpen = cfg.Defaults.Preview.PreviewOpen()
 	}
 	ctx := &context.ProgramContext{
 		Config:         cfg,
 		Client:         client,
 		User:           user,
 		View:           view,
-		PreviewOpen:    true,
+		PreviewOpen:    previewOpen,
 		Styles:         context.StylesForConfig(cfg),
 		CurrentRepo:    opts.CurrentRepo,
 		SmartFiltering: opts.SmartFiltering,
@@ -2036,10 +2038,10 @@ func (m *Model) syncProgramContext() {
 	m.sidebar.UpdateProgramContext(m.ctx)
 }
 
-// syncMainContentDimensions splits the content area between the section table and
-// the preview pane. When the preview is open the screen is divided in two (the
-// preview capped at 80 columns, with a 2-column gutter between the panes); when
-// it is closed the table gets the full width and the preview collapses to zero.
+// syncMainContentDimensions splits the content area between the section table
+// and the preview pane. When the preview is open it uses defaults.preview.width
+// when configured, otherwise the previous automatic half-width layout capped at
+// 80 columns. When closed, the table gets the full width.
 func (m *Model) syncMainContentDimensions() {
 	h := m.ctx.ScreenHeight - 7
 	if h < 3 {
@@ -2048,13 +2050,7 @@ func (m *Model) syncMainContentDimensions() {
 	m.ctx.MainContentHeight = h
 
 	if m.ctx.PreviewOpen {
-		pw := (m.ctx.ScreenWidth - 4) / 2
-		if pw > 80 {
-			pw = 80
-		}
-		if pw < 0 {
-			pw = 0
-		}
+		pw := m.configuredPreviewWidth()
 		m.ctx.PreviewWidth = pw
 		mw := m.ctx.ScreenWidth - 4 - pw - 2
 		if mw < 0 {
@@ -2067,6 +2063,40 @@ func (m *Model) syncMainContentDimensions() {
 	m.ctx.PreviewWidth = 0
 	m.ctx.PreviewHeight = 0
 	m.ctx.MainContentWidth = m.ctx.ScreenWidth - 4
+}
+
+func (m *Model) configuredPreviewWidth() int {
+	available := m.ctx.ScreenWidth - 4
+	if available < 0 {
+		available = 0
+	}
+	if available == 0 {
+		return 0
+	}
+
+	configured := 0
+	if m.ctx.Config != nil {
+		configured = m.ctx.Config.Defaults.Preview.PreviewWidth()
+	}
+	pw := available / 2
+	if configured > 0 {
+		pw = configured
+	}
+
+	maxPreview := available - 2 // reserve the gutter; the table may shrink to zero.
+	if maxPreview < 0 {
+		maxPreview = 0
+	}
+	if pw > maxPreview {
+		pw = maxPreview
+	}
+	if configured == 0 && pw > 80 {
+		pw = 80
+	}
+	if pw < 0 {
+		pw = 0
+	}
+	return pw
 }
 
 func (m Model) statusLine() string {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1328,6 +1328,39 @@ func TestPreviewStartsOpenAndToggles(t *testing.T) {
 	}
 }
 
+func TestPreviewCanStartClosedFromConfig(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{Preview: config.PreviewConfig{Open: boolPtr(false)}}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	if m.ctx.PreviewOpen {
+		t.Fatal("defaults.preview.open=false should start with the preview closed")
+	}
+	if m.ctx.PreviewWidth != 0 || m.ctx.PreviewHeight != 0 {
+		t.Fatalf("closed preview dimensions = %dx%d, want 0x0", m.ctx.PreviewWidth, m.ctx.PreviewHeight)
+	}
+	if m.ctx.MainContentWidth != 116 {
+		t.Fatalf("closed preview main width = %d, want full content width 116", m.ctx.MainContentWidth)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'p', Text: "p"})
+	if !m.ctx.PreviewOpen {
+		t.Fatal("'p' should still open a config-closed preview")
+	}
+}
+
+func TestPreviewWidthCanBeConfigured(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{Preview: config.PreviewConfig{Width: 64}}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 180, Height: 40})
+	if !m.ctx.PreviewOpen {
+		t.Fatal("preview should still default open when only width is configured")
+	}
+	if m.ctx.PreviewWidth != 64 {
+		t.Fatalf("preview width = %d, want configured width 64", m.ctx.PreviewWidth)
+	}
+	if m.ctx.MainContentWidth != 110 {
+		t.Fatalf("main content width = %d, want screen minus padding/gutter/preview = 110", m.ctx.MainContentWidth)
+	}
+}
+
 // TestEnrichedMsgPopulatesSidebar verifies that, with the preview open, an
 // enrichedMsg for the selected row's key is cached and the sidebar re-renders to
 // show the fetched body (and no longer the loading placeholder).
@@ -2452,6 +2485,10 @@ var errBoom = errBoomType("boom")
 type errBoomType string
 
 func (e errBoomType) Error() string { return string(e) }
+
+func boolPtr(v bool) *bool {
+	return &v
+}
 
 func newNotificationActionClient(
 	t *testing.T,


### PR DESCRIPTION
## Summary
- Add `defaults.preview.open` and `defaults.preview.width` config support.
- Preserve the current default-open preview behavior when `open` is omitted, while allowing `open: false`.
- Let configured preview width override the automatic half-width layout with terminal-size clamping.

## Test Plan
- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/ui -run 'TestUnmarshalSectionsAndDefaults|TestPreviewCanStartClosedFromConfig|TestPreviewWidthCanBeConfigured|TestPreviewStartsOpenAndToggles' -v`\n- `git diff --check`\n- public hygiene scan: only `scripts/check-public-hygiene.sh` contains the `op://` regex pattern\n- `GOCACHE=/tmp/tea-dash-go-cache make check`\n- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`