### PR TITLE
Fan out repo sections and fix external diff launch

### DIFF
--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -133,6 +133,9 @@ func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
 	if intent.Kind == uiactions.KindCustomCommand {
 		return r.dispatchCustomCommand(intent)
 	}
+	if intent.Kind == uiactions.KindExternalDiff {
+		return r.dispatchExternalDiff(intent)
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
@@ -142,6 +145,34 @@ func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
 			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
 		}
 		return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultSucceeded, Message: message}
+	}
+}
+
+func (r Runner) dispatchExternalDiff(intent uiactions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		if r.client == nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))}
+		}
+		owner, repo, err := splitRepo(intent.Target.Repo)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		diff, err := r.client.GetPullDiff(owner, repo, intent.Target.Number)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		command := r.cfg.Pager.DiffCommand()
+		cmd := shell.BuildExecCommand(command, diff, r.cwd)
+		return r.execProcess(cmd, func(err error) tea.Msg {
+			if err != nil {
+				return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("run diff pager %q: %w", command, err)}
+			}
+			return uiactions.ResultMsg{
+				Intent:  intent,
+				Status:  uiactions.ResultSucceeded,
+				Message: fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, intent.Target.Number),
+			}
+		})()
 	}
 }
 
@@ -327,23 +358,6 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 			return fmt.Sprintf("%s#%d is already draft.", intent.Target.Repo, index), nil
 		}
 		return fmt.Sprintf("Marked %s#%d draft.", intent.Target.Repo, index), nil
-
-	case uiactions.KindExternalDiff:
-		diff, err := r.client.GetPullDiff(owner, repo, index)
-		if err != nil {
-			return "", err
-		}
-		command := r.cfg.Pager.DiffCommand()
-		cmd := shell.BuildCommand(command, diff, r.cwd)
-		out, err := r.shellRunner.Run(ctx, cmd)
-		if err != nil {
-			msg := strings.TrimSpace(string(out))
-			if msg != "" {
-				return "", fmt.Errorf("run diff pager %q: %w: %s", command, err, msg)
-			}
-			return "", fmt.Errorf("run diff pager %q: %w", command, err)
-		}
-		return fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, index), nil
 
 	case uiactions.KindCheckout:
 		switch intent.Target.RowKind {

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -3,6 +3,7 @@ package actionrunner
 import (
 	"context"
 	"errors"
+	"io"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -329,26 +330,30 @@ func TestDispatchMarkPullDraft(t *testing.T) {
 
 func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
 	client := &fakeClient{diff: []byte("diff --git a/a b/a\n+hello\n")}
-	shellRunner := &fakeShellRunner{}
+	execProcess := &fakeExecProcess{}
 	r := New(Options{
 		Client:      client,
 		Config:      &config.Config{Pager: config.Pager{Diff: "diffnav"}},
 		CWD:         "/tmp/repo",
-		ShellRunner: shellRunner,
+		ExecProcess: execProcess.Run,
 	})
 
 	got := runDispatch(t, r, pullIntent(uiactions.KindExternalDiff))
 	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
 		t.Fatalf("diff result = %+v", got)
 	}
-	if shellRunner.command.Name == "" {
-		t.Fatal("shell runner was not called")
+	if execProcess.cmd == nil {
+		t.Fatal("exec process was not called")
 	}
-	if !reflect.DeepEqual(shellRunner.command.Args, []string{"-c", "diffnav"}) {
-		t.Fatalf("shell args = %#v, want shell -c diffnav", shellRunner.command.Args)
+	if !reflect.DeepEqual(execProcess.cmd.Args[1:], []string{"-c", "diffnav"}) {
+		t.Fatalf("shell args = %#v, want shell -c diffnav", execProcess.cmd.Args)
 	}
-	if string(shellRunner.command.Stdin) != string(client.diff) || shellRunner.command.Dir != "/tmp/repo" {
-		t.Fatalf("shell command = %+v", shellRunner.command)
+	stdin, err := io.ReadAll(execProcess.cmd.Stdin)
+	if err != nil {
+		t.Fatalf("read pager stdin: %v", err)
+	}
+	if string(stdin) != string(client.diff) || execProcess.cmd.Dir != "/tmp/repo" {
+		t.Fatalf("exec command stdin=%q dir=%q, want diff bytes in /tmp/repo", string(stdin), execProcess.cmd.Dir)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1739,7 +1739,10 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 }
 
 func actionDispatchesDirectly(kind actions.Kind) bool {
-	return kind == actions.KindRerunRun || kind == actions.KindSubscribe || kind == actions.KindUnsubscribe
+	return kind == actions.KindRerunRun ||
+		kind == actions.KindSubscribe ||
+		kind == actions.KindUnsubscribe ||
+		kind == actions.KindExternalDiff
 }
 
 func promptModeForAction(kind actions.Kind) actions.PromptMode {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1748,8 +1748,6 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "update branch", key: tea.KeyPressMsg{Code: 'u', Text: "u"}, kind: actions.KindUpdateBranch},
 		{name: "mark ready", key: tea.KeyPressMsg{Code: 'W', Text: "W"}, kind: actions.KindMarkReady},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
-		{name: "external diff", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindExternalDiff},
-		{name: "external diff ctrl-t alias", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, kind: actions.KindExternalDiff},
 		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
 		{name: "checkout space alias", key: tea.KeyPressMsg{Code: ' ', Text: " "}, kind: actions.KindCheckout},
 	}
@@ -1984,6 +1982,54 @@ func TestIssueHelpShowsIssueActionsOnly(t *testing.T) {
 		if strings.Contains(help, bad) {
 			t.Fatalf("issue help = %q, should not advertise PR-only action %q", help, bad)
 		}
+	}
+}
+
+func TestExternalDiffHotkeysDispatchDirectly(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{name: "d", key: tea.KeyPressMsg{Code: 'd', Text: "d"}},
+		{name: "ctrl-t", key: tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, fetchedMsg([]data.PullRequest{{
+				Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+				Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+			}}))
+
+			m = update(t, m, tt.key)
+
+			if m.actionPrompt.Active() {
+				t.Fatalf("%s should dispatch the external diff directly, not open a confirmation prompt", tt.name)
+			}
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:   0,
+				SectionType: pullsection.SectionType,
+				RowKind:     actions.RowKindPullRequest,
+				Repo:        "gbarany/tea-dash",
+				Number:      42,
+				Title:       "Action row",
+				URL:         "https://example.test/gbarany/tea-dash/pulls/42",
+				Author:      "me",
+			}
+			if got[0].Kind != actions.KindExternalDiff || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want external diff target %+v", got[0], wantTarget)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fan out PR and issue section searches across configured repos.
- Make external diff open immediately on d/ctrl+t instead of requiring a confirmation prompt.
- Run the diff pager through Bubble Tea ExecProcess so full-screen pagers can take over the terminal.

## Test Plan
- GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui ./internal/actionrunner -run 'TestExternalDiffHotkeysDispatchDirectly|TestDispatchExternalDiffRunsConfiguredPager' -v
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build