### PR TITLE
Support up and down keybinding builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ actions; commands run through your shell with row template fields such as
 for PR rows once their preview detail has loaded.
 The universal `redraw` builtin asks Bubble Tea to clear and repaint the screen,
 which is useful if a terminal leaves visual artifacts.
+The universal `up` and `down` builtins move the selected row and can be rebound
+independently of the default `j`/`k` and arrow-key navigation.
 The universal `firstLine` and `lastLine` builtins jump to the first and last
 currently loaded row, matching gh-dash's `g`/`G` navigation behavior.
 Scoped `viewIssues` and `viewPrs` built-ins jump directly between the PRs and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,7 +441,7 @@ func (k Keybindings) Validate() error {
 var universalBuiltins = builtinSet(
 	"refresh", "refreshAll", "openGithub", "open", "search", "togglePreview",
 	"toggleSmartFiltering", "toggleSmartFilter", "currentRepo",
-	"firstLine", "lastLine",
+	"up", "down", "firstLine", "lastLine",
 	"pageUp", "pageDown", "scrollUp", "scrollDown", "prevSection",
 	"previousSection", "nextSection", "switchView", "copyurl", "copyNumber",
 	"help", "quit", "redraw", "expand", "summaryViewMore",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -409,6 +409,8 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "R", Builtin: "refreshAll"},
 		{Key: "ctrl+l", Builtin: "redraw"},
 		{Key: "t", Builtin: "toggleSmartFiltering"},
+		{Key: "J", Builtin: "down"},
+		{Key: "K", Builtin: "up"},
 		{Key: "g", Builtin: "firstLine"},
 		{Key: "G", Builtin: "lastLine"},
 		{Key: "z", Command: "lazygit"},

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -450,6 +450,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		switch {
+		case !m.scopedBuiltinOverridden("up") && key.Matches(msg, m.keys.Up):
+			return m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyUp})
+		case !m.scopedBuiltinOverridden("down") && key.Matches(msg, m.keys.Down):
+			return m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyDown})
 		case !m.scopedBuiltinOverridden("markRead") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkRead):
 			return m.markSelectedNotificationRead()
 		case !m.scopedBuiltinOverridden("markUnread") && m.ctx.View == context.NotificationsView && key.Matches(msg, m.keys.MarkUnread):
@@ -581,13 +585,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Fall-through: forward to the current section (row navigation, etc.). When
 	// the preview is open, moving the cursor to a new row re-renders the pane and
 	// lazily fetches that row's detail.
-	before := m.selKey()
-	cmd := m.updateCurrentSection(msg)
-	if m.ctx.PreviewOpen && m.selKey() != before {
-		m.syncSidebar()
-		cmd = tea.Batch(cmd, m.enrichCurrRow())
-	}
-	return m, cmd
+	return m.updateCurrentSectionWithPreview(msg)
 }
 
 // View composes the same shell as before: title, (tab bar), section body,
@@ -1301,21 +1299,14 @@ func (m Model) handleMouseWheel(msg tea.MouseWheelMsg) (Model, tea.Cmd) {
 	if !m.inMainListPane(msg.X, msg.Y) {
 		return m, nil
 	}
-	before := m.selKey()
-	var cmd tea.Cmd
 	switch msg.Button {
 	case tea.MouseWheelUp:
-		cmd = m.updateCurrentSection(tea.KeyPressMsg{Code: tea.KeyUp})
+		return m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyUp})
 	case tea.MouseWheelDown:
-		cmd = m.updateCurrentSection(tea.KeyPressMsg{Code: tea.KeyDown})
+		return m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyDown})
 	default:
 		return m, nil
 	}
