### PR TITLE
Support scoped view-switch keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ keybindings:
     - key: H
       builtin: help
   prs:
+    - key: I
+      builtin: viewIssues
     - key: O
       builtin: checkout
     - key: a
@@ -248,6 +250,8 @@ keybindings:
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
   issues:
+    - key: P
+      builtin: viewPrs
     - key: C
       builtin: checkout
     - key: a
@@ -309,6 +313,9 @@ The universal `redraw` builtin asks Bubble Tea to clear and repaint the screen,
 which is useful if a terminal leaves visual artifacts.
 The universal `firstLine` and `lastLine` builtins jump to the first and last
 currently loaded row, matching gh-dash's `g`/`G` navigation behavior.
+Scoped `viewIssues` and `viewPrs` built-ins jump directly between the PRs and
+Issues views, while the universal `switchView` cycles through every top-level
+view.
 
 > **Note:** the me-scoped author fields (`createdBy`, `assignedBy`, `mentioned`,
 > `reviewRequested`) support the sentinel `"@me"` on cross-repo sections.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -427,12 +427,13 @@ var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
 	"update", "updateBranch", "ready", "markReady", "draft", "markDraft",
 	"watch", "watchChecks", "checks", "close", "reopen", "diff", "checkout", "approve", "review",
-	"summaryViewMore", "expand",
+	"viewIssues", "summaryViewMore", "expand",
 )
 
 var issueBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
 	"milestone", "setMilestone", "checkout", "subscribe", "unsubscribe",
+	"milestone", "setMilestone", "checkout", "subscribe", "unsubscribe", "viewPrs",
 )
 
 var notificationBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -379,7 +379,9 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "W", Builtin: "ready"},
 		{Key: "D", Builtin: "draft"},
 		{Key: "w", Builtin: "watchChecks"},
+		{Key: "i", Builtin: "viewIssues"},
 	}, Issues: []Keybinding{
+		{Key: "p", Builtin: "viewPrs"},
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},
 	}}}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1144,18 +1144,27 @@ func (m Model) switchToPullChecks(row data.PullRequest, branch, sha string) (Mod
 // switchView cycles pulls -> issues -> notifications -> actions -> branches, lazily
 // building and fetching the target view's sections on first visit.
 func (m *Model) switchView() tea.Cmd {
+	var next context.ViewType
 	switch m.ctx.View {
 	case context.PullsView:
-		m.ctx.View = context.IssuesView
+		next = context.IssuesView
 	case context.IssuesView:
-		m.ctx.View = context.NotificationsView
+		next = context.NotificationsView
 	case context.NotificationsView:
-		m.ctx.View = context.ActionsView
+		next = context.ActionsView
 	case context.ActionsView:
-		m.ctx.View = context.BranchesView
+		next = context.BranchesView
 	default:
-		m.ctx.View = context.PullsView
+		next = context.PullsView
 	}
+	return m.switchToView(next)
+}
+
+func (m *Model) switchToView(view context.ViewType) tea.Cmd {
+	if m.ctx.View == view {
+		return nil
+	}
+	m.ctx.View = view
 	m.syncMainContentDimensions()
 	var cmds []tea.Cmd
 	s := m.currentViewSections()
@@ -1530,7 +1539,11 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 			return m, m.enrichCurrRow(), true
 		}
 		return m, nil, true
-	case "viewissues", "viewprs", "switchview":
+	case "viewissues":
+		return m, m.switchToView(context.IssuesView), true
+	case "viewprs":
+		return m, m.switchToView(context.PullsView), true
+	case "switchview":
 		return m, m.switchView(), true
 	case "search":
 		if s := m.getCurrSection(); s != nil {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -698,6 +698,31 @@ func TestSwitchViewCyclesToActionsBranchesAndBackToPulls(t *testing.T) {
 	}
 }
 
+func TestScopedViewSwitchBuiltinsJumpBetweenPullsAndIssues(t *testing.T) {
+	cfg := &config.Config{
+		Keybindings: config.Keybindings{
+			PRs:    []config.Keybinding{{Key: "i", Builtin: "viewIssues"}},
+			Issues: []config.Keybinding{{Key: "p", Builtin: "viewPrs"}},
+		},
+	}
+	m := New(cfg, nil)
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	m = next.(Model)
+	if m.ctx.View != context.IssuesView {
+		t.Fatalf("viewIssues builtin switched to %v, want IssuesView", m.ctx.View)
+	}
+	if cmd == nil {
+		t.Fatal("viewIssues should fetch issues on first visit")
+	}
+
+	next, _ = m.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	m = next.(Model)
+	if m.ctx.View != context.PullsView {
+		t.Fatalf("viewPrs builtin switched to %v, want PullsView", m.ctx.View)
+	}
+}
+
 func TestSectionSwitchWithTwoSections(t *testing.T) {
 	cfg := &config.Config{
 		PRSections: []config.SectionConfig{


### PR DESCRIPTION
## Summary
- Accept gh-dash-compatible `viewIssues` in PR keybindings and `viewPrs` in issue keybindings.
- Make those scoped builtins jump directly between PRs and Issues instead of using the full top-level view cycle.
- Document the scoped view-switch bindings in the README example.

## Test Plan
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`