### PR TITLE
Pin notification threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ tea-dash --help
 | `m`             | merge PR                |
 | `u`             | update PR branch from its base branch |
 | `m` / `u` / `M` | mark notification read / unread / all read |
+| `b` / `B`       | pin / unpin notification |
 | `x` / `X`       | close / reopen          |
 | `v`             | submit PR review        |
 | `d` / `ctrl+t`  | open PR diff in external pager |
@@ -219,6 +220,10 @@ keybindings:
     - key: i
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:
+    - key: b
+      builtin: togglePin
+    - key: B
+      builtin: unpin
     - key: D
       builtin: markAllRead
   actions:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -349,7 +349,7 @@ var issueBuiltins = builtinSet(
 var notificationBuiltins = builtinSet(
 	"openGithub", "open", "markAsRead", "markRead", "markAsUnread",
 	"markUnread", "markAllAsRead", "markAllRead", "markAsDone", "markDone",
-	"markAllAsDone", "markAllDone",
+	"markAllAsDone", "markAllDone", "pin", "unpin", "togglePin", "togglePinned",
 )
 
 var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -215,6 +215,10 @@ keybindings:
     - key: i
       command: echo {{.IssueNumber}}
   notifications:
+    - key: b
+      builtin: togglePin
+    - key: B
+      builtin: unpin
     - key: D
       builtin: markAllRead
   actions:
@@ -236,7 +240,10 @@ keybindings:
 		!strings.Contains(c.Keybindings.PRs[1].Command, "lazygit") {
 		t.Fatalf("prs keybindings = %+v", c.Keybindings.PRs)
 	}
-	if c.Keybindings.Notifications[0].Builtin != "markAllRead" ||
+	if len(c.Keybindings.Notifications) != 3 ||
+		c.Keybindings.Notifications[0].Builtin != "togglePin" ||
+		c.Keybindings.Notifications[1].Builtin != "unpin" ||
+		c.Keybindings.Notifications[2].Builtin != "markAllRead" ||
 		c.Keybindings.Actions[0].Key != "a" ||
 		c.Keybindings.Branches[0].Command == "" {
 		t.Fatalf("keybindings = %+v", c.Keybindings)

--- a/internal/gitea/notifications.go
+++ b/internal/gitea/notifications.go
@@ -48,6 +48,24 @@ func (c *Client) MarkNotificationUnread(_ context.Context, threadID int64) error
 	return c.markNotification(threadID, sdk.NotifyStatusUnread, "unread")
 }
 
+// PinNotification pins one notification thread.
+func (c *Client) PinNotification(_ context.Context, threadID int64) error {
+	return c.markNotification(threadID, sdk.NotifyStatusPinned, "pinned")
+}
+
+// UnpinNotification unpins one notification thread by restoring its normal
+// read/unread status. Gitea models pinned as a notification status rather than
+// a boolean patch, so the caller must pass the row's current unread state.
+func (c *Client) UnpinNotification(_ context.Context, threadID int64, unread bool) error {
+	status := sdk.NotifyStatusRead
+	label := "unpinned read"
+	if unread {
+		status = sdk.NotifyStatusUnread
+		label = "unpinned unread"
+	}
+	return c.markNotification(threadID, status, label)
+}
+
 // MarkAllNotificationsRead marks all unread notification threads as read.
 func (c *Client) MarkAllNotificationsRead(_ context.Context) error {
 	err := c.call(func() error {

--- a/internal/gitea/notifications_test.go
+++ b/internal/gitea/notifications_test.go
@@ -130,6 +130,66 @@ func TestMarkNotificationUnreadUsesThreadEndpoint(t *testing.T) {
 	}
 }
 
+func TestPinNotificationUsesPinnedStatus(t *testing.T) {
+	var hit bool
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			if got := r.URL.Query().Get("to-status"); got != "pinned" {
+				t.Fatalf("to-status = %q, want pinned", got)
+			}
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"pinned":true}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.PinNotification(context.Background(), 12); err != nil {
+		t.Fatalf("PinNotification: %v", err)
+	}
+	if !hit {
+		t.Fatal("notification thread endpoint was not called")
+	}
+}
+
+func TestUnpinNotificationRestoresReadOrUnreadStatus(t *testing.T) {
+	var statuses []string
+	srv := notificationServer(t, nil, notificationRoute{
+		pattern: "/api/v1/notifications/threads/12",
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Fatalf("method = %s, want PATCH", r.Method)
+			}
+			statuses = append(statuses, r.URL.Query().Get("to-status"))
+			assertEmptyBody(t, r)
+			fmt.Fprint(w, `{"id":12,"pinned":false}`)
+		},
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := c.UnpinNotification(context.Background(), 12, true); err != nil {
+		t.Fatalf("UnpinNotification unread: %v", err)
+	}
+	if err := c.UnpinNotification(context.Background(), 12, false); err != nil {
+		t.Fatalf("UnpinNotification read: %v", err)
+	}
+	if strings.Join(statuses, ",") != "unread,read" {
+		t.Fatalf("to-status values = %v, want [unread read]", statuses)
+	}
+}
+
 func TestMarkAllNotificationsReadUsesNotificationsEndpoint(t *testing.T) {
 	var hit bool
 	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -104,6 +104,8 @@ type notificationActionMsg struct {
 	sectionID int
 	all       bool
 	unread    bool
+	pinned    bool
+	unpinned  bool
 	err       error
 }
 
@@ -414,6 +416,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.markSelectedNotificationUnread()
 		case !m.scopedBuiltinOverridden("markAllRead") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkAllRead):
 			return m.markAllNotificationsRead()
+		case !m.scopedBuiltinOverridden("togglePin") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.Pin):
+			return m.toggleSelectedNotificationPin()
+		case !m.scopedBuiltinOverridden("unpin") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.Unpin):
+			return m.unpinSelectedNotification()
 		case !m.scopedBuiltinOverridden("rerun") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.RerunRun):
 			return m, m.startAction(actions.KindRerunRun)
 		case !m.scopedBuiltinOverridden("cancel") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.CancelRun):
