### PR TITLE
Discover repo-local config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ make build      # -> ./bin/tea-dash
 
 ```sh
 tea-dash            # start the dashboard
+tea-dash --config ./team.tea-dash.yml
 tea-dash --version  # print version info
 tea-dash --help
 ```
@@ -105,9 +106,15 @@ tea-dash --help
 
 ## Configuration
 
-Optional. Create `~/.config/tea-dash/config.yml`
-(`$XDG_CONFIG_HOME/tea-dash/config.yml`) to pick a tea login, choose the startup
-view, and define your own sections:
+Optional. tea-dash reads the first config it finds in this order:
+
+1. `--config <path>` / `-c <path>`
+2. `TEA_DASH_CONFIG`
+3. `.tea-dash.yml` or `.tea-dash.yaml` in the current git repository root
+4. `$XDG_CONFIG_HOME/tea-dash/config.yml`
+
+Use config to pick a tea login, choose the startup view, and define your own
+sections:
 
 ```yaml
 instance:
@@ -290,7 +297,7 @@ internal/gitea/         Gitea Go SDK client wrapper + PR/issue/notification APIs
 internal/git/           read-only local git branch status
 internal/auth/          resolves instance URL + token from the tea config
 internal/data/          TUI-agnostic domain models
-internal/config/        ~/.config/tea-dash/config.yml loading
+internal/config/        config discovery + YAML loading
 internal/build/         version metadata (set via -ldflags)
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -492,7 +492,9 @@ func (c *Config) ParsedRepos() ([]Repo, error) {
 	return repos, nil
 }
 
-// Path returns the config file path:
+const envConfigPath = "TEA_DASH_CONFIG"
+
+// Path returns the default config file path:
 // $XDG_CONFIG_HOME/tea-dash/config.yml (falling back to ~/.config).
 func Path() (string, error) {
 	dir := os.Getenv("XDG_CONFIG_HOME")
@@ -506,10 +508,63 @@ func Path() (string, error) {
 	return filepath.Join(dir, "tea-dash", "config.yml"), nil
 }
 
+// ResolvePath returns the config path tea-dash should read, following the same
+// precedence as the CLI:
+//
+//	explicit path -> TEA_DASH_CONFIG -> repo-root .tea-dash.yml/.tea-dash.yaml -> XDG default
+func ResolvePath(explicit string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return ResolvePathFrom(explicit, cwd)
+}
+
+// ResolvePathFrom is ResolvePath with an injected cwd for tests.
+func ResolvePathFrom(explicit, cwd string) (string, error) {
+	if p := strings.TrimSpace(explicit); p != "" {
+		return ExpandPath(p)
+	}
+	if p := strings.TrimSpace(os.Getenv(envConfigPath)); p != "" {
+		return ExpandPath(p)
+	}
+	if p, ok := findRepoConfig(cwd); ok {
+		return p, nil
+	}
+	return Path()
+}
+
+func findRepoConfig(cwd string) (string, bool) {
+	dir, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", false
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			for _, name := range []string{".tea-dash.yml", ".tea-dash.yaml"} {
+				p := filepath.Join(dir, name)
+				if _, err := os.Stat(p); err == nil {
+					return p, true
+				}
+			}
+			return "", false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
 // Load reads the config file. A missing file is not an error: it returns an
 // empty Config so tea-dash can fall back to the repository in $PWD.
-func Load() (*Config, error) {
-	path, err := Path()
+func Load(configPath ...string) (*Config, error) {
+	explicit := ""
+	if len(configPath) > 0 {
+		explicit = configPath[0]
+	}
+	path, err := ResolvePath(explicit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -499,3 +499,111 @@ func TestLoadMalformedFileErrors(t *testing.T) {
 		t.Fatal("expected a parse error for malformed config YAML")
 	}
 }
+
+func TestResolvePathExplicitWins(t *testing.T) {
+	t.Setenv("TEA_DASH_CONFIG", filepath.Join(t.TempDir(), "env.yml"))
+	explicit := filepath.Join(t.TempDir(), "explicit.yml")
+
+	got, err := ResolvePathFrom(explicit, t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolvePathFrom: %v", err)
+	}
+	if got != explicit {
+		t.Fatalf("ResolvePathFrom explicit = %q, want %q", got, explicit)
+	}
+}
+
+func TestResolvePathUsesEnv(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), "env.yml")
+	t.Setenv("TEA_DASH_CONFIG", envPath)
+
+	got, err := ResolvePathFrom("", t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolvePathFrom: %v", err)
+	}
+	if got != envPath {
+		t.Fatalf("ResolvePathFrom env = %q, want %q", got, envPath)
+	}
+}
+
+func TestResolvePathFindsRepoRootConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: /tmp/worktree\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(repo, ".tea-dash.yml")
+	if err := os.WriteFile(want, []byte("defaults:\n  view: issues\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(repo, "nested", "pkg")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolvePathFrom("", cwd)
+	if err != nil {
+		t.Fatalf("ResolvePathFrom: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolvePathFrom repo config = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePathFindsRepoRootYamlFallback(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(repo, ".tea-dash.yaml")
+	if err := os.WriteFile(want, []byte("defaults:\n  view: branches\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolvePathFrom("", repo)
+	if err != nil {
+		t.Fatalf("ResolvePathFrom: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolvePathFrom repo config = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePathFallsBackToXDGConfig(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	cwd := t.TempDir()
+
+	got, err := ResolvePathFrom("", cwd)
+	if err != nil {
+		t.Fatalf("ResolvePathFrom: %v", err)
+	}
+	want := filepath.Join(configHome, "tea-dash", "config.yml")
+	if got != want {
+		t.Fatalf("ResolvePathFrom default = %q, want %q", got, want)
+	}
+}
+
+func TestLoadUsesRepoRootConfig(t *testing.T) {
+	t.Setenv("TEA_DASH_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".tea-dash.yml"), []byte("defaults:\n  view: issues\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(repo, "nested")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Defaults.View != "issues" {
+		t.Fatalf("Defaults.View = %q, want issues from repo-local config", cfg.Defaults.View)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -19,25 +20,63 @@ import (
 )
 
 func main() {
-	for _, arg := range os.Args[1:] {
-		switch arg {
-		case "-v", "--version", "version":
-			fmt.Println("tea-dash", build.String())
-			return
-		case "-h", "--help", "help":
-			fmt.Println(usage)
-			return
-		}
+	opts, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "tea-dash:", err)
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(2)
+	}
+	if opts.showVersion {
+		fmt.Println("tea-dash", build.String())
+		return
+	}
+	if opts.showHelp {
+		fmt.Println(usage)
+		return
 	}
 
-	if err := run(); err != nil {
+	if err := run(opts); err != nil {
 		fmt.Fprintln(os.Stderr, "tea-dash:", err)
 		os.Exit(1)
 	}
 }
 
-func run() error {
-	cfg, err := config.Load()
+type cliOptions struct {
+	configPath  string
+	showVersion bool
+	showHelp    bool
+}
+
+func parseArgs(args []string) (cliOptions, error) {
+	var opts cliOptions
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-v" || arg == "--version" || arg == "version":
+			opts.showVersion = true
+		case arg == "-h" || arg == "--help" || arg == "help":
+			opts.showHelp = true
+		case arg == "-c" || arg == "--config":
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
+				return cliOptions{}, fmt.Errorf("%s requires a path", arg)
+			}
+			i++
+			opts.configPath = args[i]
+		case strings.HasPrefix(arg, "--config="):
+			path := strings.TrimSpace(strings.TrimPrefix(arg, "--config="))
+			if path == "" {
+				return cliOptions{}, fmt.Errorf("--config requires a path")
+			}
+			opts.configPath = path
+		default:
+			return cliOptions{}, fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+	return opts, nil
+}
+
+func run(opts cliOptions) error {
+	cfg, err := config.Load(opts.configPath)
 	if err != nil {
 		return err
 	}
@@ -119,9 +158,11 @@ func expandHome(path string) string {
 const usage = `tea-dash — a terminal dashboard for Gitea
 
 Usage:
