### PR TITLE
Include read notifications by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ notifications, and local branches across one or more Gitea instances, without
 leaving the terminal.
 
 > **Status: early — v1.** A working multi-view dashboard: live tables of your
-> pull requests, issues, unread notifications, Actions runs, and read-only local
+> pull requests, issues, notifications, Actions runs, and read-only local
 > branch status (fetched via the Gitea API (Go SDK + REST) and local `git`),
 > with view switching (`s`), configurable sections you page through with `h`/`l`,
 > live keyword search (`/`), progressive PR/issue loading, a default-open
@@ -143,6 +143,7 @@ defaults:
   prsLimit: 50           # PR page size; more rows load when you reach the bottom (0 -> 50)
   issuesLimit: 50        # issue page size; more rows load when you reach the bottom (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)
+  includeReadNotifications: true # include read notifications in default notification sections
   actionsLimit: 50       # rows fetched per Actions section (0 -> 50)
   branchesLimit: 0       # local branches shown (0 -> all)
 
@@ -209,7 +210,7 @@ issuesSections:
       milestone: v2
 
 notificationsSections:
-  - title: Unread
+  - title: Inbox
     limit: 50
 
 branchSections:
@@ -326,12 +327,14 @@ view.
 > endpoint has no per-login author filter.
 
 With or without a config file, tea-dash shows the pull requests and issues you
-authored, plus unread notifications, across every repo you can access on your
-Gitea instance. The default PR view has separate open and closed-history tabs;
-sections and filters let you tailor what each tab shows. Notification sections
-currently support title/limit configuration and default to unread threads. The
-branches view shells out to local `git` for configured `localRepos` only and is
-read-only; with no `localRepos`, it falls back to the current working directory.
+authored, plus read and unread notifications, across every repo you can access
+on your Gitea instance. The default PR view has separate open and closed-history
+tabs; sections and filters let you tailor what each tab shows. Notification
+sections currently support title/limit configuration and include read
+notifications by default; set `defaults.includeReadNotifications: false` for
+unread/pinned-only threads. The branches view shells out to local `git` for
+configured `localRepos` only and is read-only; with no `localRepos`, it falls
+back to the current working directory.
 
 ## Development
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,14 +69,15 @@ func (c *Config) SmartFilteringEnabled() bool {
 // cap used when a section omits its own Limit. Precedence: section Limit ->
 // per-view default -> 50.
 type Defaults struct {
-	View                   string        `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
-	Preview                PreviewConfig `yaml:"preview"`
-	RefetchIntervalMinutes int           `yaml:"refetchIntervalMinutes"`
-	PRsLimit               int           `yaml:"prsLimit"`
-	IssuesLimit            int           `yaml:"issuesLimit"`
-	NotificationsLimit     int           `yaml:"notificationsLimit"`
-	ActionsLimit           int           `yaml:"actionsLimit"`
-	BranchesLimit          int           `yaml:"branchesLimit"`
+	View                     string        `yaml:"view"` // "prs" | "issues" | "notifications" | "actions" | "branches"
+	Preview                  PreviewConfig `yaml:"preview"`
+	RefetchIntervalMinutes   int           `yaml:"refetchIntervalMinutes"`
+	PRsLimit                 int           `yaml:"prsLimit"`
+	IssuesLimit              int           `yaml:"issuesLimit"`
+	NotificationsLimit       int           `yaml:"notificationsLimit"`
+	IncludeReadNotifications *bool         `yaml:"includeReadNotifications"`
+	ActionsLimit             int           `yaml:"actionsLimit"`
+	BranchesLimit            int           `yaml:"branchesLimit"`
 }
 
 // PreviewConfig controls the side preview pane. Open is a pointer so an omitted
@@ -102,6 +103,17 @@ func (p PreviewConfig) PreviewWidth() int {
 		return 0
 	}
 	return p.Width
+}
+
+// IncludeReadNotificationsEnabled reports whether notification sections with no
+// explicit status filter should include read notifications. It defaults to true
+// to match gh-dash and GitHub's notification view; configuring false restores
+// an unread/pinned-only inbox.
+func (d Defaults) IncludeReadNotificationsEnabled() bool {
+	if d.IncludeReadNotifications == nil {
+		return true
+	}
+	return *d.IncludeReadNotifications
 }
 
 // RefetchInterval returns the configured automatic refetch interval. A zero or

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -86,6 +86,7 @@ defaults:
   prsLimit: 25
   issuesLimit: 40
   notificationsLimit: 30
+  includeReadNotifications: true
   actionsLimit: 20
   branchesLimit: 100
 prSections:
@@ -127,7 +128,7 @@ localRepos:
 	}
 	if c.Defaults.View != "notifications" || c.Defaults.PRsLimit != 25 || c.Defaults.IssuesLimit != 40 ||
 		c.Defaults.NotificationsLimit != 30 || c.Defaults.ActionsLimit != 20 || c.Defaults.BranchesLimit != 100 ||
-		c.Defaults.RefetchIntervalMinutes != 3 {
+		c.Defaults.RefetchIntervalMinutes != 3 || !c.Defaults.IncludeReadNotificationsEnabled() {
 		t.Fatalf("defaults = %+v", c.Defaults)
 	}
 	if c.Defaults.Preview.Open == nil || *c.Defaults.Preview.Open || c.Defaults.Preview.Width != 72 {
@@ -161,6 +162,27 @@ localRepos:
 	if len(c.LocalRepos) != 1 || c.LocalRepos[0].Name != "tea-dash" ||
 		c.LocalRepos[0].Path != "/path/to/tea-dash" {
 		t.Fatalf("localRepos = %+v", c.LocalRepos)
+	}
+}
+
+func TestDefaultsIncludeReadNotificationsDefaultsToEnabled(t *testing.T) {
+	var d Defaults
+	if !d.IncludeReadNotificationsEnabled() {
+		t.Fatal("IncludeReadNotificationsEnabled should default to true when omitted")
+	}
+}
+
+func TestDefaultsIncludeReadNotificationsCanBeDisabled(t *testing.T) {
+	const y = `
+defaults:
+  includeReadNotifications: false
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Defaults.IncludeReadNotificationsEnabled() {
+		t.Fatal("IncludeReadNotificationsEnabled should be false when configured false")
 	}
 }
 

--- a/internal/gitea/notifications.go
+++ b/internal/gitea/notifications.go
@@ -15,7 +15,7 @@ import (
 // ListNotifications returns the authenticated user's notification threads.
 // Gitea's notification list response does not expose X-Total-Count through the
 // SDK response, so total is the number of rows returned for this page.
-func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notification, int, error) {
+func (c *Client) ListNotifications(_ context.Context, limit int, includeRead bool) ([]data.Notification, int, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -24,7 +24,7 @@ func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notific
 		var e error
 		threads, _, e = c.sdk.ListNotifications(sdk.ListNotificationOptions{
 			ListOptions: sdk.ListOptions{PageSize: limit},
-			Status:      []sdk.NotifyStatus{sdk.NotifyStatusUnread},
+			Status:      notificationStatuses(includeRead),
 		})
 		return e
 	})
@@ -36,6 +36,13 @@ func (c *Client) ListNotifications(_ context.Context, limit int) ([]data.Notific
 		rows = append(rows, mapNotificationThread(thread))
 	}
 	return rows, len(rows), nil
+}
+
+func notificationStatuses(includeRead bool) []sdk.NotifyStatus {
+	if includeRead {
+		return []sdk.NotifyStatus{sdk.NotifyStatusUnread, sdk.NotifyStatusRead, sdk.NotifyStatusPinned}
+	}
+	return []sdk.NotifyStatus{sdk.NotifyStatusUnread, sdk.NotifyStatusPinned}
 }
 
 // MarkNotificationRead marks one notification thread as read.

