### PR TITLE
Mark draft pull requests ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ tea-dash --help
 | `L` / `U`       | add / remove labels     |
 | `m`             | merge PR                |
 | `u`             | update PR branch from its base branch |
+| `W`             | mark draft PR ready for review |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
@@ -201,6 +202,8 @@ keybindings:
       builtin: removeLabel
     - key: u
       builtin: update
+    - key: W
+      builtin: ready
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -35,6 +35,8 @@ type Client interface {
 	RemoveLabels(owner, repo string, index int64, names []string) error
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
 	UpdatePullRequest(owner, repo string, index int64) error
+	MarkPullReady(owner, repo string, index int64) (bool, error)
+	MarkPullDraft(owner, repo string, index int64) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
 	RerunActionRun(ctx context.Context, owner, repo string, runID int64) error
@@ -268,6 +270,26 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		return fmt.Sprintf("Updated %s#%d from its base branch.", intent.Target.Repo, index), nil
 
+	case uiactions.KindMarkReady:
+		changed, err := r.client.MarkPullReady(owner, repo, index)
+		if err != nil {
+			return "", err
+		}
+		if !changed {
+			return fmt.Sprintf("%s#%d is already ready for review.", intent.Target.Repo, index), nil
+		}
+		return fmt.Sprintf("Marked %s#%d ready for review.", intent.Target.Repo, index), nil
+
+	case uiactions.KindMarkDraft:
+		changed, err := r.client.MarkPullDraft(owner, repo, index)
+		if err != nil {
+			return "", err
+		}
+		if !changed {
+			return fmt.Sprintf("%s#%d is already draft.", intent.Target.Repo, index), nil
+		}
+		return fmt.Sprintf("Marked %s#%d draft.", intent.Target.Repo, index), nil
+
 	case uiactions.KindExternalDiff:
 		diff, err := r.client.GetPullDiff(owner, repo, index)
 		if err != nil {
@@ -490,6 +512,10 @@ func actionLabel(kind uiactions.Kind) string {
 		return "merge"
 	case uiactions.KindUpdateBranch:
 		return "update branch"
+	case uiactions.KindMarkReady:
+		return "mark ready"
+	case uiactions.KindMarkDraft:
+		return "mark draft"
 	case uiactions.KindClose:
 		return "close"
 	case uiactions.KindReopen:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -229,6 +229,34 @@ func TestDispatchUpdatePullRequest(t *testing.T) {
 	}
 }
 
+func TestDispatchMarkPullReady(t *testing.T) {
+	client := &fakeClient{markReadyChanged: true}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMarkReady))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("mark ready result = %+v", got)
+	}
+	if client.markReady != 7 {
+		t.Fatalf("markReady = %d, want 7", client.markReady)
+	}
+	if !strings.Contains(got.Message, "Marked acme/widgets#7 ready for review") {
+		t.Fatalf("message = %q, want ready confirmation", got.Message)
+	}
+}
+
+func TestDispatchMarkPullDraft(t *testing.T) {
+	client := &fakeClient{markDraftChanged: true}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMarkDraft))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("mark draft result = %+v", got)
+	}
+	if client.markDraft != 7 {
+		t.Fatalf("markDraft = %d, want 7", client.markDraft)
+	}
+	if !strings.Contains(got.Message, "Marked acme/widgets#7 draft") {
+		t.Fatalf("message = %q, want draft confirmation", got.Message)
+	}
+}
+
 func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
 	client := &fakeClient{diff: []byte("diff --git a/a b/a\n+hello\n")}
 	shellRunner := &fakeShellRunner{}
@@ -382,23 +410,27 @@ func TestDispatchReturnsErrorResult(t *testing.T) {
 }
 
 type fakeClient struct {
-	err           error
-	commentBody   string
-	issueState    data.ItemState
-	pullState     data.ItemState
-	merge         data.MergeOptions
-	review        data.PullReviewOptions
-	updatePull    int64
-	diff          []byte
-	rerunRunID    int64
-	cancelRunID   int64
-	assignPull    int64
-	assignIssue   int64
-	unassignPull  int64
-	unassignIssue int64
-	labelIndex    int64
-	addLabels     []string
-	removeLabels  []string
+	err              error
+	commentBody      string
+	issueState       data.ItemState
+	pullState        data.ItemState
+	merge            data.MergeOptions
+	review           data.PullReviewOptions
+	updatePull       int64
+	markReady        int64
+	markDraft        int64
+	diff             []byte
+	rerunRunID       int64
+	cancelRunID      int64
+	assignPull       int64
+	assignIssue      int64
+	unassignPull     int64
+	unassignIssue    int64
+	labelIndex       int64
+	addLabels        []string
+	removeLabels     []string
+	markReadyChanged bool
+	markDraftChanged bool
 }
 
 func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
