### PR TITLE
Set issue milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ tea-dash --help
 | `c`             | add comment             |
 | `a` / `A`       | assign / unassign yourself |
 | `L` / `U`       | add / remove labels     |
+| `M`             | set issue milestone     |
 | `m`             | merge PR                |
 | `u`             | update PR branch from its base branch |
 | `W`             | mark draft PR ready for review |
@@ -219,6 +220,8 @@ keybindings:
       builtin: addLabel
     - key: U
       builtin: removeLabel
+    - key: M
+      builtin: setMilestone
     - key: i
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -33,6 +33,7 @@ type Client interface {
 	UnassignIssueFromMe(owner, repo string, index int64) error
 	AddLabels(owner, repo string, index int64, names []string) error
 	RemoveLabels(owner, repo string, index int64, names []string) error
+	SetIssueMilestone(owner, repo string, index int64, title string) error
 	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
 	UpdatePullRequest(owner, repo string, index int64) error
 	MarkPullReady(owner, repo string, index int64) (bool, error)
@@ -239,6 +240,19 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 			return "", err
 		}
 		return fmt.Sprintf("Removed labels from %s#%d.", intent.Target.Repo, index), nil
+
+	case uiactions.KindSetMilestone:
+		title := strings.TrimSpace(intent.Prompt.Value)
+		if title == "" {
+			return "", fmt.Errorf("milestone title cannot be empty")
+		}
+		if intent.Target.RowKind != uiactions.RowKindIssue {
+			return "", fmt.Errorf("set milestone is only available for issues")
+		}
+		if err := r.client.SetIssueMilestone(owner, repo, index, title); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Set milestone %q on %s#%d.", title, intent.Target.Repo, index), nil
 
 	case uiactions.KindMerge:
 		style, err := mergeStyle(intent.Prompt.Value)
@@ -508,6 +522,8 @@ func actionLabel(kind uiactions.Kind) string {
 		return "add label"
 	case uiactions.KindRemoveLabel:
 		return "remove label"
+	case uiactions.KindSetMilestone:
+		return "set milestone"
 	case uiactions.KindMerge:
 		return "merge"
 	case uiactions.KindUpdateBranch:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -182,6 +182,41 @@ func TestDispatchLabelsRejectUnsupportedRows(t *testing.T) {
 	}
 }
 
+func TestDispatchSetIssueMilestone(t *testing.T) {
+	client := &fakeClient{}
+	intent := issueIntent(uiactions.KindSetMilestone)
+	intent.Prompt.Value = "v1.2"
+
+	got := runDispatch(t, New(Options{Client: client}), intent)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("set milestone result = %+v", got)
+	}
+	if client.milestoneIndex != 7 || client.milestoneTitle != "v1.2" {
+		t.Fatalf("milestone index=%d title=%q, want #7 v1.2", client.milestoneIndex, client.milestoneTitle)
+	}
+	if !strings.Contains(got.Message, `Set milestone "v1.2" on acme/widgets#7`) {
+		t.Fatalf("message = %q, want set milestone confirmation", got.Message)
+	}
+}
+
+func TestDispatchSetMilestoneRejectsEmptyAndUnsupportedRows(t *testing.T) {
+	empty := issueIntent(uiactions.KindSetMilestone)
+	empty.Prompt.Value = "  "
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), empty)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "milestone title cannot be empty") {
+		t.Fatalf("empty milestone result = %+v", got)
+	}
+
+	pull := pullIntent(uiactions.KindSetMilestone)
+	pull.Prompt.Value = "v1.2"
+	got = runDispatch(t, New(Options{Client: &fakeClient{}}), pull)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "only available for issues") {
+		t.Fatalf("pull milestone result = %+v", got)
+	}
+}
+
 func TestDispatchMergeAndReview(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})
@@ -429,6 +464,8 @@ type fakeClient struct {
 	labelIndex       int64
 	addLabels        []string
 	removeLabels     []string
+	milestoneIndex   int64
+	milestoneTitle   string
 	markReadyChanged bool
 	markDraftChanged bool
 }
