### PR TITLE
Support notification toggleBookmark keybinding alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ keybindings:
       command: echo issue {{.IssueNumber}} in {{.RepoName}}
   notifications:
     - key: b
-      builtin: togglePin
+      builtin: togglePin      # gh-dash-compatible alias: toggleBookmark
     - key: B
       builtin: unpin
     - key: D

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -463,7 +463,7 @@ var issueBuiltins = builtinSet(
 var notificationBuiltins = builtinSet(
 	"openGithub", "open", "markAsRead", "markRead", "markAsUnread",
 	"markUnread", "markAllAsRead", "markAllRead", "markAsDone", "markDone",
-	"markAllAsDone", "markAllDone", "pin", "unpin", "togglePin", "togglePinned",
+	"markAllAsDone", "markAllDone", "pin", "unpin", "togglePin", "togglePinned", "toggleBookmark",
 )
 
 var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -288,6 +288,8 @@ keybindings:
   notifications:
     - key: b
       builtin: togglePin
+    - key: t
+      builtin: toggleBookmark
     - key: B
       builtin: unpin
     - key: D
@@ -319,10 +321,11 @@ keybindings:
 		c.Keybindings.Issues[4].Builtin != "unsubscribe" {
 		t.Fatalf("issues keybindings = %+v", c.Keybindings.Issues)
 	}
-	if len(c.Keybindings.Notifications) != 3 ||
+	if len(c.Keybindings.Notifications) != 4 ||
 		c.Keybindings.Notifications[0].Builtin != "togglePin" ||
-		c.Keybindings.Notifications[1].Builtin != "unpin" ||
-		c.Keybindings.Notifications[2].Builtin != "markAllRead" ||
+		c.Keybindings.Notifications[1].Builtin != "toggleBookmark" ||
+		c.Keybindings.Notifications[2].Builtin != "unpin" ||
+		c.Keybindings.Notifications[3].Builtin != "markAllRead" ||
 		c.Keybindings.Actions[0].Key != "a" ||
 		c.Keybindings.Branches[0].Command == "" {
 		t.Fatalf("keybindings = %+v", c.Keybindings)
@@ -426,6 +429,8 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "p", Builtin: "viewPrs"},
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},
+	}, Notifications: []Keybinding{
+		{Key: "b", Builtin: "toggleBookmark"},
 	}}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected valid keybindings: %v", err)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1598,7 +1598,7 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 	case "markallasread", "markallread", "markallasdone", "markalldone":
 		next, cmd := m.markAllNotificationsRead()
 		return next, cmd, true
-	case "pin", "togglepin", "togglepinned":
+	case "pin", "togglepin", "togglepinned", "togglebookmark":
 		next, cmd := m.toggleSelectedNotificationPin()
 		return next, cmd, true
 	case "unpin":

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1165,11 +1165,26 @@ func TestToggleNotificationPinRefreshesNotifications(t *testing.T) {
 		pinned     bool
 		unread     bool
 		key        tea.KeyPressMsg
+		cfg        *config.Config
 		wantStatus string
 		wantNotice string
 	}{
 		{name: "pin", key: tea.KeyPressMsg{Code: 'b', Text: "b"}, pinned: false, unread: true, wantStatus: "pinned", wantNotice: "Pinned notification"},
 		{name: "toggle unpin unread", key: tea.KeyPressMsg{Code: 'b', Text: "b"}, pinned: true, unread: true, wantStatus: "unread", wantNotice: "Unpinned notification"},
+		{
+			name: "configured toggleBookmark alias pins",
+			key:  tea.KeyPressMsg{Code: 't', Text: "t"},
+			cfg: &config.Config{
+				Defaults: config.Defaults{View: "notifications"},
+				Keybindings: config.Keybindings{Notifications: []config.Keybinding{
+					{Key: "t", Builtin: "toggleBookmark"},
+				}},
+			},
+			pinned:     false,
+			unread:     true,
+			wantStatus: "pinned",
+			wantNotice: "Pinned notification",
+		},
 		{name: "explicit unpin read", key: tea.KeyPressMsg{Code: 'B', Text: "B"}, pinned: true, unread: false, wantStatus: "read", wantNotice: "Unpinned notification"},
 	}
 
@@ -1187,7 +1202,11 @@ func TestToggleNotificationPinRefreshesNotifications(t *testing.T) {
 				},
 				nil,
 			)
-			m := New(&config.Config{Defaults: config.Defaults{View: "notifications"}}, client)
+			cfg := tt.cfg
+			if cfg == nil {
+				cfg = &config.Config{Defaults: config.Defaults{View: "notifications"}}
+			}
+			m := New(cfg, client)
 			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
 			m = update(t, m, notificationFetchedMsg([]data.Notification{{
 				ID: 12, Number: 42, SubjectTitle: "Review the new dashboard",

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -326,7 +326,7 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.MarkUnread = binding(keyName, "mark unread")
 	case "markallasread", "markallread":
 		k.MarkAllRead = binding(keyName, "mark all read")
-	case "pin", "togglepin", "togglepinned":
+	case "pin", "togglepin", "togglepinned", "togglebookmark":
 		k.Pin = binding(keyName, "pin")
 	case "unpin":
 		k.Unpin = binding(keyName, "unpin")


### PR DESCRIPTION
## Summary

- accept gh-dash-compatible `toggleBookmark` as a notification builtin
- route `toggleBookmark` through the existing notification pin/unpin action
- cover parse, validation, and configured-key behavior in tests

## Verification

- `GOCACHE=/tmp/tea-dash-go-cache go test -count=1 ./internal/config ./internal/ui -run 'TestUnmarshalKeybindings|TestConfigValidateKeybindingsRequireKeyAndAction|TestToggleNotificationPinRefreshesNotifications'`
- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`