@@ -461,6 +493,16 @@ func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewO
 func (f *fakeClient) UpdatePullRequest(_, _ string, index int64) error {
 	f.updatePull = index
 	return f.err
+}
+
+func (f *fakeClient) MarkPullReady(_, _ string, index int64) (bool, error) {
+	f.markReady = index
+	return f.markReadyChanged, f.err
+}
+
+func (f *fakeClient) MarkPullDraft(_, _ string, index int64) (bool, error) {
+	f.markDraft = index
+	return f.markDraftChanged, f.err
 }
 
 func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,7 +324,7 @@ var universalBuiltins = builtinSet(
 
 var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
-	"update", "updateBranch", "close", "reopen", "diff", "checkout", "approve", "review",
+	"update", "updateBranch", "ready", "markReady", "draft", "markDraft", "close", "reopen", "diff", "checkout", "approve", "review",
 	"summaryViewMore", "expand",
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -270,6 +270,8 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "a", Builtin: "assign"},
 		{Key: "L", Builtin: "addLabel"},
 		{Key: "u", Builtin: "update"},
+		{Key: "W", Builtin: "ready"},
+		{Key: "D", Builtin: "draft"},
 	}, Issues: []Keybinding{
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"fmt"
+	"strings"
 
 	sdk "code.gitea.io/sdk/gitea"
 
@@ -279,6 +280,75 @@ func (c *Client) UpdatePullRequest(owner, repo string, index int64) error {
 		return fmt.Errorf("update pull request %s/%s#%d: %w", owner, repo, index, err)
 	}
 	return nil
+}
+
+// MarkPullReady removes Gitea/Forgejo's work-in-progress title prefix. The
+// pinned SDK exposes no draft edit field, and Gitea documents WIP prefixes as
+// the portable way to mark a pull request as not ready.
+func (c *Client) MarkPullReady(owner, repo string, index int64) (bool, error) {
+	return c.setPullDraft(owner, repo, index, false)
+}
+
+// MarkPullDraft adds Gitea/Forgejo's default work-in-progress title prefix.
+func (c *Client) MarkPullDraft(owner, repo string, index int64) (bool, error) {
+	return c.setPullDraft(owner, repo, index, true)
+}
+
+func (c *Client) setPullDraft(owner, repo string, index int64, draft bool) (bool, error) {
+	var current *sdk.PullRequest
+	err := c.call(func() error {
+		var e error
+		current, _, e = c.sdk.GetPullRequest(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return false, fmt.Errorf("get pull title %s/%s#%d: %w", owner, repo, index, err)
+	}
+	if current == nil {
+		return false, fmt.Errorf("get pull title %s/%s#%d: empty response", owner, repo, index)
+	}
+
+	title, changed := draftTitle(current.Title, draft)
+	if !changed {
+		return false, nil
+	}
+	err = c.call(func() error {
+		_, _, e := c.sdk.EditPullRequest(owner, repo, index, sdk.EditPullRequestOption{Title: title})
+		return e
+	})
+	if err != nil {
+		action := "mark pull ready"
+		if draft {
+			action = "mark pull draft"
+		}
+		return false, fmt.Errorf("%s %s/%s#%d: %w", action, owner, repo, index, err)
+	}
+	return true, nil
+}
+
+func draftTitle(title string, draft bool) (string, bool) {
+	readyTitle, hadPrefix := stripWIPPrefix(title)
+	if draft {
+		if hadPrefix {
+			return title, false
+		}
+		return "WIP: " + title, true
+	}
+	if !hadPrefix {
+		return title, false
+	}
+	return readyTitle, true
+}
+
+func stripWIPPrefix(title string) (string, bool) {
+	trimmedLeft := strings.TrimLeft(title, " \t")
+	lower := strings.ToLower(trimmedLeft)
+	for _, prefix := range []string{"wip:", "[wip]"} {
+		if strings.HasPrefix(lower, prefix) {
+			return strings.TrimLeft(trimmedLeft[len(prefix):], " \t"), true
+		}
+	}
+	return title, false
 }
 
 // SubmitPullReview creates a submitted pull-request review.

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -311,6 +311,86 @@ func TestUpdatePullRequestPostsUpdateEndpoint(t *testing.T) {
 	}
 }
 
+func TestMarkPullReadyRemovesWIPPrefix(t *testing.T) {
+	var patchedTitle string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"number":44,"title":"WIP: Add dashboard"}`)
+		case http.MethodPatch:
+			body := decodeMutationBody(t, r)
+			patchedTitle, _ = body["title"].(string)
+			fmt.Fprintf(w, `{"number":44,"title":%q}`, patchedTitle)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	changed, err := c.MarkPullReady("acme", "widgets", 44)
+	if err != nil {
+		t.Fatalf("MarkPullReady: %v", err)
+	}
+	if !changed || patchedTitle != "Add dashboard" {
+		t.Fatalf("changed=%v patchedTitle=%q, want changed title without WIP prefix", changed, patchedTitle)
+	}
+}
+
+func TestMarkPullReadyNoOpsWhenAlreadyReady(t *testing.T) {
+	var patchCalls int
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"number":44,"title":"Add dashboard"}`)
+		case http.MethodPatch:
+			patchCalls++
+			fmt.Fprint(w, `{"number":44,"title":"unexpected"}`)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	changed, err := c.MarkPullReady("acme", "widgets", 44)
+	if err != nil {
+		t.Fatalf("MarkPullReady: %v", err)
+	}
+	if changed || patchCalls != 0 {
+		t.Fatalf("changed=%v patchCalls=%d, want no mutation when title is already ready", changed, patchCalls)
+	}
+}
+
+func TestMarkPullDraftAddsWIPPrefix(t *testing.T) {
+	var patchedTitle string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodGet:
+			fmt.Fprint(w, `{"number":44,"title":"Add dashboard"}`)
+		case http.MethodPatch:
+			body := decodeMutationBody(t, r)
+			patchedTitle, _ = body["title"].(string)
+			fmt.Fprintf(w, `{"number":44,"title":%q}`, patchedTitle)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	changed, err := c.MarkPullDraft("acme", "widgets", 44)
+	if err != nil {
+		t.Fatalf("MarkPullDraft: %v", err)
+	}
+	if !changed || patchedTitle != "WIP: Add dashboard" {
+		t.Fatalf("changed=%v patchedTitle=%q, want WIP-prefixed title", changed, patchedTitle)
+	}
+}
+
 func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -13,6 +13,8 @@ const (
 	KindRemoveLabel   Kind = "remove_label"
 	KindMerge         Kind = "merge"
 	KindUpdateBranch  Kind = "update_branch"
+	KindMarkReady     Kind = "mark_ready"
+	KindMarkDraft     Kind = "mark_draft"
 	KindClose         Kind = "close"
 	KindReopen        Kind = "reopen"
 	KindReview        Kind = "review"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -9,6 +9,8 @@ func TestKindConstants(t *testing.T) {
 		KindRemoveLabel:  "remove_label",
 		KindMerge:        "merge",
 		KindUpdateBranch: "update_branch",
+		KindMarkReady:    "mark_ready",
+		KindMarkDraft:    "mark_draft",
 		KindClose:        "close",
 		KindReopen:       "reopen",
 		KindReview:       "review",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -418,6 +418,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindMerge)
 		case !m.scopedBuiltinOverridden("update") && key.Matches(msg, m.keys.UpdateBranch):
 			return m, m.startAction(actions.KindUpdateBranch)
+		case !m.scopedBuiltinOverridden("ready") && key.Matches(msg, m.keys.MarkReady):
+			return m, m.startAction(actions.KindMarkReady)
 		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
 			return m, m.startAction(actions.KindClose)
 		case !m.scopedBuiltinOverridden("reopen") && key.Matches(msg, m.keys.Reopen):
@@ -573,7 +575,7 @@ func (m Model) helpLine() string {
 		case context.BranchesView:
 			text += " · C/space switch"
 		default:
-			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · W ready · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
@@ -586,7 +588,7 @@ func (m Model) helpLine() string {
 	case context.BranchesView:
 		text += " · C/space switch"
 	default:
-		text += " · c comment · a/A assign · L/U labels · m merge · u update · d/ctrl+t diff · C/space checkout"
+		text += " · c comment · a/A assign · L/U labels · m merge · u update · W ready · d/ctrl+t diff · C/space checkout"
 	}
 	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
 }
@@ -637,6 +639,9 @@ func (m Model) actionButtons() []actionButton {
 			buttons = append(buttons, actionButton{Label: "Close", Builtin: "close"})
 		}
 	default:
+		if pr, ok := row.(data.PullRequest); ok && pr.Draft {
+			buttons = append(buttons, actionButton{Label: "Ready", Builtin: "ready"})
+		}
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
 			actionButton{Label: "Diff", Builtin: "diff"},
@@ -1355,6 +1360,10 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindMerge), true
 	case "update", "updatebranch":
 		return m, m.startAction(actions.KindUpdateBranch), true