-	if m.ctx.PreviewOpen && m.selKey() != before {
-		m.syncSidebar()
-		cmd = tea.Batch(cmd, m.enrichCurrRow())
-	}
-	return m, cmd
 }
 
 func (m Model) failedPreview(row data.RowData, err error) string {
@@ -1512,6 +1503,12 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return next, cmd, true
 	case "redraw":
 		return m, tea.ClearScreen, true
+	case "up":
+		next, cmd := m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyUp})
+		return next, cmd, true
+	case "down":
+		next, cmd := m.updateCurrentSectionWithPreview(tea.KeyPressMsg{Code: tea.KeyDown})
+		return next, cmd, true
 	case "firstline":
 		next, cmd := m.selectCurrentSectionRow(0)
 		return next, cmd, true
@@ -2200,6 +2197,16 @@ func (m *Model) updateCurrentSection(msg tea.Msg) tea.Cmd {
 		return nil
 	}
 	return m.updateSection(s.GetId(), s.GetType(), msg)
+}
+
+func (m Model) updateCurrentSectionWithPreview(msg tea.Msg) (Model, tea.Cmd) {
+	before := m.selKey()
+	cmd := m.updateCurrentSection(msg)
+	if m.ctx.PreviewOpen && m.selKey() != before {
+		m.syncSidebar()
+		cmd = tea.Batch(cmd, m.enrichCurrRow())
+	}
+	return m, cmd
 }
 
 func (m *Model) syncProgramContext() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2644,6 +2644,30 @@ func TestConfiguredFirstLastBuiltinsMoveSelection(t *testing.T) {
 	}
 }
 
+func TestConfiguredUpDownBuiltinsMoveSelection(t *testing.T) {
+	m := New(&config.Config{
+		Keybindings: config.Keybindings{Universal: []config.Keybinding{
+			{Key: "J", Builtin: "down"},
+			{Key: "K", Builtin: "up"},
+		}},
+	}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{
+		{Number: 1, Title: "First row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 2, Title: "Second row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+		{Number: 3, Title: "Third row", RepoNameWithOwner: "gbarany/tea-dash", Author: "me", State: "open"},
+	}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'J', Text: "J"})
+	if got := m.getCurrRowData().GetNumber(); got != 2 {
+		t.Fatalf("down selected #%d, want #2", got)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'K', Text: "K"})
+	if got := m.getCurrRowData().GetNumber(); got != 1 {
+		t.Fatalf("up selected #%d, want #1", got)
+	}
+}
+
 func TestInvalidActionOnIssueShowsNotice(t *testing.T) {
 	var dispatched bool
 	m := New(&config.Config{Defaults: config.Defaults{View: "issues"}}, nil)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -8,13 +8,15 @@ import (
 	"github.com/gbarany/tea-dash/internal/config"
 )
 
-// keyMap defines the app-level key bindings. Row navigation (↑/↓, j/k, page
-// keys) is handled by the underlying table widget.
+// keyMap defines the app-level key bindings. Row navigation is also forwarded
+// to the underlying table widget so configurable builtins reuse table behavior.
 type keyMap struct {
 	Refresh       key.Binding
 	RefreshAll    key.Binding
 	Open          key.Binding
 	Quit          key.Binding
+	Up            key.Binding
+	Down          key.Binding
 	NextSection   key.Binding
 	PrevSection   key.Binding
 	SwitchView    key.Binding
@@ -70,6 +72,14 @@ func defaultKeyMap() keyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
 			key.WithHelp("q", "quit"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "move up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "move down"),
 		),
 		NextSection: key.NewBinding(
 			key.WithKeys("l", "right"),
@@ -244,6 +254,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Open = binding(keyName, "open in browser")
 	case "quit":
 		k.Quit = binding(keyName, "quit")
+	case "up":
+		k.Up = binding(keyName, "move up")
+	case "down":
+		k.Down = binding(keyName, "move down")
 	case "nextsection":
 		k.NextSection = binding(keyName, "next section")
 	case "prevsection", "previoussection":


### PR DESCRIPTION
## Summary

- add universal configurable `up` and `down` builtins
- route those builtins through the same table movement and preview-refresh path as default navigation and mouse wheel movement
- document the new builtins in the README

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config ./internal/ui -run 'TestConfigValidateKeybindingsRequireKeyAndAction|TestConfiguredUpDownBuiltinsMoveSelection'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`