### PR TITLE
Support redraw keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ keybindings:
   universal:
     - key: tab
       builtin: nextSection
+    - key: ctrl+l
+      builtin: redraw
     - key: H
       builtin: help
   prs:
@@ -280,6 +282,8 @@ and exactly one of `builtin` or `command`. Built-ins remap implemented tea-dash
 actions; commands run through your shell with row template fields such as
 `RepoName`, `RepoPath`, `PrIndex`/`PrNumber`, `IssueIndex`/`IssueNumber`,
 `RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `Url`/`URL`.
+The universal `redraw` builtin asks Bubble Tea to clear and repaint the screen,
+which is useful if a terminal leaves visual artifacts.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` on cross-repo sections.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -393,7 +393,7 @@ var universalBuiltins = builtinSet(
 	"toggleSmartFiltering", "toggleSmartFilter", "currentRepo",
 	"pageUp", "pageDown", "scrollUp", "scrollDown", "prevSection",
 	"previousSection", "nextSection", "switchView", "copyurl", "copyNumber",
-	"help", "quit", "expand", "summaryViewMore",
+	"help", "quit", "redraw", "expand", "summaryViewMore",
 )
 
 var prBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,6 +354,7 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 
 	ok := Config{Keybindings: Keybindings{Universal: []Keybinding{
 		{Key: "R", Builtin: "refreshAll"},
+		{Key: "ctrl+l", Builtin: "redraw"},
 		{Key: "t", Builtin: "toggleSmartFiltering"},
 		{Key: "g", Command: "lazygit"},
 	}, PRs: []Keybinding{

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1394,6 +1394,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.openSelected(), true
 	case "quit":
 		return m, tea.Quit, true
+	case "redraw":
+		return m, tea.ClearScreen, true
 	case "nextsection":
 		if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 			m.currSectionId++

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2004,6 +2004,24 @@ func TestConfigKeybindingRebindsBuiltin(t *testing.T) {
 	}
 }
 
+func TestRedrawBuiltinClearsScreen(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	next, cmd, handled := m.handleBuiltinKeybinding(config.Keybinding{Builtin: "redraw"})
+	if !handled {
+		t.Fatal("redraw builtin should be handled")
+	}
+	if cmd == nil {
+		t.Fatal("redraw builtin should return a command")
+	}
+	msg := cmd()
+	if got, want := fmt.Sprintf("%T", msg), fmt.Sprintf("%T", tea.ClearScreen()); got != want {
+		t.Fatalf("redraw command returned %T, want %T", msg, tea.ClearScreen())
+	}
+	if next.notice != "" {
+		t.Fatalf("redraw should not set a notice, got %q", next.notice)
+	}
+}
+
 func TestConfigCustomKeybindingDispatchesSelectedRowCommand(t *testing.T) {
 	cfg := &config.Config{
 		RepoPaths: map[string]string{"gbarany/tea-dash": "/src/tea-dash"},


### PR DESCRIPTION
## Summary
- Add a gh-dash-compatible universal `redraw` builtin for custom keybindings.
- Validate `redraw` in universal keybinding config and dispatch it to Bubble Tea screen clearing.
- Document a `ctrl+l` redraw binding in the README example.

## Test Plan
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`