### PR TITLE
Add validated example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Optional. tea-dash reads the first config it finds in this order:
 4. `$XDG_CONFIG_HOME/tea-dash/config.yml`
 
 Use config to pick a tea login, choose the startup view, and define your own
-sections:
+sections. A fuller copyable example lives at
+[`examples/tea-dash.yml`](examples/tea-dash.yml).
 
 ```yaml
 instance:

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -1,0 +1,122 @@
+# tea-dash example configuration.
+#
+# Copy this to one of tea-dash's config locations and adjust the repo names,
+# local checkout paths, and login name for your environment.
+
+instance:
+  # Empty means "use the default tea login". Set this to a named tea login when
+  # you have multiple Gitea/Forgejo instances configured.
+  login: ""
+  # Prefer tokenEnv or tokenCommand over a literal token in this file.
+  tokenEnv: TEA_DASH_TOKEN
+
+defaults:
+  view: prs
+  prsLimit: 50
+  issuesLimit: 50
+  notificationsLimit: 50
+  actionsLimit: 25
+  branchesLimit: 0
+
+repos:
+  - acme/widgets
+  - acme/api
+
+localRepos:
+  - name: widgets
+    path: ~/src/acme/widgets
+  - name: api
+    path: ~/src/acme/api
+
+pager:
+  diff: diffnav
+
+repoPaths:
+  "acme/*": "~/src/acme/{{.Repo}}"
+
+git:
+  remote: origin
+  prBranchTemplate: "pr-{{.Owner}}-{{.Repo}}-{{.PrIndex}}"
+
+prSections:
+  - title: Open PRs
+    filter:
+      state: open
+      createdBy: "@me"
+  - title: Closed PRs
+    filter:
+      state: closed
+      createdBy: "@me"
+  - title: Needs My Review
+    filter:
+      state: open
+      reviewRequested: "@me"
+  - title: Alice in Widgets
+    repo: acme/widgets
+    filter:
+      state: open
+      createdBy: alice
+
+issuesSections:
+  - title: Assigned Issues
+    filter:
+      state: open
+      assignedBy: "@me"
+      labels: [bug]
+  - title: Widget Bugs
+    repo: acme/widgets
+    filter:
+      state: open
+      createdBy: alice
+      labels: [bug, urgent]
+      milestone: v2
+
+notificationsSections:
+  - title: Inbox
+    limit: 50
+
+actionsSections:
+  - title: Widget CI
+    repo: acme/widgets
+    limit: 25
+    filter:
+      branch: main
+
+branchSections:
+  - title: Local Branches
+
+keybindings:
+  universal:
+    - key: tab
+      builtin: nextSection
+    - key: H
+      builtin: help
+  prs:
+    - key: O
+      builtin: checkout
+    - key: a
+      builtin: assign
+    - key: A
+      builtin: unassign
+    - key: L
+      builtin: addLabel
+    - key: U
+      builtin: removeLabel
+  issues:
+    - key: a
+      builtin: assign
+    - key: A
+      builtin: unassign
+    - key: L
+      builtin: addLabel
+    - key: U
+      builtin: removeLabel
+  notifications:
+    - key: D
+      builtin: markAllRead
+  actions:
+    - key: R
+      builtin: rerun
+  branches:
+    - key: enter
+      builtin: checkout

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -678,3 +678,24 @@ func TestLoadUsesRepoRootConfig(t *testing.T) {
 		t.Fatalf("Defaults.View = %q, want issues from repo-local config", cfg.Defaults.View)
 	}
 }
+
+func TestExampleConfigParsesAndValidates(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "examples", "tea-dash.yml"))
+	if err != nil {
+		t.Fatalf("read example config: %v", err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal example config: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("example config should validate: %v", err)
+	}
+	if cfg.Instance.TokenEnv != "TEA_DASH_TOKEN" {
+		t.Fatalf("example should prefer tokenEnv over literal secrets, got %+v", cfg.Instance)
+	}
+	if len(cfg.PRSections) == 0 || len(cfg.IssuesSections) == 0 || len(cfg.NotificationsSections) == 0 ||
+		len(cfg.ActionsSections) == 0 || len(cfg.BranchSections) == 0 {
+		t.Fatalf("example should cover all top-level views: %+v", cfg)
+	}
+}


### PR DESCRIPTION
## Summary
- add examples/tea-dash.yml as a public-safe, copyable config covering all current views
- add a config test that parses and validates the example so docs cannot drift silently
- link the example from the README

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config -run TestExampleConfigParsesAndValidates -v
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build