@@ -477,6 +514,12 @@ func (f *fakeClient) AddLabels(_, _ string, index int64, names []string) error {
 func (f *fakeClient) RemoveLabels(_, _ string, index int64, names []string) error {
 	f.labelIndex = index
 	f.removeLabels = append([]string(nil), names...)
+	return f.err
+}
+
+func (f *fakeClient) SetIssueMilestone(_, _ string, index int64, title string) error {
+	f.milestoneIndex = index
+	f.milestoneTitle = title
 	return f.err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,6 +344,7 @@ var prBuiltins = builtinSet(
 
 var issueBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
+	"milestone", "setMilestone",
 )
 
 var notificationBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,6 +214,8 @@ keybindings:
   issues:
     - key: i
       command: echo {{.IssueNumber}}
+    - key: M
+      builtin: setMilestone
   notifications:
     - key: D
       builtin: markAllRead

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -246,6 +246,48 @@ func (c *Client) resolveLabelIDs(owner, repo string, names []string) ([]int64, e
 	return ids, nil
 }
 
+// SetIssueMilestone sets an issue milestone by exact milestone title.
+func (c *Client) SetIssueMilestone(owner, repo string, index int64, title string) error {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return fmt.Errorf("milestone title cannot be empty")
+	}
+
+	var milestones []*sdk.Milestone
+	err := c.call(func() error {
+		var e error
+		milestones, _, e = c.sdk.ListRepoMilestones(owner, repo, sdk.ListMilestoneOption{
+			ListOptions: sdk.ListOptions{Page: -1},
+			State:       sdk.StateAll,
+			Name:        title,
+		})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("list milestones for %s/%s: %w", owner, repo, err)
+	}
+
+	var id int64
+	for _, milestone := range milestones {
+		if milestone != nil && milestone.Title == title {
+			id = milestone.ID
+			break
+		}
+	}
+	if id == 0 {
+		return fmt.Errorf("unknown milestone %q in %s/%s", title, owner, repo)
+	}
+
+	err = c.call(func() error {
+		_, _, e := c.sdk.EditIssue(owner, repo, index, sdk.EditIssueOption{Milestone: &id})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("set milestone %q on %s/%s#%d: %w", title, owner, repo, index, err)
+	}
+	return nil
+}
+
 // MergePullRequest merges a pull request with the requested strategy and
 // optional server-side controls.
 func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -254,6 +254,50 @@ func TestAddLabelsUnknownNameErrors(t *testing.T) {
 	}
 }
 
+func TestSetIssueMilestoneResolvesTitleAndPatchesID(t *testing.T) {
+	var patchedID float64
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/widgets/milestones":
+			if got := r.URL.Query().Get("name"); got != "v1.2" {
+				t.Fatalf("milestone name query = %q, want v1.2", got)
+			}
+			fmt.Fprint(w, `[{"id":17,"title":"v1.2","state":"open"}]`)
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/repos/acme/widgets/issues/42":
+			body := decodeMutationBody(t, r)
+			var ok bool
+			patchedID, ok = body["milestone"].(float64)
+			if !ok {
+				t.Fatalf("milestone body = %#v", body)
+			}
+			fmt.Fprint(w, `{"number":42,"milestone":{"id":17,"title":"v1.2"}}`)
+		default:
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+	})
+
+	if err := c.SetIssueMilestone("acme", "widgets", 42, "v1.2"); err != nil {
+		t.Fatalf("SetIssueMilestone: %v", err)
+	}
+	if patchedID != 17 {
+		t.Fatalf("patched milestone = %v, want 17", patchedID)
+	}
+}
+
+func TestSetIssueMilestoneUnknownTitleErrors(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/repos/acme/widgets/milestones" {
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+		fmt.Fprint(w, `[{"id":17,"title":"v1.2","state":"open"}]`)
+	})
+
+	err := c.SetIssueMilestone("acme", "widgets", 42, "missing")
+	if err == nil || !strings.Contains(err.Error(), `unknown milestone "missing"`) {
+		t.Fatalf("SetIssueMilestone unknown error = %v", err)
+	}
+}
+
 func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -11,6 +11,7 @@ const (
 	KindUnassign      Kind = "unassign"
 	KindAddLabel      Kind = "add_label"
 	KindRemoveLabel   Kind = "remove_label"
+	KindSetMilestone  Kind = "set_milestone"
 	KindMerge         Kind = "merge"
 	KindUpdateBranch  Kind = "update_branch"
 	KindMarkReady     Kind = "mark_ready"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -7,6 +7,7 @@ func TestKindConstants(t *testing.T) {
 		KindComment:      "comment",
 		KindAddLabel:     "add_label",
 		KindRemoveLabel:  "remove_label",
+		KindSetMilestone: "set_milestone",
 		KindMerge:        "merge",
 		KindUpdateBranch: "update_branch",
 		KindMarkReady:    "mark_ready",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -428,6 +428,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindAddLabel)
 		case !m.scopedBuiltinOverridden("removelabel") && key.Matches(msg, m.keys.RemoveLabel):
 			return m, m.startAction(actions.KindRemoveLabel)
+		case !m.scopedBuiltinOverridden("setMilestone") && m.ctx.View == context.IssuesView && key.Matches(msg, m.keys.Milestone):
+			return m, m.startAction(actions.KindSetMilestone)
 		case !m.scopedBuiltinOverridden("merge") && key.Matches(msg, m.keys.Merge):
 			return m, m.startAction(actions.KindMerge)
 		case !m.scopedBuiltinOverridden("update") && key.Matches(msg, m.keys.UpdateBranch):
@@ -596,6 +598,8 @@ func (m Model) helpLine() string {
 			text += " · m mark read · u mark unread · M mark all read"
 		case context.BranchesView:
 			text += " · C/space switch"
+		case context.IssuesView:
+			text += " · c comment · a/A assign/unassign · L/U labels · M milestone · x/X close/reopen"
 		default:
 			text += " · c comment · a/A assign/unassign · L/U labels · m merge · u update · W ready · x/X close/reopen · v review · d/ctrl+t diff · C/space checkout"
 		}
@@ -615,6 +619,8 @@ func (m Model) helpLine() string {
 		text += " · m read · u unread · M all read"
 	case context.BranchesView:
 		text += " · C/space switch"
+	case context.IssuesView:
+		text += " · c comment · a/A assign · L/U labels · M milestone · x/X close/reopen"
 	default:
 		text += " · c comment · a/A assign · L/U labels · m merge · u update · W ready · d/ctrl+t diff · C/space checkout"
 	}
@@ -659,7 +665,10 @@ func (m Model) actionButtons() []actionButton {
 			{Label: "Checkout", Builtin: "checkout"},
 		}
 	case context.IssuesView:
-		buttons = append(buttons, actionButton{Label: "Comment", Builtin: "comment"})
+		buttons = append(buttons,
+			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Milestone", Builtin: "setMilestone"},
+		)
 		switch rowState(row) {
 		case "closed":
 			buttons = append(buttons, actionButton{Label: "Reopen", Builtin: "reopen"})
@@ -1420,6 +1429,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindAddLabel), true
 	case "removelabel":
 		return m, m.startAction(actions.KindRemoveLabel), true
+	case "milestone", "setmilestone":
+		return m, m.startAction(actions.KindSetMilestone), true
 	case "merge":
 		return m, m.startAction(actions.KindMerge), true
 	case "update", "updatebranch":
@@ -1547,6 +1558,10 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindPullRequest && target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for pull requests and issues.", actionLabel(kind))
 		}