--- a/internal/gitea/notifications_test.go
+++ b/internal/gitea/notifications_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -44,7 +45,7 @@ func TestListNotificationsMapsThreads(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	rows, total, err := c.ListNotifications(context.Background(), 25)
+	rows, total, err := c.ListNotifications(context.Background(), 25, false)
 	if err != nil {
 		t.Fatalf("ListNotifications: %v", err)
 	}
@@ -65,9 +66,26 @@ func TestListNotificationsMapsThreads(t *testing.T) {
 	if !strings.Contains(gotQuery, "limit=25") {
 		t.Fatalf("query %q missing limit=25", gotQuery)
 	}
-	if !strings.Contains(gotQuery, "status-types=unread") {
-		t.Fatalf("query %q missing unread status filter", gotQuery)
+	assertNotificationStatuses(t, gotQuery, "unread", "pinned")
+}
+
+func TestListNotificationsCanIncludeReadThreads(t *testing.T) {
+	var gotQuery string
+	srv := notificationServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		fmt.Fprint(w, notificationJSON)
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
 	}
+
+	if _, _, err := c.ListNotifications(context.Background(), 25, true); err != nil {
+		t.Fatalf("ListNotifications: %v", err)
+	}
+
+	assertNotificationStatuses(t, gotQuery, "unread", "read", "pinned")
 }
 
 func TestMarkNotificationReadUsesThreadEndpoint(t *testing.T) {
@@ -291,6 +309,18 @@ func notificationServer(t *testing.T, notifications http.HandlerFunc, routes ...
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func assertNotificationStatuses(t *testing.T, rawQuery string, want ...string) {
+	t.Helper()
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("ParseQuery(%q): %v", rawQuery, err)
+	}
+	got := values["status-types"]
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("status-types = %v, want %v in query %q", got, want, rawQuery)
+	}
 }
 
 func assertEmptyBody(t *testing.T, r *http.Request) {

--- a/internal/ui/components/notificationsection/notificationsection.go
+++ b/internal/ui/components/notificationsection/notificationsection.go
@@ -40,8 +40,12 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 		SingularForm: "notification",
 		PluralForm:   "notifications",
 		Limit:        func(c *config.Config) int { return c.Defaults.NotificationsLimit },
-		Fetch: func(ctx stdctx.Context, c *gitea.Client, _ config.PrIssueFilter, limit, _ int) ([]data.Notification, int, error) {
-			return c.ListNotifications(ctx, limit)
+		Fetch: func(fetchCtx stdctx.Context, c *gitea.Client, _ config.PrIssueFilter, limit, _ int) ([]data.Notification, int, error) {
+			includeRead := true
+			if ctx.Config != nil {
+				includeRead = ctx.Config.Defaults.IncludeReadNotificationsEnabled()
+			}
+			return c.ListNotifications(fetchCtx, limit, includeRead)
 		},
 		BuildRow: notificationBuildRow,
 	})


### PR DESCRIPTION
## Summary
- add defaults.includeReadNotifications with gh-dash-compatible default-on semantics
- request notification statuses explicitly: unread+pinned when disabled, unread+read+pinned when enabled
- update README notification docs away from unread-only wording

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build