@@ -591,7 +597,7 @@ func (m Model) helpLine() string {
 				text += " · t current repo"
 			}
 		case context.NotificationsView:
-			text += " · m mark read · u mark unread · M mark all read"
+			text += " · m mark read · u mark unread · M mark all read · b pin/unpin · B unpin"
 		case context.BranchesView:
 			text += " · C/space switch"
 		default:
@@ -610,7 +616,7 @@ func (m Model) helpLine() string {
 			text += " · t current repo"
 		}
 	case context.NotificationsView:
-		text += " · m read · u unread · M all read"
+		text += " · m read · u unread · M all read · b pin · B unpin"
 	case context.BranchesView:
 		text += " · C/space switch"
 	default:
@@ -643,6 +649,11 @@ func (m Model) actionButtons() []actionButton {
 				buttons = append(buttons, actionButton{Label: "Mark read", Builtin: "markRead"})
 			} else {
 				buttons = append(buttons, actionButton{Label: "Mark unread", Builtin: "markUnread"})
+			}
+			if n.Pinned {
+				buttons = append(buttons, actionButton{Label: "Unpin", Builtin: "unpin"})
+			} else {
+				buttons = append(buttons, actionButton{Label: "Pin", Builtin: "togglePin"})
 			}
 		}
 		buttons = append(buttons, actionButton{Label: "All read", Builtin: "markAllRead"})
@@ -1405,6 +1416,12 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 	case "markallasread", "markallread", "markallasdone", "markalldone":
 		next, cmd := m.markAllNotificationsRead()
 		return next, cmd, true
+	case "pin", "togglepin", "togglepinned":
+		next, cmd := m.toggleSelectedNotificationPin()
+		return next, cmd, true
+	case "unpin":
+		next, cmd := m.unpinSelectedNotification()
+		return next, cmd, true
 	case "comment":
 		return m, m.startAction(actions.KindComment), true
 	case "assign":
@@ -1739,6 +1756,51 @@ func (m Model) markSelectedNotificationUnread() (Model, tea.Cmd) {
 	return m, markNotificationUnreadCmd(m.ctx.Client, m.currSectionId, row.ID)
 }
 
