### PR TITLE
Jump from PRs to checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ tea-dash --help
 | `m`             | merge PR                |
 | `u`             | update PR branch from its base branch |
 | `W`             | mark draft PR ready for review |
+| `w`             | show/watch PR checks in the Actions view |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `b` / `B`       | pin / unpin notification |
 | `x` / `X`       | close / reopen          |
@@ -222,6 +223,8 @@ keybindings:
       builtin: update
     - key: W
       builtin: ready
+    - key: w
+      builtin: watchChecks
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -388,7 +388,8 @@ var universalBuiltins = builtinSet(
 
 var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
-	"update", "updateBranch", "ready", "markReady", "draft", "markDraft", "close", "reopen", "diff", "checkout", "approve", "review",
+	"update", "updateBranch", "ready", "markReady", "draft", "markDraft",
+	"watch", "watchChecks", "checks", "close", "reopen", "diff", "checkout", "approve", "review",
 	"summaryViewMore", "expand",
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -353,6 +353,7 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "u", Builtin: "update"},
 		{Key: "W", Builtin: "ready"},
 		{Key: "D", Builtin: "draft"},
+		{Key: "w", Builtin: "watchChecks"},
 	}, Issues: []Keybinding{
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},

--- a/internal/data/model.go
+++ b/internal/data/model.go
@@ -28,6 +28,8 @@ type PullRequest struct {
 	Author            string // poster login
 	State             string // "open" | "closed" | "merged"
 	Draft             bool
+	HeadRef           string
+	HeadSHA           string
 	HTMLURL           string
 	CreatedAt         time.Time
 	UpdatedAt         time.Time

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -41,6 +41,10 @@ type searchIssue struct {
 	PullRequest *struct {
 		Merged bool `json:"merged"`
 		Draft  bool `json:"draft"`
+		Head   *struct {
+			Ref string `json:"ref"`
+			Sha string `json:"sha"`
+		} `json:"head"`
 	} `json:"pull_request"`
 }
 
@@ -374,6 +378,10 @@ func mapSearchIssue(it searchIssue) data.PullRequest {
 		pr.Draft = it.PullRequest.Draft
 		if it.PullRequest.Merged {
 			pr.State = "merged"
+		}
+		if it.PullRequest.Head != nil {
+			pr.HeadRef = it.PullRequest.Head.Ref
+			pr.HeadSHA = it.PullRequest.Head.Sha
 		}
 	}
 	for _, l := range it.Labels {

--- a/internal/gitea/search_test.go
+++ b/internal/gitea/search_test.go
@@ -20,7 +20,7 @@ const searchJSON = `[
    "labels":[{"name":"bug","color":"ff0000"}],
    "created_at":"2026-06-01T00:00:00Z","updated_at":"2026-06-02T00:00:00Z",
    "repository":{"full_name":"acme/widgets"},
-   "pull_request":{"merged":false}}
+   "pull_request":{"merged":false,"head":{"ref":"feature/checks","sha":"abc123"}}}
 ]`
 
 const issueJSON = `[
@@ -130,6 +130,9 @@ func TestSearchPulls(t *testing.T) {
 	pr := prs[0]
 	if pr.Number != 7 || pr.RepoNameWithOwner != "acme/widgets" || pr.Author != "me" {
 		t.Fatalf("mapped PR = %+v", pr)
+	}
+	if pr.HeadRef != "feature/checks" || pr.HeadSHA != "abc123" {
+		t.Fatalf("mapped PR head = %q/%q, want feature/checks/abc123", pr.HeadRef, pr.HeadSHA)
 	}
 
 	// The me-scope MUST be the boolean `created=true` on the search endpoint,

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -118,6 +118,12 @@ type Options struct {
 	SmartFiltering bool
 }
 
+type watchChecksMsg struct {
+	row    data.PullRequest
+	detail data.PullDetail
+	err    error
+}
+
 // New builds the root model. client may be nil in tests (only FetchRows uses it).
 func New(cfg *config.Config, client *gitea.Client) Model {
 	return NewWithOptions(cfg, client, Options{SmartFiltering: cfg.SmartFilteringEnabled()})
@@ -405,6 +411,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case autoRefreshMsg:
 		return m.handleAutoRefresh()
 
+	case watchChecksMsg:
+		if msg.err != nil {
+			m.notice = fmt.Sprintf("Couldn't load PR checks: %v", msg.err)
+			return m, nil
+		}
+		return m.switchToPullChecks(msg.row, msg.detail.HeadRef, msg.detail.HeadSHA)
+
 	case tea.MouseClickMsg:
 		return m.handleMouseClick(msg)
 
@@ -466,6 +479,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindUpdateBranch)
 		case !m.scopedBuiltinOverridden("ready") && key.Matches(msg, m.keys.MarkReady):
 			return m, m.startAction(actions.KindMarkReady)
+		case !m.scopedBuiltinOverridden("watch") && !m.scopedBuiltinOverridden("watchChecks") &&
+			!m.scopedBuiltinOverridden("checks") && key.Matches(msg, m.keys.WatchChecks):
+			return m.watchSelectedPullChecks()
 		case !m.scopedBuiltinOverridden("close") && key.Matches(msg, m.keys.Close):
 			return m, m.startAction(actions.KindClose)
 		case !m.scopedBuiltinOverridden("reopen") && key.Matches(msg, m.keys.Reopen):
@@ -631,7 +647,7 @@ func (m Model) helpLine() string {
 		case context.IssuesView:
 			text += " · c comment · a/A assign/unassign · L/U labels · M milestone · x/X close/reopen"
 		default:
-			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · W ready · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
+			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · W ready · w checks · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
 		return text + " · q quit"
 	}
@@ -652,7 +668,7 @@ func (m Model) helpLine() string {
 	case context.IssuesView:
 		text += " · c comment · a/A assign · L/U labels · M milestone · x/X close/reopen"
 	default:
-		text += " · c comment · a/A assign · L/U labels · m merge · u update · W ready · d/ctrl+t diff · C/space checkout"
+		text += " · c comment · a/A assign · L/U labels · m merge · u update · W ready · w checks · d/ctrl+t diff · C/space checkout"
 	}
 	return text + fmt.Sprintf(" · %s help · %s quit", keyHelp(m.keys.Help, "?"), keyHelp(m.keys.Quit, "q"))
 }
@@ -716,6 +732,7 @@ func (m Model) actionButtons() []actionButton {
 		}
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Checks", Builtin: "watchChecks"},
 			actionButton{Label: "Diff", Builtin: "diff"},
 			actionButton{Label: "Checkout", Builtin: "checkout"},
 		)
@@ -1040,6 +1057,79 @@ func (m *Model) clearPreviewCacheForAction(target actions.Target) {
 		delete(m.actionDetails, key)
 		delete(m.actionEnrichErr, key)
 	}
+}
+
+func (m Model) watchSelectedPullChecks() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.PullRequest)
+	if !ok {
+		m.notice = "Select a pull request to watch checks."
+		return m, nil
+	}
+	branch, sha := pullCheckHead(row, m.pullDetails[m.selKey()])
+	if branch != "" || sha != "" {
+		return m.switchToPullChecks(row, branch, sha)
+	}
+	if m.ctx.Client == nil {
+		return m.switchToPullChecks(row, "", "")
+	}
+	owner, repo, ok := data.SplitOwnerRepo(row.RepoNameWithOwner)
+	if !ok {
+		m.notice = fmt.Sprintf("Can't watch checks for invalid repo %q.", row.RepoNameWithOwner)
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		detail, err := m.ctx.Client.GetPullDetail(owner, repo, row.Number)
+		return watchChecksMsg{row: row, detail: detail, err: err}
+	}
+}
+
+func pullCheckHead(row data.PullRequest, detail *data.PullDetail) (branch, sha string) {
+	branch = row.HeadRef
+	sha = row.HeadSHA
+	if detail != nil {
+		if branch == "" {
+			branch = detail.HeadRef
+		}
+		if sha == "" {
+			sha = detail.HeadSHA
+		}
+	}
+	return branch, sha
+}
+
+func (m Model) switchToPullChecks(row data.PullRequest, branch, sha string) (Model, tea.Cmd) {
+	if _, _, ok := data.SplitOwnerRepo(row.RepoNameWithOwner); !ok {
+		m.notice = fmt.Sprintf("Can't watch checks for invalid repo %q.", row.RepoNameWithOwner)
+		return m, nil
+	}
+	m.ctx.View = context.ActionsView
+	m.currSectionId = 0
+	m.syncMainContentDimensions()
+	cfg := config.SectionConfig{
+		Title: fmt.Sprintf("Checks for #%d", row.Number),
+		Repo:  row.RepoNameWithOwner,
+		Filter: config.PrIssueFilter{
+			Branch:  branch,
+			HeadSHA: sha,
+		},
+	}
+	m.actionDetails = map[string]*data.ActionRunDetail{}
+	m.actionEnrichErr = map[string]error{}
+	m.setCurrentViewSections([]section.Section{actionsection.NewModel(0, m.ctx, cfg)})
+	m.tabs.SetCurrSectionId(0)
+	m.syncProgramContext()
+	if branch == "" && sha == "" {
+		m.notice = fmt.Sprintf("Showing Actions for %s; PR head was not available to narrow checks.", row.RepoNameWithOwner)
+	} else {
+		m.notice = fmt.Sprintf("Watching checks for %s#%d.", row.RepoNameWithOwner, row.Number)
+	}
+	if m.ctx.PreviewOpen {
+		m.syncSidebar()
+	}
+	if s := m.getCurrSection(); s != nil {
+		return m, s.FetchRows()
+	}
+	return m, nil
 }
 
 // switchView cycles pulls -> issues -> notifications -> actions -> branches, lazily
@@ -1495,6 +1585,9 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindMarkReady), true
 	case "draft", "markdraft":
 		return m, m.startAction(actions.KindMarkDraft), true
+	case "watch", "watchchecks", "checks":
+		next, cmd := m.watchSelectedPullChecks()
+		return next, cmd, true
 	case "close":
 		return m, m.startAction(actions.KindClose), true
 	case "reopen":

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -289,6 +289,72 @@ func TestMouseClickReadyActionButtonStartsPromptAction(t *testing.T) {
 	}
 }
 
+func TestWatchChecksHotkeySwitchesToActionsForSelectedPullRequest(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 7, Title: "Fix checks", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+		HeadRef: "feature/checks", HeadSHA: "abc123",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'w', Text: "w"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("watch checks should fetch the transient Actions section")
+	}
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("view = %v, want ActionsView", m.ctx.View)
+	}
+	if len(m.actions) != 1 {
+		t.Fatalf("actions sections = %d, want 1 transient section", len(m.actions))
+	}
+	sec, ok := m.actions[0].(*actionsection.Model)
+	if !ok {
+		t.Fatalf("actions section type = %T", m.actions[0])
+	}
+	if sec.Config.Title != "Checks for #7" || sec.Config.Repo != "gitea/tea" {
+		t.Fatalf("transient section config = %+v", sec.Config)
+	}
+	if sec.Config.Filter.Branch != "feature/checks" || sec.Config.Filter.HeadSHA != "abc123" {
+		t.Fatalf("actions filter = %+v, want PR head branch+SHA", sec.Config.Filter)
+	}
+}
+
+func TestWatchChecksUsesCachedPullDetailWhenRowLacksHead(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 7, Title: "Fix checks", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+	m.pullDetails[m.selKey()] = &data.PullDetail{HeadRef: "detail-branch", HeadSHA: "detail-sha"}
+
+	next, _ := m.Update(tea.KeyPressMsg{Code: 'w', Text: "w"})
+	m = next.(Model)
+	sec := m.actions[0].(*actionsection.Model)
+	if sec.Config.Filter.Branch != "detail-branch" || sec.Config.Filter.HeadSHA != "detail-sha" {
+		t.Fatalf("actions filter = %+v, want cached detail branch+SHA", sec.Config.Filter)
+	}
+}
+
+func TestMouseClickChecksActionButtonSwitchesToActions(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 7, Title: "Fix checks", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+		HeadRef: "feature/checks", HeadSHA: "abc123",
+	}}))
+
+	x := actionButtonClickX(t, m, "Checks")
+	next, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.actionBarY(), Button: tea.MouseLeft})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("checks action button should fetch the transient Actions section")
+	}
+	if m.ctx.View != context.ActionsView {
+		t.Fatalf("view = %v, want ActionsView", m.ctx.View)
+	}
+}
+
 func TestMouseClickRefreshActionButtonRefreshesCurrentSection(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -33,6 +33,7 @@ type keyMap struct {
 	Merge         key.Binding
 	UpdateBranch  key.Binding
 	MarkReady     key.Binding
+	WatchChecks   key.Binding
 	Close         key.Binding
 	Reopen        key.Binding
 	Review        key.Binding
@@ -139,6 +140,10 @@ func defaultKeyMap() keyMap {
 		MarkReady: key.NewBinding(
 			key.WithKeys("W"),
 			key.WithHelp("W", "ready"),
+		),
+		WatchChecks: key.NewBinding(
+			key.WithKeys("w"),
+			key.WithHelp("w", "checks"),
 		),
 		Close: key.NewBinding(
 			key.WithKeys("x"),
@@ -265,6 +270,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.UpdateBranch = binding(keyName, "update branch")
 	case "ready", "markready":
 		k.MarkReady = binding(keyName, "ready")
+	case "watch", "watchchecks", "checks":
+		k.WatchChecks = binding(keyName, "checks")
 	case "close":
 		k.Close = binding(keyName, "close")
 	case "reopen":


### PR DESCRIPTION
## Summary
- Add a gh-dash-style `w` PR hotkey and a clickable `[Checks]` action button.
- Switch from the selected PR into a transient Actions section filtered to that PR's repo/head branch/SHA when available.
- Carry PR head metadata through the row model when the API provides it, with cached detail fallback for list rows that do not include head data.

## Testing
- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui ./internal/gitea ./internal/config -run 'TestWatchChecks|TestMouseClickChecks|TestSearchPulls|TestConfigValidateKeybindingsRequireKeyAndAction|TestScopedBuiltin'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