-  tea-dash            start the dashboard (your open pull requests)
-  tea-dash --version  print version information
-  tea-dash --help     show this help
+  tea-dash                 start the dashboard
+  tea-dash --config <path> use a specific config file
+  tea-dash --version       print version information
+  tea-dash --help          show this help
 
-tea-dash reuses your ` + "`tea`" + ` login (run ` + "`tea login add`" + ` once), or set
-instance.url + instance.token in ~/.config/tea-dash/config.yml.`
+Config lookup order:
+  --config/-c, TEA_DASH_CONFIG, repo-local .tea-dash.yml/.tea-dash.yaml,
+  then $XDG_CONFIG_HOME/tea-dash/config.yml.`

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,52 @@ func TestLaunchOptionsHonorsSmartFilteringDisabled(t *testing.T) {
 	}
 }
 
+func TestParseArgsConfigLongFlag(t *testing.T) {
+	opts, err := parseArgs([]string{"--config", "custom.yml"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if opts.configPath != "custom.yml" {
+		t.Fatalf("configPath = %q, want custom.yml", opts.configPath)
+	}
+}
+
+func TestParseArgsConfigEqualsFlag(t *testing.T) {
+	opts, err := parseArgs([]string{"--config=custom.yml"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if opts.configPath != "custom.yml" {
+		t.Fatalf("configPath = %q, want custom.yml", opts.configPath)
+	}
+}
+
+func TestParseArgsConfigShortFlag(t *testing.T) {
+	opts, err := parseArgs([]string{"-c", "custom.yml"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if opts.configPath != "custom.yml" {
+		t.Fatalf("configPath = %q, want custom.yml", opts.configPath)
+	}
+}
+
+func TestParseArgsMissingConfigValueErrors(t *testing.T) {
+	if _, err := parseArgs([]string{"--config"}); err == nil {
+		t.Fatal("parseArgs should reject --config without a value")
+	}
+}
+
+func TestParseArgsVersion(t *testing.T) {
+	opts, err := parseArgs([]string{"--version"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if !opts.showVersion {
+		t.Fatal("showVersion should be true")
+	}
+}
+
 func makeGitDir(t *testing.T, remoteName, remoteURL string) string {
 	t.Helper()
 	cwd := t.TempDir()
@@ -39,7 +85,7 @@ func makeGitDir(t *testing.T, remoteName, remoteURL string) string {
 		t.Fatal(err)
 	}
 	cfg := `[remote "` + remoteName + `"]
-	url = ` + remoteURL + `
+url = ` + remoteURL + `
 `
 	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(cfg), 0o600); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- add --config/-c and TEA_DASH_CONFIG support
- discover .tea-dash.yml/.tea-dash.yaml from the current git repository root
- document config lookup order and preserve XDG fallback

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build
- tmux main:9.2 live launch smoke