+func (m Model) toggleSelectedNotificationPin() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.Notification)
+	if !ok {
+		m.notice = "Select a notification to pin."
+		return m, nil
+	}
+	if row.Pinned {
+		return m.unpinNotification(row)
+	}
+	return m.pinNotification(row)
+}
+
+func (m Model) unpinSelectedNotification() (Model, tea.Cmd) {
+	row, ok := m.getCurrRowData().(data.Notification)
+	if !ok {
+		m.notice = "Select a notification to unpin."
+		return m, nil
+	}
+	return m.unpinNotification(row)
+}
+
+func (m Model) pinNotification(row data.Notification) (Model, tea.Cmd) {
+	if row.ID == 0 {
+		m.notice = "Selected notification has no thread id."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to pin notifications."
+		return m, nil
+	}
+	return m, markNotificationPinnedCmd(m.ctx.Client, m.currSectionId, row.ID)
+}
+
+func (m Model) unpinNotification(row data.Notification) (Model, tea.Cmd) {
+	if row.ID == 0 {
+		m.notice = "Selected notification has no thread id."
+		return m, nil
+	}
+	if m.ctx.Client == nil {
+		m.notice = "No Gitea client available to unpin notifications."
+		return m, nil
+	}
+	return m, markNotificationUnpinnedCmd(m.ctx.Client, m.currSectionId, row.ID, row.Unread)
+}
+
 func (m Model) markAllNotificationsRead() (Model, tea.Cmd) {
 	if m.ctx.View != context.NotificationsView {
 		m.notice = "Switch to notifications to mark all read."
@@ -1774,6 +1836,31 @@ func markNotificationUnreadCmd(client *gitea.Client, sectionID int, threadID int
 	}
 }
 
+func markNotificationPinnedCmd(client *gitea.Client, sectionID int, threadID int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			pinned:    true,
+			err:       client.PinNotification(ctx, threadID),
+		}
+	}
+}
+
+func markNotificationUnpinnedCmd(client *gitea.Client, sectionID int, threadID int64, unread bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
+		defer cancel()
+		return notificationActionMsg{
+			sectionID: sectionID,
+			unread:    unread,
+			unpinned:  true,
+			err:       client.UnpinNotification(ctx, threadID, unread),
+		}
+	}
+}
+
 func markAllNotificationsReadCmd(client *gitea.Client, sectionID int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := stdctx.WithTimeout(stdctx.Background(), 30*time.Second)
@@ -1790,6 +1877,10 @@ func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.C
 	if msg.err != nil {
 		if msg.all {
 			m.notice = fmt.Sprintf("Couldn't mark all notifications read: %v", msg.err)
+		} else if msg.pinned {
+			m.notice = fmt.Sprintf("Couldn't pin notification: %v", msg.err)
+		} else if msg.unpinned {
+			m.notice = fmt.Sprintf("Couldn't unpin notification: %v", msg.err)
 		} else if msg.unread {
 			m.notice = fmt.Sprintf("Couldn't mark notification unread: %v", msg.err)
 		} else {
@@ -1799,6 +1890,10 @@ func (m Model) handleNotificationAction(msg notificationActionMsg) (Model, tea.C
 	}
 	if msg.all {
 		m.notice = "Marked all notifications read."
+	} else if msg.pinned {
+		m.notice = "Pinned notification."
+	} else if msg.unpinned {
+		m.notice = "Unpinned notification."
 	} else if msg.unread {
 		m.notice = "Marked notification unread."
 	} else {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -936,6 +936,94 @@ func TestMarkSelectedNotificationUnreadRefreshesNotifications(t *testing.T) {
 	}
 }
 
+func TestToggleNotificationPinRefreshesNotifications(t *testing.T) {
+	tests := []struct {
+		name       string
+		pinned     bool
+		unread     bool
+		key        tea.KeyPressMsg
+		wantStatus string
+		wantNotice string
+	}{
+		{name: "pin", key: tea.KeyPressMsg{Code: 'b', Text: "b"}, pinned: false, unread: true, wantStatus: "pinned", wantNotice: "Pinned notification"},
+		{name: "toggle unpin unread", key: tea.KeyPressMsg{Code: 'b', Text: "b"}, pinned: true, unread: true, wantStatus: "unread", wantNotice: "Unpinned notification"},
+		{name: "explicit unpin read", key: tea.KeyPressMsg{Code: 'B', Text: "B"}, pinned: true, unread: false, wantStatus: "read", wantNotice: "Unpinned notification"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotStatus string
+			client := newNotificationActionClient(t,
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/api/v1/notifications/threads/12" {
+						http.NotFound(w, r)
+						return
+					}
+					gotStatus = r.URL.Query().Get("to-status")
+					fmt.Fprint(w, `{"id":12}`)
+				},
+				nil,
+			)
+			m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, notificationFetchedMsg([]data.Notification{{
+				ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+				SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+				Unread: tt.unread, Pinned: tt.pinned, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+			}}))
+
+			next, cmd := m.Update(tt.key)
+			if cmd == nil {
+				t.Fatalf("%s should return a notification pin command", tt.name)
+			}
+			m = next.(Model)
+			msg := cmd()
+			if gotStatus != tt.wantStatus {
+				t.Fatalf("to-status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+			next, refresh := m.Update(msg)
+			m = next.(Model)
+			if refresh == nil {
+				t.Fatal("successful pin action should refresh the notifications section")
+			}
+			if !strings.Contains(m.notice, tt.wantNotice) {
+				t.Fatalf("notice = %q, want %q", m.notice, tt.wantNotice)
+			}
+		})
+	}
+}
+
+func TestNotificationActionButtonsIncludePinStateAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		pinned bool
+		want   string
+	}{
+		{name: "unpinned", pinned: false, want: "Pin"},
+		{name: "pinned", pinned: true, want: "Unpin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, nil)
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, notificationFetchedMsg([]data.Notification{{
+				ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",
+				SubjectType: "Pull", SubjectState: "open", RepoNameWithOwner: "gbarany/tea-dash",
+				Unread: true, Pinned: tt.pinned, HTMLURL: "https://git.example/gbarany/tea-dash/pulls/42",
+			}}))
+			found := false
+			for _, b := range m.actionButtons() {
+				if b.Label == tt.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s notification buttons = %+v, want %q", tt.name, m.actionButtons(), tt.want)
+			}
+		})
+	}
+}
+
 func TestMarkAllNotificationsReadRefreshesNotifications(t *testing.T) {
 	var hit bool
 	client := newNotificationActionClient(t,
@@ -1849,9 +1937,15 @@ func TestNotificationsHelpShowsUnreadShortcut(t *testing.T) {
 	if view := m.View().Content; !strings.Contains(view, "u unread") {
 		t.Fatalf("compact notifications help missing unread shortcut:\n%s", view)
 	}
+	if view := m.View().Content; !strings.Contains(view, "b pin") {
+		t.Fatalf("compact notifications help missing pin shortcut:\n%s", view)
+	}
 	m = update(t, m, tea.KeyPressMsg{Code: '?', Text: "?"})
 	if view := m.View().Content; !strings.Contains(view, "u mark unread") {
 		t.Fatalf("full notifications help missing mark-unread shortcut:\n%s", view)
+	}
+	if view := m.View().Content; !strings.Contains(view, "b pin") {
+		t.Fatalf("full notifications help missing pin shortcut:\n%s", view)
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -44,6 +44,8 @@ type keyMap struct {
 	MarkRead      key.Binding
 	MarkUnread    key.Binding
 	MarkAllRead   key.Binding
+	Pin           key.Binding
+	Unpin         key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -180,6 +182,14 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("M"),
 			key.WithHelp("M", "mark all read"),
 		),
+		Pin: key.NewBinding(
+			key.WithKeys("b"),
+			key.WithHelp("b", "pin"),
+		),
+		Unpin: key.NewBinding(
+			key.WithKeys("B"),
+			key.WithHelp("B", "unpin"),
+		),
 	}
 }
 
@@ -267,6 +277,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.MarkUnread = binding(keyName, "mark unread")
 	case "markallasread", "markallread":
 		k.MarkAllRead = binding(keyName, "mark all read")
+	case "pin", "togglepin", "togglepinned":
+		k.Pin = binding(keyName, "pin")
+	case "unpin":
+		k.Unpin = binding(keyName, "unpin")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds notification pinning controls to the Notifications view.

- Adds Gitea notification pin/unpin wrappers using `ReadNotification(..., pinned/read/unread)`.
- Adds `b` to pin/unpin the selected notification and `B` to explicitly unpin.
- Adds clickable `[Pin]` / `[Unpin]` action buttons based on the selected notification's current pinned state.
- Allows notification-scoped `pin`, `unpin`, and `togglePin` builtins in config.
- Documents the new keys in README and keybinding examples.

Unpin preserves the selected row's unread/read state because Gitea models pinned as a notification status.

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/gitea ./internal/config ./internal/ui -run 'TestPinNotification|TestUnpinNotification|TestUnmarshalKeybindings|TestToggleNotificationPin|TestNotificationActionButtons|TestNotificationsHelpShowsUnreadShortcut'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