+	case "ready", "markready":
+		return m, m.startAction(actions.KindMarkReady), true
+	case "draft", "markdraft":
+		return m, m.startAction(actions.KindMarkDraft), true
 	case "close":
 		return m, m.startAction(actions.KindClose), true
 	case "reopen":
@@ -1466,7 +1475,7 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 
 func validateActionTarget(kind actions.Kind, target actions.Target) error {
 	switch kind {
-	case actions.KindMerge, actions.KindUpdateBranch, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
+	case actions.KindMerge, actions.KindUpdateBranch, actions.KindMarkReady, actions.KindMarkDraft, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
 		}
@@ -1584,6 +1593,10 @@ func actionLabel(kind actions.Kind) string {
 		return "Merge"
 	case actions.KindUpdateBranch:
 		return "Update branch"
+	case actions.KindMarkReady:
+		return "Mark ready"
+	case actions.KindMarkDraft:
+		return "Mark draft"
 	case actions.KindClose:
 		return "Close"
 	case actions.KindReopen:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -177,6 +177,19 @@ func TestActionBarRendersCommonPullRequestButtons(t *testing.T) {
 	}
 }
 
+func TestActionBarRendersReadyButtonForDraftPullRequest(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "Draft work", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open", Draft: true,
+	}}))
+
+	view := m.View().Content
+	if !strings.Contains(view, "[Ready]") {
+		t.Fatalf("draft PR action bar missing Ready button:\n%s", view)
+	}
+}
+
 func TestMouseClickActionButtonStartsPromptAction(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -192,6 +205,24 @@ func TestMouseClickActionButtonStartsPromptAction(t *testing.T) {
 	}
 	if !m.actionPrompt.Active() || m.pendingAction.Kind != actions.KindComment {
 		t.Fatalf("comment button prompt active=%v pending=%s, want comment prompt", m.actionPrompt.Active(), m.pendingAction.Kind)
+	}
+}
+
+func TestMouseClickReadyActionButtonStartsPromptAction(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "Draft work", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open", Draft: true,
+	}}))
+
+	x := actionButtonClickX(t, m, "Ready")
+	next, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.actionBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("ready button should open the prompt synchronously, got cmd %v", cmd)
+	}
+	if !m.actionPrompt.Active() || m.pendingAction.Kind != actions.KindMarkReady {
+		t.Fatalf("ready button prompt active=%v pending=%s, want mark-ready prompt", m.actionPrompt.Active(), m.pendingAction.Kind)
 	}
 }
 
