### PR TITLE
Add branch push and delete actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ tea-dash --help
 | `v`             | submit PR review        |
 | `d` / `ctrl+t`  | open PR diff in external pager |
 | `C` / `space`   | checkout PR/issue locally; switch branch in Branches view |
+| `P`             | push branch in Branches view   |
+| `d` / `backspace` | delete branch in Branches view |
 | `R` / `!`       | rerun / cancel Actions run |
 | `r` / `R`       | refresh section / all sections (`ctrl+r` refreshes all in Actions view) |
 | `?`             | show / hide full help   |
@@ -285,6 +287,10 @@ keybindings:
   branches:
     - key: B
       command: git -C {{.RepoPath}} status
+    - key: P
+      builtin: push
+    - key: d
+      builtin: delete
 ```
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -55,6 +55,12 @@ type IssueCheckoutFunc func(context.Context, localgit.IssueCheckoutOptions) (loc
 // BranchSwitchFunc runs or fakes a local branch switch.
 type BranchSwitchFunc func(context.Context, localgit.SwitchBranchOptions) (localgit.SwitchBranchResult, error)
 
+// BranchPushFunc runs or fakes a local branch push.
+type BranchPushFunc func(context.Context, localgit.PushBranchOptions) (localgit.PushBranchResult, error)
+
+// BranchDeleteFunc runs or fakes a local branch deletion.
+type BranchDeleteFunc func(context.Context, localgit.DeleteBranchOptions) (localgit.DeleteBranchResult, error)
+
 // ExecProcessFunc wraps Bubble Tea's ExecProcess for interactive shell
 // commands. Tests replace it to avoid running a real process.
 type ExecProcessFunc func(*exec.Cmd, tea.ExecCallback) tea.Cmd
@@ -70,6 +76,8 @@ type Options struct {
 	Checkout      CheckoutFunc
 	IssueCheckout IssueCheckoutFunc
 	BranchSwitch  BranchSwitchFunc
+	BranchPush    BranchPushFunc
+	BranchDelete  BranchDeleteFunc
 	ExecProcess   ExecProcessFunc
 }
 
@@ -84,6 +92,8 @@ type Runner struct {
 	checkout      CheckoutFunc
 	issueCheckout IssueCheckoutFunc
 	branchSwitch  BranchSwitchFunc
+	branchPush    BranchPushFunc
+	branchDelete  BranchDeleteFunc
 	execProcess   ExecProcessFunc
 }
 
@@ -109,6 +119,14 @@ func New(opts Options) Runner {
 	if branchSwitch == nil {
 		branchSwitch = localgit.SwitchBranch
 	}
+	branchPush := opts.BranchPush
+	if branchPush == nil {
+		branchPush = localgit.PushBranch
+	}
+	branchDelete := opts.BranchDelete
+	if branchDelete == nil {
+		branchDelete = localgit.DeleteBranch
+	}
 	execProcess := opts.ExecProcess
 	if execProcess == nil {
 		execProcess = tea.ExecProcess
@@ -123,6 +141,8 @@ func New(opts Options) Runner {
 		checkout:      checkout,
 		issueCheckout: issueCheckout,
 		branchSwitch:  branchSwitch,
+		branchPush:    branchPush,
+		branchDelete:  branchDelete,
 		execProcess:   execProcess,
 	}
 }
@@ -219,6 +239,29 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 			return "", err
 		}
 		return fmt.Sprintf("Switched to %s in %s.", branch.Branch, branch.RepoPath), nil
+	}
+	if intent.Kind == uiactions.KindPushBranch {
+		branch, err := r.branchPush(ctx, localgit.PushBranchOptions{
+			RepoPath: intent.Target.RepositoryPath,
+			Branch:   intent.Target.Title,
+			Remote:   "origin",
+			Runner:   r.gitRunner,
+		})
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Pushed %s to %s in %s.", branch.Branch, branch.Remote, branch.RepoPath), nil
+	}
+	if intent.Kind == uiactions.KindDeleteBranch {
+		branch, err := r.branchDelete(ctx, localgit.DeleteBranchOptions{
+			RepoPath: intent.Target.RepositoryPath,
+			Branch:   intent.Target.Title,
+			Runner:   r.gitRunner,
+		})
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Deleted %s in %s.", branch.Branch, branch.RepoPath), nil
 	}
 	if r.client == nil {
 		return "", fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))
@@ -619,6 +662,10 @@ func actionLabel(kind uiactions.Kind) string {
 		return "checkout"
 	case uiactions.KindSwitchBranch:
 		return "switch branch"
+	case uiactions.KindPushBranch:
+		return "push branch"
+	case uiactions.KindDeleteBranch:
+		return "delete branch"
 	case uiactions.KindRerunRun:
 		return "rerun"
 	case uiactions.KindCancelRun:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -484,6 +484,50 @@ func TestDispatchSwitchBranchDoesNotRequireClient(t *testing.T) {
 	}
 }
 
+func TestDispatchBranchPushAndDeleteDoNotRequireClient(t *testing.T) {
+	t.Run("push", func(t *testing.T) {
+		var gotOpts localgit.PushBranchOptions
+		r := New(Options{
+			BranchPush: func(_ context.Context, opts localgit.PushBranchOptions) (localgit.PushBranchResult, error) {
+				gotOpts = opts
+				return localgit.PushBranchResult{RepoPath: opts.RepoPath, Branch: opts.Branch, Remote: opts.Remote}, nil
+			},
+		})
+
+		got := runDispatch(t, r, branchIntent(uiactions.KindPushBranch))
+		if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+			t.Fatalf("push branch result = %+v", got)
+		}
+		if gotOpts.RepoPath != "/src/tea-dash" || gotOpts.Branch != "feature/local-ops" || gotOpts.Remote != "origin" {
+			t.Fatalf("push branch opts = %+v", gotOpts)
+		}
+		if !strings.Contains(got.Message, "Pushed feature/local-ops") {
+			t.Fatalf("push branch message = %q", got.Message)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		var gotOpts localgit.DeleteBranchOptions
+		r := New(Options{
+			BranchDelete: func(_ context.Context, opts localgit.DeleteBranchOptions) (localgit.DeleteBranchResult, error) {
+				gotOpts = opts
+				return localgit.DeleteBranchResult{RepoPath: opts.RepoPath, Branch: opts.Branch}, nil
+			},
+		})
+
+		got := runDispatch(t, r, branchIntent(uiactions.KindDeleteBranch))
+		if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+			t.Fatalf("delete branch result = %+v", got)
+		}
+		if gotOpts.RepoPath != "/src/tea-dash" || gotOpts.Branch != "feature/local-ops" {
+			t.Fatalf("delete branch opts = %+v", gotOpts)
+		}
+		if !strings.Contains(got.Message, "Deleted feature/local-ops") {
+			t.Fatalf("delete branch message = %q", got.Message)
+		}
+	})
+}
+
 func TestDispatchActionRunControlsUseRunID(t *testing.T) {
 	client := &fakeClient{}
 	r := New(Options{Client: client})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -468,7 +468,7 @@ var notificationBuiltins = builtinSet(
 
 var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun")
 
-var branchBuiltins = builtinSet("checkout")
+var branchBuiltins = builtinSet("checkout", "push", "delete")
 
 func builtinSet(names ...string) map[string]struct{} {
 	out := make(map[string]struct{}, len(names))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -300,6 +300,10 @@ keybindings:
   branches:
     - key: B
       command: git -C {{.RepoPath}} status
+    - key: P
+      builtin: push
+    - key: d
+      builtin: delete
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
@@ -327,7 +331,10 @@ keybindings:
 		c.Keybindings.Notifications[2].Builtin != "unpin" ||
 		c.Keybindings.Notifications[3].Builtin != "markAllRead" ||
 		c.Keybindings.Actions[0].Key != "a" ||
-		c.Keybindings.Branches[0].Command == "" {
+		len(c.Keybindings.Branches) != 3 ||
+		c.Keybindings.Branches[0].Command == "" ||
+		c.Keybindings.Branches[1].Builtin != "push" ||
+		c.Keybindings.Branches[2].Builtin != "delete" {
 		t.Fatalf("keybindings = %+v", c.Keybindings)
 	}
 }
@@ -431,6 +438,9 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "U", Builtin: "removeLabel"},
 	}, Notifications: []Keybinding{
 		{Key: "b", Builtin: "toggleBookmark"},
+	}, Branches: []Keybinding{
+		{Key: "P", Builtin: "push"},
+		{Key: "d", Builtin: "delete"},
 	}}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected valid keybindings: %v", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -512,6 +512,87 @@ func switchBranchError(repoPath, branch string, err error) error {
 	}
 }
 
+// PushBranchOptions configures pushing a local branch to a remote.
+type PushBranchOptions struct {
+	RepoPath string
+	Branch   string
+	Remote   string
+	Runner   Runner
+}
+
+// PushBranchResult is the local branch push that completed.
+type PushBranchResult struct {
+	RepoPath string
+	Branch   string
+	Remote   string
+}
+
+// PushBranch pushes branch to remote and sets upstream tracking. Empty remote
+// defaults to origin.
+func PushBranch(ctx context.Context, opts PushBranchOptions) (PushBranchResult, error) {
+	repoPath := strings.TrimSpace(opts.RepoPath)
+	branch := strings.TrimSpace(opts.Branch)
+	remote := strings.TrimSpace(opts.Remote)
+	if remote == "" {
+		remote = "origin"
+	}
+	if repoPath == "" {
+		return PushBranchResult{}, errors.New("repository path is required")
+	}
+	if branch == "" {
+		return PushBranchResult{}, errors.New("branch name is required")
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+	if _, err := runGit(ctx, runner, repoPath, "push", "-u", remote, branch); err != nil {
+		return PushBranchResult{}, fmt.Errorf("push %s to %s in %s: %w", branch, remote, repoPath, err)
+	}
+	return PushBranchResult{RepoPath: repoPath, Branch: branch, Remote: remote}, nil
+}
+
+// DeleteBranchOptions configures deleting a local branch.
+type DeleteBranchOptions struct {
+	RepoPath string
+	Branch   string
+	Runner   Runner
+}
+
+// DeleteBranchResult is the local branch deletion that completed.
+type DeleteBranchResult struct {
+	RepoPath string
+	Branch   string
+}
+
+// DeleteBranch deletes a local branch with git branch -d. It refuses deleting
+// the currently checked-out branch before invoking git branch -d.
+func DeleteBranch(ctx context.Context, opts DeleteBranchOptions) (DeleteBranchResult, error) {
+	repoPath := strings.TrimSpace(opts.RepoPath)
+	branch := strings.TrimSpace(opts.Branch)
+	if repoPath == "" {
+		return DeleteBranchResult{}, errors.New("repository path is required")
+	}
+	if branch == "" {
+		return DeleteBranchResult{}, errors.New("branch name is required")
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+	current, err := runGit(ctx, runner, repoPath, "branch", "--show-current")
+	if err != nil {
+		return DeleteBranchResult{}, err
+	}
+	if strings.TrimSpace(current.Stdout) == branch {
+		return DeleteBranchResult{}, fmt.Errorf("branch %s is current in %s; switch away before deleting it", branch, repoPath)
+	}
+	if _, err := runGit(ctx, runner, repoPath, "branch", "-d", branch); err != nil {
+		return DeleteBranchResult{}, fmt.Errorf("delete branch %s in %s: %w", branch, repoPath, err)
+	}
+	return DeleteBranchResult{RepoPath: repoPath, Branch: branch}, nil
+}
+
 func branchExists(ctx context.Context, runner Runner, dir, branch string) (bool, error) {
 	res, err := runner.Run(ctx, Command{Dir: dir, Name: "git", Args: []string{"show-ref", "--verify", "--quiet", "refs/heads/" + branch}})
 	if err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -464,6 +464,68 @@ func TestSwitchBranchWorktreeConflictFailureIsActionable(t *testing.T) {
 	}
 }
 
+func TestPushBranchRunsGitPushSetUpstream(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{ExitCode: 0}}}
+
+	result, err := PushBranch(context.Background(), PushBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Remote:   "origin",
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("PushBranch: %v", err)
+	}
+	if result.RepoPath != repo || result.Branch != "feature/local-ops" || result.Remote != "origin" {
+		t.Fatalf("result = %+v", result)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"push", "-u", "origin", "feature/local-ops"}},
+	})
+}
+
+func TestDeleteBranchRunsSafeGitBranchDelete(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{
+		{Stdout: "main\n", ExitCode: 0},
+		{ExitCode: 0},
+	}}
+
+	result, err := DeleteBranch(context.Background(), DeleteBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+	if result.RepoPath != repo || result.Branch != "feature/local-ops" {
+		t.Fatalf("result = %+v", result)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"branch", "--show-current"}},
+		{Dir: repo, Name: "git", Args: []string{"branch", "-d", "feature/local-ops"}},
+	})
+}
+
+func TestDeleteBranchRefusesCurrentBranch(t *testing.T) {
+	repo := t.TempDir()
+	runner := &fakeRunner{results: []Result{{Stdout: "feature/local-ops\n", ExitCode: 0}}}
+
+	_, err := DeleteBranch(context.Background(), DeleteBranchOptions{
+		RepoPath: repo,
+		Branch:   "feature/local-ops",
+		Runner:   runner,
+	})
+	if err == nil || !strings.Contains(err.Error(), "current") {
+		t.Fatalf("DeleteBranch current error = %v", err)
+	}
+	assertCommands(t, runner.commands, []Command{
+		{Dir: repo, Name: "git", Args: []string{"branch", "--show-current"}},
+	})
+}
+
 func makeGitDir(t *testing.T, remoteURL string) string {
 	return makeGitDirWithRemote(t, "origin", remoteURL)
 }

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -24,6 +24,8 @@ const (
 	KindExternalDiff  Kind = "external_diff"
 	KindCheckout      Kind = "checkout"
 	KindSwitchBranch  Kind = "switch_branch"
+	KindPushBranch    Kind = "push_branch"
+	KindDeleteBranch  Kind = "delete_branch"
 	KindRerunRun      Kind = "rerun_run"
 	KindCancelRun     Kind = "cancel_run"
 	KindCustomCommand Kind = "custom_command"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -19,6 +19,8 @@ func TestKindConstants(t *testing.T) {
 		KindReview:       "review",
 		KindExternalDiff: "external_diff",
 		KindCheckout:     "checkout",
+		KindPushBranch:   "push_branch",
+		KindDeleteBranch: "delete_branch",
 		KindRerunRun:     "rerun_run",
 		KindCancelRun:    "cancel_run",
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -499,6 +499,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindReopen)
 		case !m.scopedBuiltinOverridden("review") && key.Matches(msg, m.keys.Review):
 			return m, m.startAction(actions.KindReview)
+		case !m.scopedBuiltinOverridden("push") && m.ctx.View == context.BranchesView && key.Matches(msg, m.keys.PushBranch):
+			return m, m.startAction(actions.KindPushBranch)
+		case !m.scopedBuiltinOverridden("delete") && m.ctx.View == context.BranchesView && key.Matches(msg, m.keys.DeleteBranch):
+			return m, m.startAction(actions.KindDeleteBranch)
 		case !m.scopedBuiltinOverridden("diff") && key.Matches(msg, m.keys.ExternalDiff):
 			return m, m.startAction(actions.KindExternalDiff)
 		case !m.scopedBuiltinOverridden("checkout") && key.Matches(msg, m.keys.Checkout):
@@ -648,7 +652,7 @@ func (m Model) helpLine() string {
 		case context.NotificationsView:
 			text += " · m mark read · u mark unread · M mark all read · b pin/unpin · B unpin"
 		case context.BranchesView:
-			text += " · C/space switch"
+			text += " · C/space switch · P push · d/backspace delete"
 		case context.IssuesView:
 			text += " · c comment · a/A assign/unassign · L/U labels · M milestone · b/B subscribe/unsubscribe · x/X close/reopen"
 		default:
@@ -669,7 +673,7 @@ func (m Model) helpLine() string {
 	case context.NotificationsView:
 		text += " · m read · u unread · M all read · b pin · B unpin"
 	case context.BranchesView:
-		text += " · C/space switch"
+		text += " · C/space switch · P push · d delete"
 	case context.IssuesView:
 		text += " · c comment · a/A assign · L/U labels · M milestone · b/B subscribe · x/X close/reopen"
 	default:
@@ -719,6 +723,8 @@ func (m Model) actionButtons() []actionButton {
 		buttons = []actionButton{
 			{Label: "Refresh", Builtin: "refresh"},
 			{Label: "Checkout", Builtin: "checkout"},
+			{Label: "Push", Builtin: "push"},
+			{Label: "Delete", Builtin: "delete"},
 		}
 	case context.IssuesView:
 		buttons = append(buttons,
@@ -1455,6 +1461,17 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 			return nil
 		}
 	}
+	if kind == actions.KindDeleteBranch {
+		branch, ok := m.getCurrRowData().(localgit.Branch)
+		if !ok || target.RowKind != actions.RowKindBranch {
+			m.notice = "Delete branch is only available for local branches."
+			return nil
+		}
+		if branch.Current {
+			m.notice = fmt.Sprintf("%s is current in %s; switch away before deleting it.", branch.Name, branch.Repository)
+			return nil
+		}
+	}
 	intent := actions.Intent{
 		Kind:   kind,
 		Target: target,
@@ -1644,6 +1661,10 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 			return m, m.startAction(actions.KindSwitchBranch), true
 		}
 		return m, m.startAction(actions.KindCheckout), true
+	case "push":
+		return m, m.startAction(actions.KindPushBranch), true
+	case "delete":
+		return m, m.startAction(actions.KindDeleteBranch), true
 	case "rerun", "rerunrun":
 		return m, m.startAction(actions.KindRerunRun), true
 	case "cancel", "cancelrun":
@@ -1798,6 +1819,10 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindActionRun {
 			return fmt.Errorf("%s is only available for action runs.", actionLabel(kind))
 		}
+	case actions.KindSwitchBranch, actions.KindPushBranch, actions.KindDeleteBranch:
+		if target.RowKind != actions.RowKindBranch {
+			return fmt.Errorf("%s is only available for local branches.", actionLabel(kind))
+		}
 	default:
 		return nil
 	}
@@ -1827,7 +1852,7 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 func promptConfigForAction(kind actions.Kind, target actions.Target) actionprompt.Config {
 	title := fmt.Sprintf("%s #%d", actionLabel(kind), target.Number)
 	message := fmt.Sprintf("%s - %s", target.Repo, target.Title)
-	if kind == actions.KindSwitchBranch {
+	if kind == actions.KindSwitchBranch || kind == actions.KindPushBranch || kind == actions.KindDeleteBranch {
 		title = actionLabel(kind)
 	}
 	switch kind {
@@ -1936,6 +1961,10 @@ func actionLabel(kind actions.Kind) string {
 		return "Checkout"
 	case actions.KindSwitchBranch:
 		return "Switch branch"
+	case actions.KindPushBranch:
+		return "Push branch"
+	case actions.KindDeleteBranch:
+		return "Delete branch"
 	case actions.KindRerunRun:
 		return "Rerun"
 	case actions.KindCancelRun:
@@ -1955,7 +1984,7 @@ func actionStartText(intent actions.Intent) string {
 		}
 		return fmt.Sprintf("Starting %s for %s.", label, intent.Target.Title)
 	}
-	if intent.Kind == actions.KindSwitchBranch {
+	if intent.Kind == actions.KindSwitchBranch || intent.Kind == actions.KindPushBranch || intent.Kind == actions.KindDeleteBranch {
 		return fmt.Sprintf("Starting %s for %s.", actionLabel(intent.Kind), intent.Target.Title)
 	}
 	return fmt.Sprintf("Starting %s for %s#%d.", actionLabel(intent.Kind), intent.Target.Repo, intent.Target.Number)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2163,6 +2163,73 @@ func TestBranchSwitchHotkeysDispatchExpectedIntent(t *testing.T) {
 	}
 }
 
+func TestBranchLocalOpHotkeysDispatchExpectedIntents(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		kind actions.Kind
+	}{
+		{name: "push", key: tea.KeyPressMsg{Code: 'P', Text: "P"}, kind: actions.KindPushBranch},
+		{name: "delete", key: tea.KeyPressMsg{Code: 'd', Text: "d"}, kind: actions.KindDeleteBranch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []actions.Intent
+			m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+			m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+				got = append(got, intent)
+				return nil
+			}
+			m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+			m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+				Repository: "tea-dash", RepositoryPath: "/src/tea-dash",
+				Name: "feature/local-ops", Current: false,
+			}}))
+
+			m = update(t, m, tt.key)
+			if !m.actionPrompt.Active() {
+				t.Fatalf("%s should open a confirmation prompt", tt.name)
+			}
+			m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+			if len(got) != 1 {
+				t.Fatalf("dispatcher calls = %d, want 1", len(got))
+			}
+			wantTarget := actions.Target{
+				SectionID:      0,
+				SectionType:    branchsection.SectionType,
+				RowKind:        actions.RowKindBranch,
+				Repo:           "tea-dash",
+				RepositoryPath: "/src/tea-dash",
+				Title:          "feature/local-ops",
+			}
+			if got[0].Kind != tt.kind || got[0].Target != wantTarget {
+				t.Fatalf("intent = %+v, want %s target %+v", got[0], tt.kind, wantTarget)
+			}
+		})
+	}
+}
+
+func TestBranchActionButtonsIncludeLocalOps(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "branches"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, branchFetchedMsg([]localgit.Branch{{
+		Repository: "tea-dash", RepositoryPath: "/src/tea-dash",
+		Name: "feature/local-ops", Current: false,
+	}}))
+
+	found := map[string]bool{}
+	for _, b := range m.actionButtons() {
+		found[b.Label] = true
+	}
+	for _, label := range []string{"Push", "Delete"} {
+		if !found[label] {
+			t.Fatalf("branch action button %q not found in %+v", label, m.actionButtons())
+		}
+	}
+}
+
 func TestActionsViewRunControlKeysDispatchExpectedIntents(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -43,6 +43,8 @@ type keyMap struct {
 	Review        key.Binding
 	ExternalDiff  key.Binding
 	Checkout      key.Binding
+	PushBranch    key.Binding
+	DeleteBranch  key.Binding
 	RerunRun      key.Binding
 	CancelRun     key.Binding
 	CopyNumber    key.Binding
@@ -185,6 +187,14 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("C", " ", "space"),
 			key.WithHelp("C/space", "checkout"),
 		),
+		PushBranch: key.NewBinding(
+			key.WithKeys("P"),
+			key.WithHelp("P", "push branch"),
+		),
+		DeleteBranch: key.NewBinding(
+			key.WithKeys("d", "backspace"),
+			key.WithHelp("d/backspace", "delete branch"),
+		),
 		RerunRun: key.NewBinding(
 			key.WithKeys("R"),
 			key.WithHelp("R", "rerun"),
@@ -310,6 +320,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.ExternalDiff = binding(keyName, "external diff")
 	case "checkout":
 		k.Checkout = binding(keyName, "checkout")
+	case "push":
+		k.PushBranch = binding(keyName, "push branch")
+	case "delete":
+		k.DeleteBranch = binding(keyName, "delete branch")
 	case "rerun", "rerunrun":
 		k.RerunRun = binding(keyName, "rerun")
 	case "cancel", "cancelrun":


### PR DESCRIPTION
## Summary
- Add branch-view push and safe delete actions with default hotkeys: P, d, and backspace.
- Support configurable branch builtins: push and delete.
- Add Branches view action buttons for Checkout, Push, and Delete.

## Behavior
- Push runs git push -u origin <branch>.
- Delete uses safe git branch -d <branch> and refuses to delete the current branch.

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build