### PR TITLE
Support first and last row keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ keybindings:
       builtin: nextSection
     - key: ctrl+l
       builtin: redraw
+    - key: g
+      builtin: firstLine
+    - key: G
+      builtin: lastLine
     - key: H
       builtin: help
   prs:
@@ -303,6 +307,8 @@ actions; commands run through your shell with row template fields such as
 `RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `Url`/`URL`.
 The universal `redraw` builtin asks Bubble Tea to clear and repaint the screen,
 which is useful if a terminal leaves visual artifacts.
+The universal `firstLine` and `lastLine` builtins jump to the first and last
+currently loaded row, matching gh-dash's `g`/`G` navigation behavior.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` on cross-repo sections.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -417,6 +417,7 @@ func (k Keybindings) Validate() error {
 var universalBuiltins = builtinSet(
 	"refresh", "refreshAll", "openGithub", "open", "search", "togglePreview",
 	"toggleSmartFiltering", "toggleSmartFilter", "currentRepo",
+	"firstLine", "lastLine",
 	"pageUp", "pageDown", "scrollUp", "scrollDown", "prevSection",
 	"previousSection", "nextSection", "switchView", "copyurl", "copyNumber",
 	"help", "quit", "redraw", "expand", "summaryViewMore",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -369,7 +369,9 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "R", Builtin: "refreshAll"},
 		{Key: "ctrl+l", Builtin: "redraw"},
 		{Key: "t", Builtin: "toggleSmartFiltering"},
-		{Key: "g", Command: "lazygit"},
+		{Key: "g", Builtin: "firstLine"},
+		{Key: "G", Builtin: "lastLine"},
+		{Key: "z", Command: "lazygit"},
 	}, PRs: []Keybinding{
 		{Key: "a", Builtin: "assign"},
 		{Key: "L", Builtin: "addLabel"},

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1240,7 +1240,14 @@ func (m Model) selectRowFromMouse(x, y int) (Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	return m.selectCurrentSectionRow(i)
+}
+
+func (m Model) selectCurrentSectionRow(i int) (Model, tea.Cmd) {
 	s := m.getCurrSection()
+	if s == nil || s.GetIsLoading() || s.GetError() != nil || s.NumRows() == 0 {
+		return m, nil
+	}
 	before := m.selKey()
 	s.SelectRow(i)
 	moreCmd := s.MaybeFetchNextPage()
@@ -1494,6 +1501,15 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, tea.Quit, true
 	case "redraw":
 		return m, tea.ClearScreen, true
+	case "firstline":
+		next, cmd := m.selectCurrentSectionRow(0)
+		return next, cmd, true
+	case "lastline":
+		if s := m.getCurrSection(); s != nil {
+			next, cmd := m.selectCurrentSectionRow(s.NumRows() - 1)
+			return next, cmd, true
+		}
+		return m, nil, true
 	case "nextsection":
 		if last := len(m.currentViewSections()) - 1; m.currSectionId < last {
 			m.currSectionId++

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2538,6 +2538,30 @@ func TestGHDashFirstLastHotkeysMoveSelection(t *testing.T) {
 	}
 }
 
+func TestConfiguredFirstLastBuiltinsMoveSelection(t *testing.T) {
+	m := New(&config.Config{
+		Keybindings: config.Keybindings{Universal: []config.Keybinding{
+			{Key: "F", Builtin: "firstLine"},
+			{Key: "L", Builtin: "lastLine"},
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Middle row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 3, Title: "Last row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'L', Text: "L"})
+	if got := m.getCurrRowData().GetNumber(); got != 3 {
+		t.Fatalf("lastLine selected #%d, want #3", got)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'F', Text: "F"})
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("firstLine selected #%d, want #1", got)
+	}
+}
+
 func TestInvalidActionOnIssueShowsNotice(t *testing.T) {
 	var dispatched bool
 	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)


### PR DESCRIPTION
## Summary
- Add gh-dash-compatible universal `firstLine` and `lastLine` builtins.
- Route those builtins through the same row-selection path used by mouse clicks, preserving preview refresh and progressive page loading.
- Document `g`/`G` first/last-row keybinding examples in the README.

## Test Plan
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`