### PR TITLE
Add configurable automatic refetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ smartFilteringAtLaunch: true # when launched inside a matching git checkout, bla
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"
+  refetchIntervalMinutes: 0 # auto-refresh current view every N minutes (0/omitted -> manual only)
   prsLimit: 50           # PR page size; more rows load when you reach the bottom (0 -> 50)
   issuesLimit: 50        # issue page size; more rows load when you reach the bottom (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -39,7 +40,7 @@ type Config struct {
 	NotificationsSections []SectionConfig `yaml:"notificationsSections"`
 	ActionsSections       []SectionConfig `yaml:"actionsSections"`
 	BranchSections        []SectionConfig `yaml:"branchSections"`
-	// Defaults sets the startup view and per-view row limits.
+	// Defaults sets startup behavior, optional auto-refresh, and per-view row limits.
 	Defaults Defaults `yaml:"defaults"`
 	// Pager configures external pager commands.
 	Pager Pager `yaml:"pager"`
@@ -65,12 +66,23 @@ func (c *Config) SmartFilteringEnabled() bool {
 // cap used when a section omits its own Limit. Precedence: section Limit ->
 // per-view default -> 50.
 type Defaults struct {
-	View               string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
-	PRsLimit           int    `yaml:"prsLimit"`
-	IssuesLimit        int    `yaml:"issuesLimit"`
-	NotificationsLimit int    `yaml:"notificationsLimit"`
-	ActionsLimit       int    `yaml:"actionsLimit"`
-	BranchesLimit      int    `yaml:"branchesLimit"`
+	View                   string `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
+	RefetchIntervalMinutes int    `yaml:"refetchIntervalMinutes"`
+	PRsLimit               int    `yaml:"prsLimit"`
+	IssuesLimit            int    `yaml:"issuesLimit"`
+	NotificationsLimit     int    `yaml:"notificationsLimit"`
+	ActionsLimit           int    `yaml:"actionsLimit"`
+	BranchesLimit          int    `yaml:"branchesLimit"`
+}
+
+// RefetchInterval returns the configured automatic refetch interval. A zero or
+// negative value disables background refreshes, preserving manual-refresh-only
+// behavior unless the user explicitly opts in.
+func (d Defaults) RefetchInterval() time.Duration {
+	if d.RefetchIntervalMinutes <= 0 {
+		return 0
+	}
+	return time.Duration(d.RefetchIntervalMinutes) * time.Minute
 }
 
 // Pager configures external pager commands.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -78,6 +79,7 @@ func TestUnmarshalSectionsAndDefaults(t *testing.T) {
 	const y = `
 defaults:
   view: notifications
+  refetchIntervalMinutes: 3
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
@@ -121,7 +123,8 @@ localRepos:
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
-		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 || c.Defaults.BranchesLimit != 100 {
+		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 || c.Defaults.BranchesLimit != 100 ||
+		c.Defaults.RefetchIntervalMinutes != 3 {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
@@ -170,6 +173,18 @@ func TestSmartFilteringAtLaunchCanBeDisabled(t *testing.T) {
 	}
 	if c.SmartFilteringEnabled() {
 		t.Fatal("SmartFilteringEnabled should be false when smartFilteringAtLaunch is false")
+	}
+}
+
+func TestDefaultsRefetchInterval(t *testing.T) {
+	if got := (Defaults{}).RefetchInterval(); got != 0 {
+		t.Fatalf("zero refetch interval = %v, want disabled", got)
+	}
+	if got := (Defaults{RefetchIntervalMinutes: -1}).RefetchInterval(); got != 0 {
+		t.Fatalf("negative refetch interval = %v, want disabled", got)
+	}
+	if got := (Defaults{RefetchIntervalMinutes: 5}).RefetchInterval(); got != 5*time.Minute {
+		t.Fatalf("refetch interval = %v, want 5m", got)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -88,6 +88,9 @@ type copyResultMsg struct {
 	err   error
 }
 
+// autoRefreshMsg is emitted by the optional background refetch timer.
+type autoRefreshMsg struct{}
+
 // enrichedMsg carries the result of a lazy detail fetch back to the root, keyed
 // by the "owner/repo#num" it was requested for so a stale result (the user moved
 // on) is still cached under the right key rather than shown against the wrong row.
@@ -292,7 +295,25 @@ func (m Model) Init() tea.Cmd {
 	for _, s := range m.currentViewSections() {
 		cmds = append(cmds, s.FetchRows())
 	}
+	cmds = append(cmds, m.autoRefreshCmd())
 	return tea.Batch(cmds...)
+}
+
+func (m Model) autoRefreshInterval() time.Duration {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return 0
+	}
+	return m.ctx.Config.Defaults.RefetchInterval()
+}
+
+func (m Model) autoRefreshCmd() tea.Cmd {
+	interval := m.autoRefreshInterval()
+	if interval <= 0 {
+		return nil
+	}
+	return tea.Tick(interval, func(time.Time) tea.Msg {
+		return autoRefreshMsg{}
+	})
 }
 
 // Update routes messages: layout, async results, keys, then generic fallthrough.
@@ -378,6 +399,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case notificationActionMsg:
 		return m.handleNotificationAction(msg)
+
+	case autoRefreshMsg:
+		return m.handleAutoRefresh()
 
 	case tea.MouseClickMsg:
 		return m.handleMouseClick(msg)
@@ -1261,6 +1285,21 @@ func (m Model) toggleSmartFiltering() (Model, tea.Cmd) {
 		m.syncProgramContext()
 		return m, nil
 	}
+}
+
+func (m Model) handleAutoRefresh() (Model, tea.Cmd) {
+	if m.autoRefreshInterval() <= 0 {
+		return m, nil
+	}
+	cmds := []tea.Cmd{m.autoRefreshCmd()}
+	if m.actionPrompt.Active() {
+		return m, tea.Batch(cmds...)
+	}
+	if s := m.getCurrSection(); s != nil && s.IsSearchFocused() {
+		return m, tea.Batch(cmds...)
+	}
+	cmds = append(cmds, m.refreshAllSections())
+	return m, tea.Batch(cmds...)
 }
 
 func (m *Model) startAction(kind actions.Kind) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -464,6 +464,42 @@ func TestRefreshGatedWhileLoading(t *testing.T) {
 	}
 }
 
+func TestAutoRefreshDisabledByDefault(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	if got := m.autoRefreshInterval(); got != 0 {
+		t.Fatalf("auto-refresh interval = %v, want disabled by default", got)
+	}
+	if cmd := m.autoRefreshCmd(); cmd != nil {
+		t.Fatalf("auto-refresh command = %v, want nil when disabled", cmd)
+	}
+}
+
+func TestAutoRefreshTickRefreshesCurrentViewAndReschedules(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{RefetchIntervalMinutes: 1}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+	if s := m.getCurrSection(); s == nil || s.GetIsLoading() {
+		t.Fatal("section should be loaded before the auto-refresh tick")
+	}
+
+	next, cmd := m.Update(autoRefreshMsg{})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("auto-refresh tick should return a batched refresh + reschedule command")
+	}
+	if got := m.autoRefreshInterval(); got != time.Minute {
+		t.Fatalf("auto-refresh interval = %v, want 1m", got)
+	}
+	if s := m.getCurrSection(); s == nil || !s.GetIsLoading() {
+		t.Fatal("auto-refresh tick should mark current view sections loading")
+	}
+	if len(m.tasks) == 0 {
+		t.Fatal("auto-refresh tick should register fetch tasks")
+	}
+}
+
 func TestFetchRowsRegistersTask(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	// Exercise the real StartTask closure wired in New: FetchRows registers the


### PR DESCRIPTION
## Summary
- add defaults.refetchIntervalMinutes to configure optional background refetches
- wire a Bubble Tea timer that refreshes the current view via the existing refresh-all path and reschedules itself
- keep auto-refresh disabled by default, and skip fetches while an action prompt or search input is active
- document the generic YAML knob in README

## Verification
- GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/ui -run 'TestDefaultsRefetchInterval|TestUnmarshalSectionsAndDefaults|TestAutoRefresh'
- git diff --check
- bash scripts/check-public-hygiene.sh
- GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build