+	case actions.KindSetMilestone:
+		if target.RowKind != actions.RowKindIssue {
+			return fmt.Errorf("%s is only available for issues.", actionLabel(kind))
+		}
 	case actions.KindRerunRun, actions.KindCancelRun:
 		if target.RowKind != actions.RowKindActionRun {
 			return fmt.Errorf("%s is only available for action runs.", actionLabel(kind))
@@ -1565,7 +1580,7 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 	switch kind {
 	case actions.KindComment:
 		return actions.PromptText
-	case actions.KindAddLabel, actions.KindRemoveLabel:
+	case actions.KindAddLabel, actions.KindRemoveLabel, actions.KindSetMilestone:
 		return actions.PromptText
 	case actions.KindMerge, actions.KindReview:
 		return actions.PromptPicker
@@ -1601,6 +1616,13 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 			Title:       title,
 			Message:     message,
 			Placeholder: "Label names to remove, comma-separated",
+		}
+	case actions.KindSetMilestone:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Milestone title",
 		}
 	case actions.KindReview:
 		return actionprompt.Config{
@@ -1653,6 +1675,8 @@ func actionLabel(kind actions.Kind) string {
 		return "Add label"
 	case actions.KindRemoveLabel:
 		return "Remove label"
+	case actions.KindSetMilestone:
+		return "Set milestone"
 	case actions.KindMerge:
 		return "Merge"
 	case actions.KindUpdateBranch:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1561,6 +1561,65 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 	}
 }
 
