### PR TITLE
Support confirmQuit setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ instance:
   # tokenEnv:     TEA_DASH_TOKEN                           # name of an env var holding the token
 
 smartFilteringAtLaunch: true # when launched inside a matching git checkout, blank PR/issue sections scope to that repo
+confirmQuit: false           # set true to ask before quitting with q/ctrl+c
 
 defaults:
   view: prs              # startup view: "prs", "issues", "notifications", "actions", or "branches"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// the git repository tea-dash was launched from, when that checkout's remote
 	// host matches the configured Gitea instance. Nil means enabled.
 	SmartFilteringAtLaunch *bool `yaml:"smartFilteringAtLaunch"`
+	// ConfirmQuit asks before quitting with q/ctrl+c. Nil means disabled,
+	// matching gh-dash's default confirmQuit: false behavior.
+	ConfirmQuit *bool `yaml:"confirmQuit"`
 	// LocalRepos lists local git repository paths for read-only branch status.
 	LocalRepos []LocalRepoConfig `yaml:"localRepos"`
 	// PRSections, IssuesSections, NotificationsSections, ActionsSections, and BranchSections
@@ -63,6 +66,15 @@ func (c *Config) SmartFilteringEnabled() bool {
 		return true
 	}
 	return *c.SmartFilteringAtLaunch
+}
+
+// ConfirmQuitEnabled reports whether tea-dash should ask before quitting. It
+// defaults off, matching gh-dash.
+func (c *Config) ConfirmQuitEnabled() bool {
+	if c == nil || c.ConfirmQuit == nil {
+		return false
+	}
+	return *c.ConfirmQuit
 }
 
 // Defaults holds startup and limit defaults. Per-view limits set the row-fetch

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,6 +204,24 @@ func TestSmartFilteringAtLaunchCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestConfirmQuitDefaultsToDisabled(t *testing.T) {
+	var c Config
+	if c.ConfirmQuitEnabled() {
+		t.Fatal("ConfirmQuitEnabled should default to false when confirmQuit is omitted")
+	}
+}
+
+func TestConfirmQuitCanBeEnabled(t *testing.T) {
+	const y = `confirmQuit: true`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !c.ConfirmQuitEnabled() {
+		t.Fatal("ConfirmQuitEnabled should be true when confirmQuit is true")
+	}
+}
+
 func TestDefaultsRefetchInterval(t *testing.T) {
 	if got := (Defaults{}).RefetchInterval(); got != 0 {
 		t.Fatalf("zero refetch interval = %v, want disabled", got)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -50,6 +50,7 @@ type Model struct {
 	actionDispatcher func(actions.Intent) tea.Cmd
 	actionPrompt     actionprompt.Model
 	pendingAction    actions.Intent
+	pendingQuit      bool
 	actionFeedback   actionfeedback.Model
 	copyToClipboard  func(string) error
 	showHelp         bool
@@ -502,7 +503,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.startAction(actions.KindCheckout)
 		case !m.scopedBuiltinOverridden("quit") && key.Matches(msg, m.keys.Quit):
-			return m, tea.Quit
+			return m.quitOrConfirm()
 		case !m.scopedBuiltinOverridden("refresh") && key.Matches(msg, m.keys.Refresh):
 			if s := m.getCurrSection(); s != nil && !s.GetIsLoading() {
 				if m.ctx.PreviewOpen {
@@ -1507,7 +1508,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 	case "opengithub", "open", "openbrowser":
 		return m, m.openSelected(), true
 	case "quit":
-		return m, tea.Quit, true
+		next, cmd := m.quitOrConfirm()
+		return next, cmd, true
 	case "redraw":
 		return m, tea.ClearScreen, true
 	case "firstline":
@@ -1659,6 +1661,20 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 	var result actionprompt.Result
 	var cmd tea.Cmd
 	m.actionPrompt, result, cmd = m.actionPrompt.Update(msg)
+	if m.pendingQuit {
+		if result.Canceled {
+			m.pendingQuit = false
+			return cmd
+		}
+		if result.Submitted {
+			m.pendingQuit = false
+			if cmd == nil {
+				return tea.Quit
+			}
+			return tea.Batch(cmd, tea.Quit)
+		}
+		return cmd
+	}
 	if result.Canceled {
 		m.pendingAction = actions.Intent{}
 		m.actionFeedback = m.actionFeedback.Set(actionfeedback.Cancel("Action cancelled."))
@@ -1683,6 +1699,19 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		return cmd
 	}
 	return tea.Batch(cmd, dispatchCmd)
+}
+
+func (m Model) quitOrConfirm() (Model, tea.Cmd) {
+	if m.ctx != nil && m.ctx.Config != nil && m.ctx.Config.ConfirmQuitEnabled() {
+		m.pendingQuit = true
+		m.actionPrompt = m.actionPrompt.Focus(actionprompt.Config{
+			Mode:    actionprompt.ModeConfirm,
+			Title:   "Quit tea-dash",
+			Message: "Quit tea-dash?",
+		})
+		return m, nil
+	}
+	return m, tea.Quit
 }
 
 func (m *Model) dispatchActionIntent(intent actions.Intent) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -536,6 +536,45 @@ func TestQuitKeyStopsProgram(t *testing.T) {
 	}
 }
 
+func TestQuitKeyOpensConfirmationWhenEnabled(t *testing.T) {
+	confirmQuit := true
+	m := New(&config.Config{ConfirmQuit: &confirmQuit}, nil)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if isQuitCmd(cmd) {
+		t.Fatal("confirmQuit=true should ask for confirmation before returning tea.Quit")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Quit tea-dash") {
+		t.Fatalf("quit should open a confirmation prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+}
+
+func TestQuitConfirmationEnterStopsProgram(t *testing.T) {
+	confirmQuit := true
+	m := New(&config.Config{ConfirmQuit: &confirmQuit}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("quit prompt should be active")
+	}
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !isQuitCmd(cmd) {
+		t.Fatal("enter in the quit confirmation should return tea.Quit")
+	}
+}
+
+func TestQuitConfirmationEscCancels(t *testing.T) {
+	confirmQuit := true
+	m := New(&config.Config{ConfirmQuit: &confirmQuit}, nil)
+	m = update(t, m, tea.KeyPressMsg{Code: 'q', Text: "q"})
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.actionPrompt.Active() {
+		t.Fatal("esc should close the quit confirmation prompt")
+	}
+	if strings.Contains(m.View().Content, "Quit tea-dash") {
+		t.Fatalf("quit confirmation should be gone:\n%s", m.View().Content)
+	}
+}
+
 func TestUnknownSectionIsNoOp(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})


### PR DESCRIPTION
## Summary
- add top-level confirmQuit config with gh-dash-compatible default false
- when confirmQuit is true, q/ctrl+c and quit builtins open a confirmation prompt before tea.Quit
- document the setting in the README example

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build