@@ -1414,6 +1445,7 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "close", key: tea.KeyPressMsg{Code: 'x', Text: "x"}, kind: actions.KindClose},
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "update branch", key: tea.KeyPressMsg{Code: 'u', Text: "u"}, kind: actions.KindUpdateBranch},
+		{name: "mark ready", key: tea.KeyPressMsg{Code: 'W', Text: "W"}, kind: actions.KindMarkReady},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
 		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
 		{name: "external diff ctrl-t alias", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, kind: actions.KindExternalDiff},

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -30,6 +30,7 @@ type keyMap struct {
 	RemoveLabel   key.Binding
 	Merge         key.Binding
 	UpdateBranch  key.Binding
+	MarkReady     key.Binding
 	Close         key.Binding
 	Reopen        key.Binding
 	Review        key.Binding
@@ -122,6 +123,10 @@ func defaultKeyMap() keyMap {
 		UpdateBranch: key.NewBinding(
 			key.WithKeys("u"),
 			key.WithHelp("u", "update branch"),
+		),
+		MarkReady: key.NewBinding(
+			key.WithKeys("W"),
+			key.WithHelp("W", "ready"),
 		),
 		Close: key.NewBinding(
 			key.WithKeys("x"),
@@ -234,6 +239,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Merge = binding(keyName, "merge")
 	case "update", "updatebranch":
 		k.UpdateBranch = binding(keyName, "update branch")
+	case "ready", "markready":
+		k.MarkReady = binding(keyName, "ready")
 	case "close":
 		k.Close = binding(keyName, "close")
 	case "reopen":


### PR DESCRIPTION
## Summary
- Add a pull-request action for marking WIP/draft pull requests ready for review.
- Wire the action through the Gitea client, action runner, default W hotkey, custom keybindings, and the clickable action bar for draft rows.
- Keep a configurable draft action available through scoped keybindings while exposing ready as the default gh-dash-style shortcut.

## Testing
- GOCACHE=/tmp/tea-dash-go-cache go test ./internal/gitea ./internal/actionrunner ./internal/ui ./internal/ui/actions ./internal/config -run 'TestMarkPull|TestDispatchMarkPull|TestActionBarRendersReady|TestMouseClickReady|TestActionKeysDispatchExpectedIntents|TestKindConstants|TestConfigValidateKeybindingsRequireKeyAndAction'
- git diff --check
- bash scripts/check-public-hygiene.sh
- GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build