+func TestIssueMilestoneKeyDispatchesExpectedIntent(t *testing.T) {
+	var got []actions.Intent
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+		got = append(got, intent)
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 42, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/issues/42",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'M', Text: "M"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("'M' in Issues should open a milestone prompt")
+	}
+	for _, key := range []tea.KeyPressMsg{{Code: 'v', Text: "v"}, {Code: '1', Text: "1"}} {
+		m = update(t, m, key)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if len(got) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(got))
+	}
+	wantTarget := actions.Target{
+		SectionID:   0,
+		SectionType: issuesection.SectionType,
+		RowKind:     actions.RowKindIssue,
+		Repo:        "gbarany/tea-dash",
+		Number:      42,
+		Title:       "Issue row",
+		URL:         "https://example.test/gbarany/tea-dash/issues/42",
+		Author:      "me",
+	}
+	if got[0].Kind != actions.KindSetMilestone || got[0].Target != wantTarget ||
+		got[0].Prompt.Mode != actions.PromptText || got[0].Prompt.Value != "v1" {
+		t.Fatalf("intent = %+v, want set-milestone target %+v value v1", got[0], wantTarget)
+	}
+}
+
+func TestIssueActionButtonsIncludeMilestone(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedIssuesMsg([]data.Issue{{
+		Number: 42, Title: "Issue row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/issues/42",
+	}}))
+
+	found := false
+	for _, b := range m.actionButtons() {
+		if b.Label == "Milestone" && b.Builtin == "setMilestone" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("milestone action button not found in %+v", m.actionButtons())
+	}
+}
+
 func TestBranchSwitchHotkeysDispatchExpectedIntent(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -29,6 +29,7 @@ type keyMap struct {
 	Unassign      key.Binding
 	AddLabel      key.Binding
 	RemoveLabel   key.Binding
+	Milestone     key.Binding
 	Merge         key.Binding
 	UpdateBranch  key.Binding
 	MarkReady     key.Binding
@@ -120,6 +121,10 @@ func defaultKeyMap() keyMap {
 		RemoveLabel: key.NewBinding(
 			key.WithKeys("U"),
 			key.WithHelp("U", "remove label"),
+		),
+		Milestone: key.NewBinding(
+			key.WithKeys("M"),
+			key.WithHelp("M", "milestone"),
 		),
 		Merge: key.NewBinding(
 			key.WithKeys("m"),
@@ -242,6 +247,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.AddLabel = binding(keyName, "add label")
 	case "removelabel":
 		k.RemoveLabel = binding(keyName, "remove label")
+	case "milestone", "setmilestone":
+		k.Milestone = binding(keyName, "milestone")
 	case "merge":
 		k.Merge = binding(keyName, "merge")
 	case "update", "updatebranch":


### PR DESCRIPTION
## Summary

- add issue-only milestone assignment from the TUI with the default `M` shortcut and a clickable `[Milestone]` action button
- resolve milestone titles to Gitea milestone IDs before patching the issue
- expose `setMilestone` / `milestone` as issue-scoped keybinding builtins

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui/actions ./internal/gitea ./internal/actionrunner ./internal/config ./internal/ui -run 'TestKindConstants|TestSetIssueMilestone|TestDispatchSet.*Milestone|TestUnmarshalKeybindings|TestIssueMilestoneKey|TestIssueActionButtonsIncludeMilestone'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`
