### PR TITLE
Checkout local issue branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tea-dash --help
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
 | `d` / `ctrl+t`  | open PR diff in external pager |
-| `C` / `space`   | checkout PR locally; switch branch in Branches view |
+| `C` / `space`   | checkout PR/issue locally; switch branch in Branches view |
 | `R` / `!`       | rerun / cancel Actions run |
 | `r` / `R`       | refresh section / all sections (`ctrl+r` refreshes all in Actions view) |
 | `?`             | show / hide full help   |
@@ -150,6 +150,7 @@ repoPaths:
 git:
   remote: origin
   prBranchTemplate: "pr-{{.PrIndex}}"
+  issueBranchTemplate: "issue-{{.IssueIndex}}"
 
 theme:
   colors:
@@ -226,6 +227,8 @@ keybindings:
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
   issues:
+    - key: C
+      builtin: checkout
     - key: a
       builtin: assign
     - key: A

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -47,6 +47,9 @@ type Client interface {
 // CheckoutFunc runs or fakes a local PR checkout.
 type CheckoutFunc func(context.Context, localgit.CheckoutOptions) (localgit.CheckoutPlan, error)
 
+// IssueCheckoutFunc runs or fakes a local issue branch checkout.
+type IssueCheckoutFunc func(context.Context, localgit.IssueCheckoutOptions) (localgit.IssueCheckoutPlan, error)
+
 // BranchSwitchFunc runs or fakes a local branch switch.
 type BranchSwitchFunc func(context.Context, localgit.SwitchBranchOptions) (localgit.SwitchBranchResult, error)
 
@@ -56,28 +59,30 @@ type ExecProcessFunc func(*exec.Cmd, tea.ExecCallback) tea.Cmd
 
 // Options configures a Runner.
 type Options struct {
-	Client       Client
-	Config       *config.Config
-	InstanceURL  string
-	CWD          string
-	ShellRunner  shell.Runner
-	GitRunner    localgit.Runner
-	Checkout     CheckoutFunc
-	BranchSwitch BranchSwitchFunc
-	ExecProcess  ExecProcessFunc
+	Client        Client
+	Config        *config.Config
+	InstanceURL   string
+	CWD           string
+	ShellRunner   shell.Runner
+	GitRunner     localgit.Runner
+	Checkout      CheckoutFunc
+	IssueCheckout IssueCheckoutFunc
+	BranchSwitch  BranchSwitchFunc
+	ExecProcess   ExecProcessFunc
 }
 
 // Runner executes actions and returns ResultMsg values for the UI.
 type Runner struct {
-	client       Client
-	cfg          *config.Config
-	instanceURL  string
-	cwd          string
-	shellRunner  shell.Runner
-	gitRunner    localgit.Runner
-	checkout     CheckoutFunc
-	branchSwitch BranchSwitchFunc
-	execProcess  ExecProcessFunc
+	client        Client
+	cfg           *config.Config
+	instanceURL   string
+	cwd           string
+	shellRunner   shell.Runner
+	gitRunner     localgit.Runner
+	checkout      CheckoutFunc
+	issueCheckout IssueCheckoutFunc
+	branchSwitch  BranchSwitchFunc
+	execProcess   ExecProcessFunc
 }
 
 // New constructs a Runner with production defaults for omitted runners.
@@ -94,6 +99,10 @@ func New(opts Options) Runner {
 	if checkout == nil {
 		checkout = localgit.RunCheckout
 	}
+	issueCheckout := opts.IssueCheckout
+	if issueCheckout == nil {
+		issueCheckout = localgit.RunIssueCheckout
+	}
 	branchSwitch := opts.BranchSwitch
 	if branchSwitch == nil {
 		branchSwitch = localgit.SwitchBranch
@@ -103,15 +112,16 @@ func New(opts Options) Runner {
 		execProcess = tea.ExecProcess
 	}
 	return Runner{
-		client:       opts.Client,
-		cfg:          cfg,
-		instanceURL:  opts.InstanceURL,
-		cwd:          opts.CWD,
-		shellRunner:  shellRunner,
-		gitRunner:    opts.GitRunner,
-		checkout:     checkout,
-		branchSwitch: branchSwitch,
-		execProcess:  execProcess,
+		client:        opts.Client,
+		cfg:           cfg,
+		instanceURL:   opts.InstanceURL,
+		cwd:           opts.CWD,
+		shellRunner:   shellRunner,
+		gitRunner:     opts.GitRunner,
+		checkout:      checkout,
+		issueCheckout: issueCheckout,
+		branchSwitch:  branchSwitch,
+		execProcess:   execProcess,
 	}
 }
 
@@ -322,20 +332,39 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		return fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, index), nil
 
 	case uiactions.KindCheckout:
-		plan, err := r.checkout(ctx, localgit.CheckoutOptions{
-			RepoName:       intent.Target.Repo,
-			CWD:            r.cwd,
-			InstanceURL:    r.instanceURL,
-			RepoPaths:      r.cfg.RepoPaths,
-			Remote:         r.cfg.Git.Remote,
-			BranchTemplate: r.cfg.Git.PRBranchTemplate,
-			PrIndex:        index,
-			Runner:         r.gitRunner,
-		})
-		if err != nil {
-			return "", err
+		switch intent.Target.RowKind {
+		case uiactions.RowKindPullRequest:
+			plan, err := r.checkout(ctx, localgit.CheckoutOptions{
+				RepoName:       intent.Target.Repo,
+				CWD:            r.cwd,
+				InstanceURL:    r.instanceURL,
+				RepoPaths:      r.cfg.RepoPaths,
+				Remote:         r.cfg.Git.Remote,
+				BranchTemplate: r.cfg.Git.PRBranchTemplate,
+				PrIndex:        index,
+				Runner:         r.gitRunner,
+			})
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Checked out %s in %s.", plan.Branch, plan.RepoPath), nil
+		case uiactions.RowKindIssue:
+			plan, err := r.issueCheckout(ctx, localgit.IssueCheckoutOptions{
+				RepoName:       intent.Target.Repo,
+				CWD:            r.cwd,
+				InstanceURL:    r.instanceURL,
+				RepoPaths:      r.cfg.RepoPaths,
+				BranchTemplate: r.cfg.Git.IssueBranchTemplate,
+				IssueIndex:     index,
+				Runner:         r.gitRunner,
+			})
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Checked out issue branch %s in %s.", plan.Branch, plan.RepoPath), nil
+		default:
+			return "", fmt.Errorf("checkout is only available for pull requests and issues")
 		}
-		return fmt.Sprintf("Checked out %s in %s.", plan.Branch, plan.RepoPath), nil
 
 	case uiactions.KindRerunRun:
 		runID := targetRunID(intent.Target)

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -394,6 +394,33 @@ func TestDispatchCheckoutPassesConfig(t *testing.T) {
 	}
 }
 
+func TestDispatchCheckoutIssuePassesConfig(t *testing.T) {
+	var gotOpts localgit.IssueCheckoutOptions
+	r := New(Options{
+		Client:      &fakeClient{},
+		Config:      &config.Config{RepoPaths: map[string]string{"acme/widgets": "/src/widgets"}, Git: config.Git{IssueBranchTemplate: "issue/{{.IssueIndex}}"}},
+		InstanceURL: "https://git.example",
+		CWD:         "/cwd",
+		IssueCheckout: func(_ context.Context, opts localgit.IssueCheckoutOptions) (localgit.IssueCheckoutPlan, error) {
+			gotOpts = opts
+			return localgit.IssueCheckoutPlan{RepoPath: "/src/widgets", Branch: "issue/7"}, nil
+		},
+	})
+
+	got := runDispatch(t, r, issueIntent(uiactions.KindCheckout))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("issue checkout result = %+v", got)
+	}
+	if gotOpts.RepoName != "acme/widgets" || gotOpts.IssueIndex != 7 || gotOpts.CWD != "/cwd" ||
+		gotOpts.InstanceURL != "https://git.example" ||
+		gotOpts.BranchTemplate != "issue/{{.IssueIndex}}" {
+		t.Fatalf("issue checkout opts = %+v", gotOpts)
+	}
+	if !strings.Contains(got.Message, "Checked out issue branch issue/7") {
+		t.Fatalf("message = %q, want issue checkout confirmation", got.Message)
+	}
+}
+
 func TestDispatchSwitchBranchDoesNotRequireClient(t *testing.T) {
 	var gotOpts localgit.SwitchBranchOptions
 	r := New(Options{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,8 +142,9 @@ func (p Pager) DiffCommand() string {
 
 // Git configures local git checkout behavior.
 type Git struct {
-	Remote           string `yaml:"remote"`
-	PRBranchTemplate string `yaml:"prBranchTemplate"`
+	Remote              string `yaml:"remote"`
+	PRBranchTemplate    string `yaml:"prBranchTemplate"`
+	IssueBranchTemplate string `yaml:"issueBranchTemplate"`
 }
 
 // Keybindings groups configurable bindings by scope. Universal bindings are
@@ -180,6 +181,15 @@ func (g Git) BranchTemplate() string {
 		return tmpl
 	}
 	return "pr-{{.PrIndex}}"
+}
+
+// IssueBranchTemplateOrDefault returns the configured issue branch template or
+// the default.
+func (g Git) IssueBranchTemplateOrDefault() string {
+	if tmpl := strings.TrimSpace(g.IssueBranchTemplate); tmpl != "" {
+		return tmpl
+	}
+	return "issue-{{.IssueIndex}}"
 }
 
 // Instance selects and overrides the Gitea connection.
@@ -394,7 +404,7 @@ var prBuiltins = builtinSet(
 
 var issueBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
-	"milestone", "setMilestone",
+	"milestone", "setMilestone", "checkout",
 )
 
 var notificationBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -198,6 +198,7 @@ repoPaths:
 git:
   remote: upstream
   prBranchTemplate: review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}
+  issueBranchTemplate: issue/{{.Owner}}-{{.Repo}}-{{.IssueIndex}}
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
@@ -209,7 +210,8 @@ git:
 	if c.RepoPaths["acme/api"] != "~/src/acme-api" || c.RepoPaths["acme/*"] != "~/src/acme/{{.Repo}}" {
 		t.Fatalf("repoPaths = %+v", c.RepoPaths)
 	}
-	if c.Git.Remote != "upstream" || c.Git.PRBranchTemplate != "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}" {
+	if c.Git.Remote != "upstream" || c.Git.PRBranchTemplate != "review/{{.Owner}}-{{.Repo}}-{{.PrIndex}}" ||
+		c.Git.IssueBranchTemplate != "issue/{{.Owner}}-{{.Repo}}-{{.IssueIndex}}" {
 		t.Fatalf("git = %+v", c.Git)
 	}
 }
@@ -231,6 +233,8 @@ keybindings:
       command: echo {{.IssueNumber}}
     - key: M
       builtin: setMilestone
+    - key: C
+      builtin: checkout
   notifications:
     - key: b
       builtin: togglePin
@@ -256,6 +260,11 @@ keybindings:
 	if len(c.Keybindings.PRs) != 2 || c.Keybindings.PRs[1].Name != "lazygit" ||
 		!strings.Contains(c.Keybindings.PRs[1].Command, "lazygit") {
 		t.Fatalf("prs keybindings = %+v", c.Keybindings.PRs)
+	}
+	if len(c.Keybindings.Issues) != 3 ||
+		c.Keybindings.Issues[1].Builtin != "setMilestone" ||
+		c.Keybindings.Issues[2].Builtin != "checkout" {
+		t.Fatalf("issues keybindings = %+v", c.Keybindings.Issues)
 	}
 	if len(c.Keybindings.Notifications) != 3 ||
 		c.Keybindings.Notifications[0].Builtin != "togglePin" ||

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -213,26 +213,40 @@ func gitConfigPath(cwd string) (string, error) {
 
 // BranchNameFromTemplate renders a local branch name for a pull request.
 func BranchNameFromTemplate(tmpl, repoName string, prIndex int64) (string, error) {
+	return branchNameFromTemplate(tmpl, repoName, prIndex, 0, config.Git{PRBranchTemplate: tmpl}.BranchTemplate())
+}
+
+// IssueBranchNameFromTemplate renders a local branch name for an issue.
+func IssueBranchNameFromTemplate(tmpl, repoName string, issueIndex int64) (string, error) {
+	return branchNameFromTemplate(tmpl, repoName, 0, issueIndex, config.Git{IssueBranchTemplate: tmpl}.IssueBranchTemplateOrDefault())
+}
+
+func branchNameFromTemplate(tmpl, repoName string, prIndex, issueIndex int64, fallback string) (string, error) {
 	r, err := config.ParseRepo(repoName)
 	if err != nil {
 		return "", err
 	}
-	tmpl = (config.Git{PRBranchTemplate: tmpl}).BranchTemplate()
+	tmpl = strings.TrimSpace(tmpl)
+	if tmpl == "" {
+		tmpl = fallback
+	}
 	t, err := template.New("branch").Option("missingkey=error").Parse(tmpl)
 	if err != nil {
 		return "", err
 	}
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, struct {
-		Owner    string
-		Repo     string
-		RepoName string
-		PrIndex  int64
+		Owner      string
+		Repo       string
+		RepoName   string
+		PrIndex    int64
+		IssueIndex int64
 	}{
-		Owner:    r.Owner,
-		Repo:     r.Name,
-		RepoName: repoName,
-		PrIndex:  prIndex,
+		Owner:      r.Owner,
+		Repo:       r.Name,
+		RepoName:   repoName,
+		PrIndex:    prIndex,
+		IssueIndex: issueIndex,
 	}); err != nil {
 		return "", err
 	}
@@ -307,6 +321,23 @@ type CheckoutPlan struct {
 	RemoteRef    string
 }
 
+// IssueCheckoutOptions configures local issue branch checkout.
+type IssueCheckoutOptions struct {
+	RepoName       string
+	CWD            string
+	InstanceURL    string
+	RepoPaths      map[string]string
+	BranchTemplate string
+	IssueIndex     int64
+	Runner         Runner
+}
+
+// IssueCheckoutPlan is the resolved local issue checkout plan.
+type IssueCheckoutPlan struct {
+	RepoPath string
+	Branch   string
+}
+
 // PlanCheckout resolves paths, branch names, and refspecs without running git.
 func PlanCheckout(opts CheckoutOptions) (CheckoutPlan, error) {
 	if opts.PrIndex <= 0 {
@@ -369,6 +400,59 @@ func RunCheckout(ctx context.Context, opts CheckoutOptions) (CheckoutPlan, error
 	}
 	if _, err := runGit(ctx, runner, plan.RepoPath, "merge", "--ff-only", plan.RemoteRef); err != nil {
 		return CheckoutPlan{}, fmt.Errorf("fast-forward existing branch %s: %w", plan.Branch, err)
+	}
+	return plan, nil
+}
+
+// PlanIssueCheckout resolves the local issue checkout path and branch name
+// without running git.
+func PlanIssueCheckout(opts IssueCheckoutOptions) (IssueCheckoutPlan, error) {
+	if opts.IssueIndex <= 0 {
+		return IssueCheckoutPlan{}, fmt.Errorf("invalid issue index %d", opts.IssueIndex)
+	}
+	repoPath, err := ResolveRepoPath(opts.RepoName, opts.CWD, opts.InstanceURL, opts.RepoPaths)
+	if err != nil {
+		return IssueCheckoutPlan{}, err
+	}
+	branch, err := IssueBranchNameFromTemplate(opts.BranchTemplate, opts.RepoName, opts.IssueIndex)
+	if err != nil {
+		return IssueCheckoutPlan{}, err
+	}
+	return IssueCheckoutPlan{RepoPath: repoPath, Branch: branch}, nil
+}
+
+// RunIssueCheckout creates or switches to a local branch for an issue. Unlike
+// PR checkout there is no remote issue ref to fetch, so this only operates on
+// the local checkout after refusing a dirty worktree.
+func RunIssueCheckout(ctx context.Context, opts IssueCheckoutOptions) (IssueCheckoutPlan, error) {
+	plan, err := PlanIssueCheckout(opts)
+	if err != nil {
+		return IssueCheckoutPlan{}, err
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	status, err := runGit(ctx, runner, plan.RepoPath, "status", "--porcelain")
+	if err != nil {
+		return IssueCheckoutPlan{}, err
+	}
+	if strings.TrimSpace(status.Stdout) != "" {
+		return IssueCheckoutPlan{}, fmt.Errorf("refusing checkout in dirty worktree %s", plan.RepoPath)
+	}
+	exists, err := branchExists(ctx, runner, plan.RepoPath, plan.Branch)
+	if err != nil {
+		return IssueCheckoutPlan{}, err
+	}
+	if !exists {
+		if _, err := runGit(ctx, runner, plan.RepoPath, "switch", "-c", plan.Branch); err != nil {
+			return IssueCheckoutPlan{}, err
+		}
+		return plan, nil
+	}
+	if _, err := runGit(ctx, runner, plan.RepoPath, "switch", plan.Branch); err != nil {
+		return IssueCheckoutPlan{}, err
 	}
 	return plan, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -204,6 +204,24 @@ func TestBranchNameFromTemplate(t *testing.T) {
 	}
 }
 
+func TestIssueBranchNameFromTemplate(t *testing.T) {
+	got, err := IssueBranchNameFromTemplate("issue/{{.Owner}}-{{.Repo}}-{{.IssueIndex}}", "acme/api", 42)
+	if err != nil {
+		t.Fatalf("IssueBranchNameFromTemplate: %v", err)
+	}
+	if got != "issue/acme-api-42" {
+		t.Fatalf("IssueBranchNameFromTemplate = %q", got)
+	}
+
+	got, err = IssueBranchNameFromTemplate("", "acme/api", 42)
+	if err != nil {
+		t.Fatalf("IssueBranchNameFromTemplate default: %v", err)
+	}
+	if got != "issue-42" {
+		t.Fatalf("IssueBranchNameFromTemplate default = %q", got)
+	}
+}
+
 func TestRunCheckoutDirtyTreeRefusal(t *testing.T) {
 	repo := t.TempDir()
 	runner := &fakeRunner{results: []Result{{Stdout: " M file.txt\n", ExitCode: 0}}}
@@ -298,6 +316,76 @@ func TestRunCheckoutMissingRepoPath(t *testing.T) {
 	}
 	if len(runner.commands) != 0 {
 		t.Fatalf("runner should not be called, commands = %#v", runner.commands)
+	}
+}
+
+func TestRunIssueCheckoutCreatesMissingBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 1}, // show-ref missing branch
+		{ExitCode: 0}, // switch -c
+	}}
+
+	plan, err := RunIssueCheckout(context.Background(), IssueCheckoutOptions{
+		RepoName:       "acme/api",
+		RepoPaths:      map[string]string{"acme/api": repo},
+		BranchTemplate: "issue/{{.Owner}}-{{.Repo}}-{{.IssueIndex}}",
+		IssueIndex:     42,
+		Runner:         runner,
+	})
+	if err != nil {
+		t.Fatalf("RunIssueCheckout: %v", err)
+	}
+	if plan.Branch != "issue/acme-api-42" {
+		t.Fatalf("Branch = %q", plan.Branch)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/issue/acme-api-42"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "-c", "issue/acme-api-42"}},
+	})
+}
+
+func TestRunIssueCheckoutSwitchesExistingBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{ExitCode: 0}, // status
+		{ExitCode: 0}, // show-ref existing branch
+		{ExitCode: 0}, // switch branch
+	}}
+
+	_, err := RunIssueCheckout(context.Background(), IssueCheckoutOptions{
+		RepoName:   "acme/api",
+		RepoPaths:  map[string]string{"acme/api": repo},
+		IssueIndex: 7,
+		Runner:     runner,
+	})
+	if err != nil {
+		t.Fatalf("RunIssueCheckout: %v", err)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"status", "--porcelain"}},
+		{Dir: repo, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/issue-7"}},
+		{Dir: repo, Name: "git", Args: []string{"switch", "issue-7"}},
+	})
+}
+
+func TestRunIssueCheckoutDirtyTreeRefusal(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{Stdout: " M file.txt\n", ExitCode: 0}}}
+
+	_, err := RunIssueCheckout(context.Background(), IssueCheckoutOptions{
+		RepoName:   "acme/api",
+		RepoPaths:  map[string]string{"acme/api": repo},
+		IssueIndex: 42,
+		Runner:     runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("RunIssueCheckout dirty error = %v", err)
+	}
+	if len(runner.commands) != 1 || !reflect.DeepEqual(runner.commands[0].Args, []string{"status", "--porcelain"}) {
+		t.Fatalf("commands = %#v", runner.commands)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -702,6 +702,7 @@ func (m Model) actionButtons() []actionButton {
 	case context.IssuesView:
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Checkout", Builtin: "checkout"},
 			actionButton{Label: "Milestone", Builtin: "setMilestone"},
 		)
 		switch rowState(row) {
@@ -1606,9 +1607,13 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 
 func validateActionTarget(kind actions.Kind, target actions.Target) error {
 	switch kind {
-	case actions.KindMerge, actions.KindUpdateBranch, actions.KindMarkReady, actions.KindMarkDraft, actions.KindReview, actions.KindExternalDiff, actions.KindCheckout:
+	case actions.KindMerge, actions.KindUpdateBranch, actions.KindMarkReady, actions.KindMarkDraft, actions.KindReview, actions.KindExternalDiff:
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
+		}
+	case actions.KindCheckout:
+		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
+			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
 		}
 	case actions.KindComment, actions.KindAssign, actions.KindUnassign, actions.KindAddLabel, actions.KindRemoveLabel, actions.KindClose, actions.KindReopen:
 		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -253,6 +253,21 @@ func TestActionBarRendersReadyButtonForDraftPullRequest(t *testing.T) {
 	}
 }
 
+func TestActionBarRendersCommonIssueButtons(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 7, Title: "Issue row", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open",
+	}}))
+
+	view := m.View().Content
+	for _, want := range []string{"[Open]", "[Refresh]", "[Comment]", "[Checkout]", "[Close]"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("issue action bar missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestMouseClickActionButtonStartsPromptAction(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -1752,6 +1767,43 @@ func TestIssueActionButtonsIncludeMilestone(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("milestone action button not found in %+v", m.actionButtons())
+	}
+}
+
+func TestIssueCheckoutHotkeyDispatchesExpectedIntent(t *testing.T) {
+	var got []actions.Intent
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+		got = append(got, intent)
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 7, Title: "Issue row", RepoNameWithOwner: "acme/widgets",
+		Author: "me", State: "open", HTMLURL: "https://example.test/acme/widgets/issues/7",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'C', Text: "C"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("C should open an issue checkout prompt")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if len(got) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(got))
+	}
+	wantTarget := actions.Target{
+		SectionID:   0,
+		SectionType: issuesection.SectionType,
+		RowKind:     actions.RowKindIssue,
+		Repo:        "acme/widgets",
+		Number:      7,
+		Title:       "Issue row",
+		URL:         "https://example.test/acme/widgets/issues/7",
+		Author:      "me",
+	}
+	if got[0].Kind != actions.KindCheckout || got[0].Target != wantTarget {
+		t.Fatalf("intent = %+v, want checkout target %+v", got[0], wantTarget)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds gh-dash-style local checkout support for issues:

- `C` / `space` now works on selected issue rows.
- Issues view shows a `[Checkout]` action button.
- Local git creates or switches to an issue branch, defaulting to `issue-{{.IssueIndex}}`.
- Adds `git.issueBranchTemplate` for user-configurable issue branch names.
- Keeps PR checkout behavior unchanged.

Issue checkout is intentionally local-only: it resolves the repository path, refuses dirty worktrees, and runs `git switch -c <branch>` or `git switch <branch>`. It does not fetch remote PR refs.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/git ./internal/actionrunner ./internal/ui -run 'TestUnmarshalPagerRepoPathsAndGit|TestUnmarshalKeybindings|TestIssueBranchNameFromTemplate|TestRunIssueCheckout|TestDispatchCheckout|TestIssueCheckoutHotkey|TestActionBarRendersCommonIssueButtons'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
