### PR TITLE
Subscribe and unsubscribe issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ tea-dash --help
 | `a` / `A`       | assign / unassign yourself |
 | `L` / `U`       | add / remove labels     |
 | `M`             | set issue milestone     |
+| `b` / `B`       | subscribe / unsubscribe issue |
 | `m`             | merge PR                |
 | `u`             | update PR branch from its base branch |
 | `W`             | mark draft PR ready for review |
@@ -239,6 +240,10 @@ keybindings:
       builtin: removeLabel
     - key: M
       builtin: setMilestone
+    - key: b
+      builtin: subscribe
+    - key: B
+      builtin: unsubscribe
     - key: i
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -31,6 +31,8 @@ type Client interface {
 	UnassignPullFromMe(owner, repo string, index int64) error
 	AssignIssueToMe(owner, repo string, index int64) error
 	UnassignIssueFromMe(owner, repo string, index int64) error
+	SubscribeIssue(owner, repo string, index int64) error
+	UnsubscribeIssue(owner, repo string, index int64) error
 	AddLabels(owner, repo string, index int64, names []string) error
 	RemoveLabels(owner, repo string, index int64, names []string) error
 	SetIssueMilestone(owner, repo string, index int64, title string) error
@@ -230,6 +232,18 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 			return "", err
 		}
 		return fmt.Sprintf("Unassigned you from %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindSubscribe:
+		if err := r.setIssueSubscription(owner, repo, index, intent.Target.RowKind, true); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Subscribed to %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindUnsubscribe:
+		if err := r.setIssueSubscription(owner, repo, index, intent.Target.RowKind, false); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Unsubscribed from %s#%d.", intent.Target.Repo, index), nil
 
 	case uiactions.KindAddLabel:
 		names, err := parseLabelNames(intent.Prompt.Value)
@@ -471,6 +485,16 @@ func (r Runner) setAssignment(owner, repo string, index int64, kind uiactions.Ro
 	}
 }
 
