### PR TITLE
Expose PR refs to custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ configured repository.
 and exactly one of `builtin` or `command`. Built-ins remap implemented tea-dash
 actions; commands run through your shell with row template fields such as
 `RepoName`, `RepoPath`, `PrIndex`/`PrNumber`, `IssueIndex`/`IssueNumber`,
-`RunID`, `Title`, `Author`, `Sha`, `InstanceURL`, and `Url`/`URL`.
+`RunID`, `Title`, `Author`, `Sha`, `HeadRefName`, `BaseRefName`,
+`InstanceURL`, and `Url`/`URL`. `HeadRefName` and `BaseRefName` are populated
+for PR rows once their preview detail has loaded.
 The universal `redraw` builtin asks Bubble Tea to clear and repaint the screen,
 which is useful if a terminal leaves visual artifacts.
 The universal `firstLine` and `lastLine` builtins jump to the first and last

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -424,6 +424,8 @@ type customCommandContext struct {
 	Title       string
 	IssueTitle  string
 	BranchName  string
+	HeadRefName string
+	BaseRefName string
 	Author      string
 	Sha         string
 	SHA         string
@@ -450,6 +452,8 @@ func (r Runner) renderCustomCommand(command string, target uiactions.Target) (st
 		Title:       target.Title,
 		IssueTitle:  target.Title,
 		BranchName:  target.Title,
+		HeadRefName: target.HeadRefName,
+		BaseRefName: target.BaseRefName,
 		Author:      target.Author,
 		Sha:         target.SHA,
 		SHA:         target.SHA,

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -366,11 +366,13 @@ func TestDispatchCustomCommandRendersSelectedRowTemplate(t *testing.T) {
 		ExecProcess: execProcess.Run,
 	})
 	intent := pullIntent(uiactions.KindCustomCommand)
-	intent.Command = "cd {{.RepoPath}} && echo {{.RepoName}} {{.PrNumber}}/{{.PrIndex}} {{.Title}} {{.Author}} {{.InstanceURL}} {{.Url}}"
+	intent.Command = "cd {{.RepoPath}} && echo {{.RepoName}} {{.PrNumber}}/{{.PrIndex}} {{.Title}} {{.Author}} {{.HeadRefName}} {{.BaseRefName}} {{.InstanceURL}} {{.Url}}"
 	intent.Name = "lazygit"
 	intent.Target.RepositoryPath = "/src/widgets"
 	intent.Target.URL = "https://git.example/acme/widgets/pulls/7"
 	intent.Target.Author = "alice"
+	intent.Target.HeadRefName = "feature/ref-fields"
+	intent.Target.BaseRefName = "main"
 
 	got := runDispatch(t, r, intent)
 	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
@@ -382,7 +384,7 @@ func TestDispatchCustomCommandRendersSelectedRowTemplate(t *testing.T) {
 	if len(execProcess.cmd.Args) != 3 || execProcess.cmd.Args[1] != "-c" {
 		t.Fatalf("shell args = %#v, want shell -c", execProcess.cmd.Args)
 	}
-	want := "cd /src/widgets && echo acme/widgets 7/7 PR title alice https://git.example https://git.example/acme/widgets/pulls/7"
+	want := "cd /src/widgets && echo acme/widgets 7/7 PR title alice feature/ref-fields main https://git.example https://git.example/acme/widgets/pulls/7"
 	if execProcess.cmd.Args[2] != want {
 		t.Fatalf("rendered command = %q, want %q", execProcess.cmd.Args[2], want)
 	}

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -61,6 +61,8 @@ type Target struct {
 	URL            string
 	Author         string
 	SHA            string
+	HeadRefName    string
+	BaseRefName    string
 }
 
 // Prompt carries the prompt payload that was submitted with the intent.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1708,6 +1708,9 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 	case data.PullRequest:
 		rowKind = actions.RowKindPullRequest
 		author = r.Author
+		if detail := m.pullDetails[m.selKey()]; detail != nil {
+			sha = detail.HeadSHA
+		}
 	case data.Issue:
 		rowKind = actions.RowKindIssue
 		author = r.Author
@@ -1730,6 +1733,12 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 		URL:         row.GetURL(),
 		Author:      author,
 		SHA:         sha,
+	}
+	if target.RowKind == actions.RowKindPullRequest {
+		if detail := m.pullDetails[m.selKey()]; detail != nil {
+			target.HeadRefName = detail.HeadRef
+			target.BaseRefName = detail.BaseRef
+		}
 	}
 	if branch, ok := row.(localgit.Branch); ok {
 		target.RepositoryPath = branch.RepositoryPath

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2311,6 +2311,24 @@ func TestConfigCustomKeybindingDispatchesSelectedRowCommand(t *testing.T) {
 	}
 }
 
+func TestSelectedPullTargetIncludesLoadedRefNames(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 12, Title: "Custom command row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://git.example/gbarany/tea-dash/pulls/12",
+	}}))
+	m.pullDetails[m.selKey()] = &data.PullDetail{BaseRef: "main", HeadRef: "feature/ref-fields"}
+
+	target, ok := m.selectedActionTarget()
+	if !ok {
+		t.Fatal("expected selected PR target")
+	}
+	if target.BaseRefName != "main" || target.HeadRefName != "feature/ref-fields" {
+		t.Fatalf("target refs = base %q head %q, want main / feature/ref-fields", target.BaseRefName, target.HeadRefName)
+	}
+}
+
 func TestScopedBuiltinKeybindingRunsInActiveView(t *testing.T) {
 	cfg := &config.Config{
 		Defaults: config.Defaults{View: "issues"},


### PR DESCRIPTION
## Summary
- Add `HeadRefName` and `BaseRefName` to action targets and custom command template data.
- Populate those fields for selected PR rows when preview detail has loaded.
- Document the new PR template fields and their loaded-preview caveat.

## Test Plan
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`