+func (r Runner) setIssueSubscription(owner, repo string, index int64, kind uiactions.RowKind, subscribe bool) error {
+	if kind != uiactions.RowKindIssue {
+		return fmt.Errorf("subscription is only available for issues")
+	}
+	if subscribe {
+		return r.client.SubscribeIssue(owner, repo, index)
+	}
+	return r.client.UnsubscribeIssue(owner, repo, index)
+}
+
 func parseLabelNames(input string) ([]string, error) {
 	parts := strings.Split(input, ",")
 	out := make([]string, 0, len(parts))
@@ -547,6 +571,10 @@ func actionLabel(kind uiactions.Kind) string {
 		return "assign"
 	case uiactions.KindUnassign:
 		return "unassign"
+	case uiactions.KindSubscribe:
+		return "subscribe"
+	case uiactions.KindUnsubscribe:
+		return "unsubscribe"
 	case uiactions.KindAddLabel:
 		return "add label"
 	case uiactions.KindRemoveLabel:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -126,6 +126,41 @@ func TestDispatchAssignAndUnassign(t *testing.T) {
 	}
 }
 
+func TestDispatchIssueSubscribeAndUnsubscribe(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+
+	got := runDispatch(t, r, issueIntent(uiactions.KindSubscribe))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("subscribe issue result = %+v", got)
+	}
+	if client.subscribeIssue != 7 {
+		t.Fatalf("subscribeIssue = %d, want 7", client.subscribeIssue)
+	}
+	if !strings.Contains(got.Message, "Subscribed to acme/widgets#7") {
+		t.Fatalf("subscribe message = %q", got.Message)
+	}
+
+	got = runDispatch(t, r, issueIntent(uiactions.KindUnsubscribe))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("unsubscribe issue result = %+v", got)
+	}
+	if client.unsubscribeIssue != 7 {
+		t.Fatalf("unsubscribeIssue = %d, want 7", client.unsubscribeIssue)
+	}
+	if !strings.Contains(got.Message, "Unsubscribed from acme/widgets#7") {
+		t.Fatalf("unsubscribe message = %q", got.Message)
+	}
+}
+
+func TestDispatchIssueSubscriptionRejectsUnsupportedRows(t *testing.T) {
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), pullIntent(uiactions.KindSubscribe))
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "only available for issues") {
+		t.Fatalf("subscribe pull result = %+v", got)
+	}
+}
+
 func TestDispatchAssignRejectsUnsupportedRows(t *testing.T) {
 	intent := branchIntent(uiactions.KindAssign)
 	intent.Target.Repo = "acme/widgets"
@@ -493,6 +528,8 @@ type fakeClient struct {
 	removeLabels     []string
 	milestoneIndex   int64
 	milestoneTitle   string
+	subscribeIssue   int64
+	unsubscribeIssue int64
 	markReadyChanged bool
 	markDraftChanged bool
 }
@@ -529,6 +566,16 @@ func (f *fakeClient) AssignIssueToMe(_, _ string, index int64) error {
 
 func (f *fakeClient) UnassignIssueFromMe(_, _ string, index int64) error {
 	f.unassignIssue = index
+	return f.err
+}
+
+func (f *fakeClient) SubscribeIssue(_, _ string, index int64) error {
+	f.subscribeIssue = index
+	return f.err
+}
+
+func (f *fakeClient) UnsubscribeIssue(_, _ string, index int64) error {
+	f.unsubscribeIssue = index
 	return f.err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -404,7 +404,7 @@ var prBuiltins = builtinSet(
 
 var issueBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
-	"milestone", "setMilestone", "checkout",
+	"milestone", "setMilestone", "checkout", "subscribe", "unsubscribe",
 )
 
 var notificationBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -235,6 +235,10 @@ keybindings:
       builtin: setMilestone
     - key: C
       builtin: checkout
+    - key: b
+      builtin: subscribe
+    - key: B
+      builtin: unsubscribe
   notifications:
     - key: b
       builtin: togglePin
@@ -261,9 +265,12 @@ keybindings:
 		!strings.Contains(c.Keybindings.PRs[1].Command, "lazygit") {
 		t.Fatalf("prs keybindings = %+v", c.Keybindings.PRs)
 	}
-	if len(c.Keybindings.Issues) != 3 ||
+	if len(c.Keybindings.Issues) != 5 ||
+		c.Keybindings.Issues[0].Command != "echo {{.IssueNumber}}" ||
 		c.Keybindings.Issues[1].Builtin != "setMilestone" ||
-		c.Keybindings.Issues[2].Builtin != "checkout" {
+		c.Keybindings.Issues[2].Builtin != "checkout" ||
+		c.Keybindings.Issues[3].Builtin != "subscribe" ||
+		c.Keybindings.Issues[4].Builtin != "unsubscribe" {
 		t.Fatalf("issues keybindings = %+v", c.Keybindings.Issues)
 	}
 	if len(c.Keybindings.Notifications) != 3 ||

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -393,6 +393,30 @@ func stripWIPPrefix(title string) (string, bool) {
 	return title, false
 }
 
+// SubscribeIssue subscribes the authenticated user to an issue.
+func (c *Client) SubscribeIssue(owner, repo string, index int64) error {
+	err := c.call(func() error {
+		_, e := c.sdk.IssueSubscribe(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("subscribe issue %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return nil
+}
+
+// UnsubscribeIssue unsubscribes the authenticated user from an issue.
+func (c *Client) UnsubscribeIssue(owner, repo string, index int64) error {
+	err := c.call(func() error {
+		_, e := c.sdk.IssueUnSubscribe(owner, repo, index)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("unsubscribe issue %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return nil
+}
+
 // SubmitPullReview creates a submitted pull-request review.
 func (c *Client) SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error) {
 	event, err := mapPullReviewEvent(opt.Event)

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -435,6 +435,34 @@ func TestMarkPullDraftAddsWIPPrefix(t *testing.T) {
 	}
 }
 
+func TestIssueSubscriptionMutations(t *testing.T) {
+	var calls []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/42/subscriptions/me" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		calls = append(calls, r.Method)
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("method = %s", r.Method)
+		}
+	})
+
+	if err := c.SubscribeIssue("acme", "widgets", 42); err != nil {
+		t.Fatalf("SubscribeIssue: %v", err)
+	}
+	if err := c.UnsubscribeIssue("acme", "widgets", 42); err != nil {
+		t.Fatalf("UnsubscribeIssue: %v", err)
+	}
+	if strings.Join(calls, ",") != "PUT,DELETE" {
+		t.Fatalf("subscription calls = %v, want [PUT DELETE]", calls)
+	}
+}
+
 func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -12,6 +12,8 @@ const (
 	KindAddLabel      Kind = "add_label"
 	KindRemoveLabel   Kind = "remove_label"
 	KindSetMilestone  Kind = "set_milestone"
+	KindSubscribe     Kind = "subscribe"
+	KindUnsubscribe   Kind = "unsubscribe"
 	KindMerge         Kind = "merge"
 	KindUpdateBranch  Kind = "update_branch"
 	KindMarkReady     Kind = "mark_ready"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -8,6 +8,8 @@ func TestKindConstants(t *testing.T) {
 		KindAddLabel:     "add_label",
 		KindRemoveLabel:  "remove_label",
 		KindSetMilestone: "set_milestone",
+		KindSubscribe:    "subscribe",
+		KindUnsubscribe:  "unsubscribe",
 		KindMerge:        "merge",
 		KindUpdateBranch: "update_branch",
 		KindMarkReady:    "mark_ready",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -454,6 +454,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindAssign)
 		case !m.scopedBuiltinOverridden("unassign") && key.Matches(msg, m.keys.Unassign):
 			return m, m.startAction(actions.KindUnassign)
+		case !m.scopedBuiltinOverridden("subscribe") && m.ctx.View == context.IssuesView && key.Matches(msg, m.keys.Subscribe):
+			return m, m.startAction(actions.KindSubscribe)
+		case !m.scopedBuiltinOverridden("unsubscribe") && m.ctx.View == context.IssuesView && key.Matches(msg, m.keys.Unsubscribe):
+			return m, m.startAction(actions.KindUnsubscribe)
 		case !m.scopedBuiltinOverridden("addlabel") && key.Matches(msg, m.keys.AddLabel):
 			return m, m.startAction(actions.KindAddLabel)
 		case !m.scopedBuiltinOverridden("removelabel") && key.Matches(msg, m.keys.RemoveLabel):
@@ -629,7 +633,7 @@ func (m Model) helpLine() string {
 		case context.BranchesView:
 			text += " · C/space switch"
 		case context.IssuesView:
-			text += " · c comment · a/A assign/unassign · L/U labels · M milestone · x/X close/reopen"
+			text += " · c comment · a/A assign/unassign · L/U labels · M milestone · b/B subscribe/unsubscribe · x/X close/reopen"
 		default:
 			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · W ready · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
@@ -650,7 +654,7 @@ func (m Model) helpLine() string {
 	case context.BranchesView:
 		text += " · C/space switch"
 	case context.IssuesView:
-		text += " · c comment · a/A assign · L/U labels · M milestone · x/X close/reopen"
+		text += " · c comment · a/A assign · L/U labels · M milestone · b/B subscribe · x/X close/reopen"
 	default:
 		text += " · c comment · a/A assign · L/U labels · m merge · u update · W ready · d/ctrl+t diff · C/space checkout"
 	}
@@ -703,6 +707,8 @@ func (m Model) actionButtons() []actionButton {
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
 			actionButton{Label: "Checkout", Builtin: "checkout"},
+			actionButton{Label: "Subscribe", Builtin: "subscribe"},
+			actionButton{Label: "Unsubscribe", Builtin: "unsubscribe"},
 			actionButton{Label: "Milestone", Builtin: "setMilestone"},
 		)
 		switch rowState(row) {
@@ -1482,6 +1488,10 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindAssign), true
 	case "unassign":
 		return m, m.startAction(actions.KindUnassign), true
+	case "subscribe":
+		return m, m.startAction(actions.KindSubscribe), true
+	case "unsubscribe":
+		return m, m.startAction(actions.KindUnsubscribe), true
 	case "addlabel":
 		return m, m.startAction(actions.KindAddLabel), true
 	case "removelabel":
@@ -1619,7 +1629,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
 		}
-	case actions.KindSetMilestone:
+	case actions.KindSetMilestone, actions.KindSubscribe, actions.KindUnsubscribe:
 		if target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for issues.", actionLabel(kind))
 		}
@@ -1634,7 +1644,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 }
 
 func actionDispatchesDirectly(kind actions.Kind) bool {
-	return kind == actions.KindRerunRun
+	return kind == actions.KindRerunRun || kind == actions.KindSubscribe || kind == actions.KindUnsubscribe
 }
 
 func promptModeForAction(kind actions.Kind) actions.PromptMode {
@@ -1732,6 +1742,10 @@ func actionLabel(kind actions.Kind) string {
 		return "Assign"
 	case actions.KindUnassign:
 		return "Unassign"
+	case actions.KindSubscribe:
+		return "Subscribe"
+	case actions.KindUnsubscribe:
+		return "Unsubscribe"
 	case actions.KindAddLabel:
 		return "Add label"
 	case actions.KindRemoveLabel:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1751,6 +1751,51 @@ func TestIssueMilestoneKeyDispatchesExpectedIntent(t *testing.T) {
 	}
 }
 
+func TestIssueSubscriptionKeysDispatchExpectedIntents(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		kind actions.Kind
+	}{
+		{name: "subscribe", key: tea.KeyPressMsg{Code: 'b', Text: "b"}, kind: actions.KindSubscribe},
+		{name: "unsubscribe", key: tea.KeyPressMsg{Code: 'B', Text: "B"}, kind: actions.KindUnsubscribe},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+				Number: 42, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/issues/42",
+			}}))
+
+			m = update(t, m, tt.key)
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:   0,
+				SectionType: issuesection.SectionType,
+				RowKind:     actions.RowKindIssue,
+				Repo:        "gbarany/tea-dash",
+				Number:      42,
+				Title:       "Issue row",
+				URL:         "https://example.test/gbarany/tea-dash/issues/42",
+				Author:      "me",
+			}
+			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want kind %q target %+v", got[0], tt.kind, wantTarget)
+			}
+		})
+	}
+}
+
 func TestIssueActionButtonsIncludeMilestone(t *testing.T) {
 	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -1804,6 +1849,42 @@ func TestIssueCheckoutHotkeyDispatchesExpectedIntent(t *testing.T) {
 	}
 	if got[0].Kind != actions.KindCheckout || got[0].Target != wantTarget {
 		t.Fatalf("intent = %+v, want checkout target %+v", got[0], wantTarget)
+	}
+}
+
+func TestIssueActionButtonsIncludeSubscriptionActions(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 42, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/issues/42",
+	}}))
+
+	found := map[string]bool{}
+	for _, b := range m.actionButtons() {
+		found[b.Label] = true
+	}
+	for _, label := range []string{"Subscribe", "Unsubscribe"} {
+		if !found[label] {
+			t.Fatalf("issue action button %q not found in %+v", label, m.actionButtons())
+		}
+	}
+}
+
+func TestIssueHelpShowsIssueActionsOnly(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	help := m.helpLine()
+	for _, want := range []string{"M milestone", "b/B subscribe", "x/X close/reopen"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("issue help = %q, want %q", help, want)
+		}
+	}
+	for _, bad := range []string{"merge", "diff", "update"} {
+		if strings.Contains(help, bad) {
+			t.Fatalf("issue help = %q, should not advertise PR-only action %q", help, bad)
+		}
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -27,6 +27,8 @@ type keyMap struct {
 	Comment       key.Binding
 	Assign        key.Binding
 	Unassign      key.Binding
+	Subscribe     key.Binding
+	Unsubscribe   key.Binding
 	AddLabel      key.Binding
 	RemoveLabel   key.Binding
 	Milestone     key.Binding
@@ -115,6 +117,14 @@ func defaultKeyMap() keyMap {
 		Unassign: key.NewBinding(
 			key.WithKeys("A"),
 			key.WithHelp("A", "unassign"),
+		),
+		Subscribe: key.NewBinding(
+			key.WithKeys("b"),
+			key.WithHelp("b", "subscribe"),
+		),
+		Unsubscribe: key.NewBinding(
+			key.WithKeys("B"),
+			key.WithHelp("B", "unsubscribe"),
 		),
 		AddLabel: key.NewBinding(
 			key.WithKeys("L"),
@@ -253,6 +263,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Assign = binding(keyName, "assign")
 	case "unassign":
 		k.Unassign = binding(keyName, "unassign")
+	case "subscribe":
+		k.Subscribe = binding(keyName, "subscribe")
+	case "unsubscribe":
+		k.Unsubscribe = binding(keyName, "unsubscribe")
 	case "addlabel":
 		k.AddLabel = binding(keyName, "add label")
 	case "removelabel":


### PR DESCRIPTION
## Summary

Adds issue subscription actions to the Issues view.

- Adds explicit `Subscribe` and `Unsubscribe` issue actions backed by the Gitea SDK's issue subscription endpoints.
- Wires default issue hotkeys: `b` subscribes and `B` unsubscribes.
- Adds clickable `[Subscribe]` and `[Unsubscribe]` action buttons in the Issues view.
- Allows `subscribe` / `unsubscribe` as issue-scoped configurable builtins.
- Tightens the Issues help line so it no longer advertises PR-only actions like merge, update, diff, or checkout.

Gitea issue list rows do not expose whether the authenticated user is currently subscribed, so the UI intentionally exposes explicit subscribe/unsubscribe commands instead of a misleading toggle.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui/actions ./internal/gitea ./internal/actionrunner ./internal/config ./internal/ui -run 'TestKindConstants|TestIssueSubscription|TestDispatchIssueSub|TestUnmarshalKeybindings|TestIssueActionButtons|TestIssueSubscriptionKeys|TestIssueHelpShowsIssueActionsOnly'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
