### PR TITLE
Add preview sidebar tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ tea-dash --help
 | `t`             | toggle current-repo smart filtering (when launched from a matching git checkout) |
 | `p`             | show / hide preview panel |
 | `e`             | expand / fold preview body |
+| `[` / `]`       | previous / next preview tab |
 | `ctrl+u` / `ctrl+d` | scroll preview       |
 | `o` / `enter`   | open in browser         |
 | `y` / `Y`       | copy row number / URL   |
@@ -250,6 +251,10 @@ keybindings:
       builtin: ready
     - key: w
       builtin: watchChecks
+    - key: "["
+      builtin: prevSidebarTab
+    - key: "]"
+      builtin: nextSidebarTab
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
@@ -325,6 +330,9 @@ The universal `up` and `down` builtins move the selected row and can be rebound
 independently of the default `j`/`k` and arrow-key navigation.
 The universal `firstLine` and `lastLine` builtins jump to the first and last
 currently loaded row, matching gh-dash's `g`/`G` navigation behavior.
+PR-scoped `prevSidebarTab` and `nextSidebarTab` switch the preview pane through
+its Overview, Checks, Reviews, and Comments tabs, matching gh-dash's `[`/`]`
+preview navigation.
 Scoped `viewIssues` and `viewPrs` built-ins jump directly between the PRs and
 Issues views, while the universal `switchView` cycles through every top-level
 view.

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -102,6 +102,10 @@ keybindings:
       builtin: addLabel
     - key: U
       builtin: removeLabel
+    - key: "["
+      builtin: prevSidebarTab
+    - key: "]"
+      builtin: nextSidebarTab
   issues:
     - key: a
       builtin: assign

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -451,7 +451,7 @@ var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
 	"update", "updateBranch", "ready", "markReady", "draft", "markDraft",
 	"watch", "watchChecks", "checks", "close", "reopen", "diff", "checkout", "approve", "review",
-	"viewIssues", "summaryViewMore", "expand",
+	"viewIssues", "summaryViewMore", "expand", "prevSidebarTab", "nextSidebarTab",
 )
 
 var issueBuiltins = builtinSet(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -431,6 +431,8 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "W", Builtin: "ready"},
 		{Key: "D", Builtin: "draft"},
 		{Key: "w", Builtin: "watchChecks"},
+		{Key: "[", Builtin: "prevSidebarTab"},
+		{Key: "]", Builtin: "nextSidebarTab"},
 		{Key: "i", Builtin: "viewIssues"},
 	}, Issues: []Keybinding{
 		{Key: "p", Builtin: "viewPrs"},

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -578,6 +578,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.syncSidebar()
 			}
 			return m, nil
+		case !m.scopedBuiltinOverridden("prevSidebarTab") && key.Matches(msg, m.keys.PrevSidebarTab) && m.ctx.PreviewOpen:
+			m.sidebar.PrevTab()
+			return m, nil
+		case !m.scopedBuiltinOverridden("nextSidebarTab") && key.Matches(msg, m.keys.NextSidebarTab) && m.ctx.PreviewOpen:
+			m.sidebar.NextTab()
+			return m, nil
 		case (!m.scopedBuiltinOverridden("scrollUp") && key.Matches(msg, m.keys.ScrollUp) ||
 			!m.scopedBuiltinOverridden("scrollDown") && key.Matches(msg, m.keys.ScrollDown)) && m.ctx.PreviewOpen:
 			var cmd tea.Cmd
@@ -639,13 +645,13 @@ func (m Model) View() tea.View {
 
 func (m Model) helpLine() string {
 	if m.showHelp {
-		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
+		text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · [/]/ctrl+u/d preview · r refresh · R refresh all · o/enter open · y copy number · Y copy URL"
 		if m.ctx.CurrentRepo != "" {
 			text += " · t current repo"
 		}
 		switch m.ctx.View {
 		case context.ActionsView:
-			text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · ctrl+u/d scroll · r refresh · ctrl+r refresh all · R rerun · ! cancel run · o/enter open · y copy number · Y copy URL"
+			text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · e expand · [/]/ctrl+u/d preview · r refresh · ctrl+r refresh all · R rerun · ! cancel run · o/enter open · y copy number · Y copy URL"
 			if m.ctx.CurrentRepo != "" {
 				text += " · t current repo"
 			}
@@ -660,13 +666,13 @@ func (m Model) helpLine() string {
 		}
 		return text + " · q quit"
 	}
-	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r/R refresh"
+	text := "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · [/] tabs · r/R refresh"
 	if m.ctx.CurrentRepo != "" {
 		text += " · t current repo"
 	}
 	switch m.ctx.View {
 	case context.ActionsView:
-		text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · r refresh · R rerun · ! cancel"
+		text = "↑/↓/j/k move · g/G first/last · h/l section · s view · / search · p preview · [/] tabs · r refresh · R rerun · ! cancel"
 		if m.ctx.CurrentRepo != "" {
 			text += " · t current repo"
 		}
@@ -998,13 +1004,15 @@ func (m *Model) syncSidebar() {
 			m.sidebar.SetContent(m.failedPreview(row, err))
 			return
 		}
-		rendered = prview.RenderPull(r, m.pullDetails[key], w, m.expanded)
+		m.sidebar.SetTabs(sidebarTabs(prview.RenderPullTabs(r, m.pullDetails[key], w, m.expanded)))
+		return
 	case data.Issue:
 		if err := m.issueEnrichErr[key]; err != nil {
 			m.sidebar.SetContent(m.failedPreview(row, err))
 			return
 		}
-		rendered = prview.RenderIssue(r, m.issueDetails[key], w, m.expanded)
+		m.sidebar.SetTabs(sidebarTabs(prview.RenderIssueTabs(r, m.issueDetails[key], w, m.expanded)))
+		return
 	case data.Notification:
 		rendered = prview.RenderNotification(r, w)
 	case data.ActionRun:
@@ -1012,12 +1020,21 @@ func (m *Model) syncSidebar() {
 			m.sidebar.SetContent(m.failedPreview(row, err))
 			return
 		}
-		rendered = prview.RenderAction(r, m.actionDetails[key], w)
+		m.sidebar.SetTabs(sidebarTabs(prview.RenderActionTabs(r, m.actionDetails[key], w)))
+		return
 	default:
 		m.sidebar.SetContent("")
 		return
 	}
 	m.sidebar.SetContent(rendered)
+}
+
+func sidebarTabs(tabs []prview.Tab) []sidebar.Tab {
+	out := make([]sidebar.Tab, 0, len(tabs))
+	for _, t := range tabs {
+		out = append(out, sidebar.Tab{Title: t.Title, Content: t.Content})
+	}
+	return out
 }
 
 func (m *Model) setEnrichErr(sectionType, key string, err error) {
@@ -1583,6 +1600,16 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		if m.ctx.PreviewOpen {
 			m.expanded = !m.expanded
 			m.syncSidebar()
+		}
+		return m, nil, true
+	case "prevsidebartab", "previoussidebartab":
+		if m.ctx.PreviewOpen {
+			m.sidebar.PrevTab()
+		}
+		return m, nil, true
+	case "nextsidebartab":
+		if m.ctx.PreviewOpen {
+			m.sidebar.NextTab()
 		}
 		return m, nil, true
 	case "pageup", "scrollup":

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1446,9 +1446,21 @@ func TestActionsPreviewFetchesAndCachesRunDetail(t *testing.T) {
 		t.Fatalf("actionDetails should contain %q after enrichedMsg", key)
 	}
 	view := m.View().Content
-	for _, want := range []string{"Jobs:", "build", "ubuntu-latest", "checkout"} {
+	for _, want := range []string{"Overview", "Jobs", "CI passed", "Workflow:"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("action detail preview missing %q:\n%s", want, view)
+		}
+	}
+	for _, absent := range []string{"Jobs:", "build", "ubuntu-latest", "checkout"} {
+		if strings.Contains(view, absent) {
+			t.Fatalf("action overview tab should not include job detail %q:\n%s", absent, view)
+		}
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: ']', Text: "]"})
+	view = m.View().Content
+	for _, want := range []string{"Jobs:", "build", "ubuntu-latest", "checkout"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("action jobs tab missing %q:\n%s", want, view)
 		}
 	}
 	if runCalls != 1 || jobCalls != 1 {
@@ -1553,6 +1565,103 @@ func TestEnrichedMsgPopulatesSidebar(t *testing.T) {
 	}
 	if strings.Contains(view, "Loading") {
 		t.Fatalf("sidebar should no longer show Loading after enrichment:\n%s", view)
+	}
+}
+
+func TestPreviewSidebarTabsSwitchWithDefaultKeys(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Tabbed PR", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+	key := m.selKey()
+	m.pullDetails[key] = &data.PullDetail{
+		Body:      "overview-token",
+		BaseRef:   "main",
+		HeadRef:   "feature",
+		HeadSHA:   "abc123",
+		Additions: 2, Deletions: 1, ChangedFiles: 1,
+		CI: data.CIStatus{
+			State: data.CIStateFailure,
+			Total: 1,
+			Checks: []data.Check{{
+				Context: "unit-check-token",
+				State:   data.CheckStateFailure,
+			}},
+		},
+		Reviews: []data.Review{{
+			Author: "reviewer-token",
+			State:  data.ReviewStateApproved,
+		}},
+		Comments: []data.Comment{{
+			Author: "commenter-token",
+			Body:   "comment-token",
+		}},
+	}
+	m.syncSidebar()
+
+	view := m.View().Content
+	for _, want := range []string{"Overview", "Checks", "Reviews", "Comments", "overview-token"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("overview tab missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "unit-check-token") {
+		t.Fatalf("overview tab should not include check details before switching tabs:\n%s", view)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: ']', Text: "]"})
+	view = m.View().Content
+	if !strings.Contains(view, "unit-check-token") || strings.Contains(view, "overview-token") {
+		t.Fatalf("next sidebar tab should show checks without overview body:\n%s", view)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: ']', Text: "]"})
+	view = m.View().Content
+	if !strings.Contains(view, "reviewer-token") || strings.Contains(view, "unit-check-token") {
+		t.Fatalf("second next sidebar tab should show reviews only:\n%s", view)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: '[', Text: "["})
+	view = m.View().Content
+	if !strings.Contains(view, "unit-check-token") || strings.Contains(view, "reviewer-token") {
+		t.Fatalf("previous sidebar tab should return to checks:\n%s", view)
+	}
+}
+
+func TestConfiguredNextSidebarTabBuiltinSwitchesPreviewTab(t *testing.T) {
+	cfg := &config.Config{
+		Keybindings: config.Keybindings{
+			PRs: []config.Keybinding{{Key: "T", Builtin: "nextSidebarTab"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 43, Title: "Configured tab key", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+	key := m.selKey()
+	m.pullDetails[key] = &data.PullDetail{
+		Body:    "configured-overview-token",
+		BaseRef: "main",
+		HeadRef: "feature",
+		CI: data.CIStatus{
+			State: data.CIStateSuccess,
+			Total: 1,
+			Checks: []data.Check{{
+				Context: "configured-check-token",
+				State:   data.CheckStateSuccess,
+			}},
+		},
+	}
+	m.syncSidebar()
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'T', Text: "T"})
+	view := m.View().Content
+	if !strings.Contains(view, "configured-check-token") || strings.Contains(view, "configured-overview-token") {
+		t.Fatalf("configured nextSidebarTab key should switch to checks tab:\n%s", view)
 	}
 }
 

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -36,6 +36,13 @@ const (
 	maxActionSteps = 12
 )
 
+// Tab is one rendered preview tab. The UI adapts this to the stateful sidebar
+// component so this pure rendering package stays Bubble Tea-free.
+type Tab struct {
+	Title   string
+	Content string
+}
+
 var (
 	dimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	titleStyle = lipgloss.NewStyle().Bold(true)
@@ -50,26 +57,7 @@ var (
 // string. When detail is nil the body is a "Loading…" placeholder; when present
 // the body is the rendered Markdown, folded to foldLines unless expanded.
 func RenderPull(row data.PullRequest, detail *data.PullDetail, width int, expanded bool) string {
-	var header []string
-	header = append(header,
-		locator(row.RepoNameWithOwner, row.Number),
-		titleLine(row.Title, width),
-	)
-
-	if row.Draft {
-		header = append(header, pill("DRAFT", colDraft))
-	} else {
-		header = append(header, pill(stateLabel(row.State), stateColor(row.State)))
-	}
-
-	if detail != nil {
-		header = append(header,
-			subtleRef.Render(fmt.Sprintf("%s ← %s", detail.BaseRef, detail.HeadRef)),
-			dimStyle.Render(fmt.Sprintf("+%d -%d, %d files",
-				detail.Additions, detail.Deletions, detail.ChangedFiles)),
-		)
-	}
-
+	header := pullHeader(row, detail, width)
 	var body string
 	var extras []string
 	if detail != nil {
@@ -83,15 +71,38 @@ func RenderPull(row data.PullRequest, detail *data.PullDetail, width int, expand
 	return compose(header, body, detail == nil, width, expanded, extras)
 }
 
+// RenderPullTabs renders a pull request preview as gh-dash-style sidebar tabs:
+// overview, checks, reviews, and comments. Loading rows stay as one Overview
+// tab so tab navigation does not cycle through empty placeholders.
+func RenderPullTabs(row data.PullRequest, detail *data.PullDetail, width int, expanded bool) []Tab {
+	if detail == nil {
+		return []Tab{{Title: "Overview", Content: RenderPull(row, nil, width, expanded)}}
+	}
+	header := pullHeader(row, detail, width)
+	checks := renderCI(detail.CI, width)
+	if checks == "" {
+		checks = dimStyle.Render("No checks reported.")
+	}
+	reviews := renderReviews(detail.Reviews)
+	if reviews == "" {
+		reviews = dimStyle.Render("No reviews yet.")
+	}
+	comments := renderComments(detail.Comments, width)
+	if comments == "" {
+		comments = dimStyle.Render("No comments yet.")
+	}
+	return []Tab{
+		{Title: "Overview", Content: compose(header, detail.Body, false, width, expanded, nil)},
+		{Title: "Checks", Content: composePreformatted(header, checks)},
+		{Title: "Reviews", Content: composePreformatted(header, reviews)},
+		{Title: "Comments", Content: composePreformatted(header, comments)},
+	}
+}
+
 // RenderIssue renders an issue row and optional detail into the preview string,
 // mirroring RenderPull without the PR-only base/head and diffstat lines.
 func RenderIssue(row data.Issue, detail *data.IssueDetail, width int, expanded bool) string {
-	header := []string{
-		locator(row.RepoNameWithOwner, row.Number),
-		titleLine(row.Title, width),
-		pill(stateLabel(row.State), stateColor(row.State)),
-	}
-
+	header := issueHeader(row, width)
 	var body string
 	var extras []string
 	if detail != nil {
@@ -99,6 +110,23 @@ func RenderIssue(row data.Issue, detail *data.IssueDetail, width int, expanded b
 		extras = []string{renderComments(detail.Comments, width)}
 	}
 	return compose(header, body, detail == nil, width, expanded, extras)
+}
+
+// RenderIssueTabs renders an issue preview as overview/comments tabs. Loading
+// rows stay as one Overview tab.
+func RenderIssueTabs(row data.Issue, detail *data.IssueDetail, width int, expanded bool) []Tab {
+	if detail == nil {
+		return []Tab{{Title: "Overview", Content: RenderIssue(row, nil, width, expanded)}}
+	}
+	header := issueHeader(row, width)
+	comments := renderComments(detail.Comments, width)
+	if comments == "" {
+		comments = dimStyle.Render("No comments yet.")
+	}
+	return []Tab{
+		{Title: "Overview", Content: compose(header, detail.Body, false, width, expanded, nil)},
+		{Title: "Comments", Content: composePreformatted(header, comments)},
+	}
 }
 
 // RenderNotification renders a notification row into the preview. Notifications
@@ -131,36 +159,8 @@ func RenderAction(row data.ActionRun, detail *data.ActionRunDetail, width int) s
 	if detail != nil {
 		run = mergeActionRun(row, detail.Run)
 	}
-	header := []string{
-		locator(run.RepoNameWithOwner, run.GetNumber()),
-		titleLine(run.GetTitle(), width),
-	}
-	if status := actionRunStatus(run); status != "" {
-		header = append(header, pill(strings.ToUpper(status), actionRunColor(run)))
-	}
-
-	var body []string
-	if run.WorkflowName != "" {
-		body = append(body, "Workflow: "+run.WorkflowName)
-	}
-	if status := actionRunStatus(run); status != "" {
-		body = append(body, "Status: "+status)
-	}
-	if run.Event != "" {
-		body = append(body, "Event: "+run.Event)
-	}
-	if run.Actor != "" {
-		body = append(body, "Actor: @"+run.Actor)
-	}
-	if run.HeadBranch != "" {
-		body = append(body, "Branch: "+run.HeadBranch)
-	}
-	if run.HeadSHA != "" {
-		body = append(body, "SHA: "+shortSHA(run.HeadSHA))
-	}
-	if rel := section.HumanizeTime(run.GetUpdatedAt()); rel != "" {
-		body = append(body, "Updated: "+rel)
-	}
+	header := actionHeader(run, width)
+	body := actionBody(run)
 	if len(body) == 0 {
 		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
 	}
@@ -171,6 +171,27 @@ func RenderAction(row data.ActionRun, detail *data.ActionRunDetail, width int) s
 		extras = []string{renderActionJobs(detail.Jobs, width)}
 	}
 	return compose(header, strings.Join(body, "\n"), false, width, true, extras)
+}
+
+// RenderActionTabs renders an action run preview as overview/jobs tabs.
+func RenderActionTabs(row data.ActionRun, detail *data.ActionRunDetail, width int) []Tab {
+	if detail == nil {
+		return []Tab{{Title: "Overview", Content: RenderAction(row, nil, width)}}
+	}
+	run := mergeActionRun(row, detail.Run)
+	header := actionHeader(run, width)
+	body := actionBody(run)
+	if len(body) == 0 {
+		body = append(body, "Open this action run in Gitea to inspect jobs and logs.")
+	}
+	jobs := renderActionJobs(detail.Jobs, width)
+	if jobs == "" {
+		jobs = dimStyle.Render("No jobs reported.")
+	}
+	return []Tab{
+		{Title: "Overview", Content: compose(header, strings.Join(body, "\n"), false, width, true, nil)},
+		{Title: "Jobs", Content: composePreformatted(header, jobs)},
+	}
 }
 
 // compose joins the header block with the rendered body, then appends any
@@ -196,6 +217,79 @@ func compose(header []string, rawBody string, loading bool, width int, expanded 
 		parts = append(parts, "", e)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func composePreformatted(header []string, body string) string {
+	return lipgloss.JoinVertical(lipgloss.Left,
+		lipgloss.JoinVertical(lipgloss.Left, header...),
+		"",
+		body,
+	)
+}
+
+func pullHeader(row data.PullRequest, detail *data.PullDetail, width int) []string {
+	header := []string{
+		locator(row.RepoNameWithOwner, row.Number),
+		titleLine(row.Title, width),
+	}
+	if row.Draft {
+		header = append(header, pill("DRAFT", colDraft))
+	} else {
+		header = append(header, pill(stateLabel(row.State), stateColor(row.State)))
+	}
+	if detail != nil {
+		header = append(header,
+			subtleRef.Render(fmt.Sprintf("%s ← %s", detail.BaseRef, detail.HeadRef)),
+			dimStyle.Render(fmt.Sprintf("+%d -%d, %d files",
+				detail.Additions, detail.Deletions, detail.ChangedFiles)),
+		)
+	}
+	return header
+}
+
+func issueHeader(row data.Issue, width int) []string {
+	return []string{
+		locator(row.RepoNameWithOwner, row.Number),
+		titleLine(row.Title, width),
+		pill(stateLabel(row.State), stateColor(row.State)),
+	}
+}
+
+func actionHeader(run data.ActionRun, width int) []string {
+	header := []string{
+		locator(run.RepoNameWithOwner, run.GetNumber()),
+		titleLine(run.GetTitle(), width),
+	}
+	if status := actionRunStatus(run); status != "" {
+		header = append(header, pill(strings.ToUpper(status), actionRunColor(run)))
+	}
+	return header
+}
+
+func actionBody(run data.ActionRun) []string {
+	var body []string
+	if run.WorkflowName != "" {
+		body = append(body, "Workflow: "+run.WorkflowName)
+	}
+	if status := actionRunStatus(run); status != "" {
+		body = append(body, "Status: "+status)
+	}
+	if run.Event != "" {
+		body = append(body, "Event: "+run.Event)
+	}
+	if run.Actor != "" {
+		body = append(body, "Actor: @"+run.Actor)
+	}
+	if run.HeadBranch != "" {
+		body = append(body, "Branch: "+run.HeadBranch)
+	}
+	if run.HeadSHA != "" {
+		body = append(body, "SHA: "+shortSHA(run.HeadSHA))
+	}
+	if rel := section.HumanizeTime(run.GetUpdatedAt()); rel != "" {
+		body = append(body, "Updated: "+rel)
+	}
+	return body
 }
 
 // foldBody truncates a rendered body to foldLines (plus a hint) unless expanded

--- a/internal/ui/components/prview/prview_test.go
+++ b/internal/ui/components/prview/prview_test.go
@@ -153,6 +153,86 @@ func TestRenderPullCommentsCIReviews(t *testing.T) {
 	}
 }
 
+func TestRenderPullTabsSeparatesOverviewChecksReviewsAndComments(t *testing.T) {
+	detail := &data.PullDetail{
+		Body:    "overview-tab-token",
+		BaseRef: "main",
+		HeadRef: "feature",
+		CI: data.CIStatus{
+			State: data.CIStateFailure,
+			Checks: []data.Check{{
+				Context: "checks-tab-token",
+				State:   data.CheckStateFailure,
+			}},
+		},
+		Reviews: []data.Review{{
+			Author: "reviews-tab-token",
+			State:  data.ReviewStateApproved,
+		}},
+		Comments: []data.Comment{{
+			Author: "comments-author-token",
+			Body:   "comments-tab-token",
+		}},
+	}
+
+	tabs := RenderPullTabs(samplePull(), detail, 60, false)
+	if len(tabs) != 4 {
+		t.Fatalf("len(RenderPullTabs) = %d, want 4 tabs: %+v", len(tabs), tabs)
+	}
+	wantTitles := []string{"Overview", "Checks", "Reviews", "Comments"}
+	for i, want := range wantTitles {
+		if tabs[i].Title != want {
+			t.Fatalf("tab %d title = %q, want %q", i, tabs[i].Title, want)
+		}
+	}
+	if !strings.Contains(tabs[0].Content, "overview-tab-token") ||
+		strings.Contains(tabs[0].Content, "checks-tab-token") ||
+		strings.Contains(tabs[0].Content, "reviews-tab-token") ||
+		strings.Contains(tabs[0].Content, "comments-tab-token") {
+		t.Fatalf("overview tab should contain only overview detail:\n%s", tabs[0].Content)
+	}
+	if !strings.Contains(tabs[1].Content, "checks-tab-token") || strings.Contains(tabs[1].Content, "overview-tab-token") {
+		t.Fatalf("checks tab should contain checks only:\n%s", tabs[1].Content)
+	}
+	if !strings.Contains(tabs[2].Content, "reviews-tab-token") || strings.Contains(tabs[2].Content, "checks-tab-token") {
+		t.Fatalf("reviews tab should contain reviews only:\n%s", tabs[2].Content)
+	}
+	if !strings.Contains(tabs[3].Content, "comments-tab-token") || strings.Contains(tabs[3].Content, "reviews-tab-token") {
+		t.Fatalf("comments tab should contain comments only:\n%s", tabs[3].Content)
+	}
+}
+
+func TestRenderIssueTabsSeparatesOverviewAndComments(t *testing.T) {
+	row := data.Issue{
+		Number:            7,
+		Title:             "Something broke",
+		RepoNameWithOwner: "gbarany/tea-dash",
+		State:             "open",
+	}
+	tabs := RenderIssueTabs(row, &data.IssueDetail{
+		Body: "issue-overview-token",
+		Comments: []data.Comment{{
+			Author: "issue-commenter-token",
+			Body:   "issue-comment-token",
+		}},
+	}, 60, false)
+
+	if len(tabs) != 2 {
+		t.Fatalf("len(RenderIssueTabs) = %d, want 2 tabs: %+v", len(tabs), tabs)
+	}
+	if tabs[0].Title != "Overview" || tabs[1].Title != "Comments" {
+		t.Fatalf("issue tab titles = %+v, want Overview/Comments", tabs)
+	}
+	if !strings.Contains(tabs[0].Content, "issue-overview-token") ||
+		strings.Contains(tabs[0].Content, "issue-comment-token") {
+		t.Fatalf("issue overview tab should not include comments:\n%s", tabs[0].Content)
+	}
+	if !strings.Contains(tabs[1].Content, "issue-comment-token") ||
+		strings.Contains(tabs[1].Content, "issue-overview-token") {
+		t.Fatalf("issue comments tab should not include overview body:\n%s", tabs[1].Content)
+	}
+}
+
 // TestRenderIssueSingleComment verifies the issue comments block uses the
 // singular "1 comment" header and shows the comment body.
 func TestRenderIssueSingleComment(t *testing.T) {

--- a/internal/ui/components/sidebar/sidebar.go
+++ b/internal/ui/components/sidebar/sidebar.go
@@ -1,7 +1,6 @@
-// Package sidebar is a dumb, scrollable preview pane: a viewport wrapper that
-// renders a pre-formatted string and offers half-page scrolling plus a
-// bottom-right scroll indicator. It owns no content of its own — callers push a
-// rendered string via SetContent — and it draws nothing while the preview is
+// Package sidebar is a scrollable preview pane: a viewport wrapper that renders
+// pre-formatted content, optionally split into tabs, with half-page scrolling
+// and a bottom-right scroll indicator. It draws nothing while the preview is
 // closed.
 package sidebar
 
@@ -17,8 +16,17 @@ import (
 
 // Model wraps a viewport bound to the shared program context.
 type Model struct {
-	vp  viewport.Model
-	ctx *context.ProgramContext
+	vp      viewport.Model
+	ctx     *context.ProgramContext
+	tabs    []Tab
+	tab     int
+	content string
+}
+
+// Tab is one selectable sidebar page.
+type Tab struct {
+	Title   string
+	Content string
 }
 
 // New builds a sidebar sized to the context's current preview dimensions.
@@ -31,12 +39,49 @@ func New(ctx *context.ProgramContext) Model {
 // SetContent replaces the previewed text and scrolls back to the top so a newly
 // selected row starts at its header.
 func (m *Model) SetContent(s string) {
-	m.vp.SetContent(s)
+	m.SetTabs([]Tab{{Title: "Overview", Content: s}})
+}
+
+// SetTabs replaces the preview tabs and scrolls back to the top. Empty tabs
+// clear the viewport.
+func (m *Model) SetTabs(tabs []Tab) {
+	m.tabs = compactTabs(tabs)
+	m.tab = 0
+	m.resize()
+	m.syncViewport()
 	m.vp.GotoTop()
 }
 
 // ScrollToTop resets the viewport to the first line.
 func (m *Model) ScrollToTop() { m.vp.GotoTop() }
+
+// CurrentTabTitle returns the selected tab title, or "" when no tab exists.
+func (m Model) CurrentTabTitle() string {
+	if len(m.tabs) == 0 || m.tab < 0 || m.tab >= len(m.tabs) {
+		return ""
+	}
+	return m.tabs[m.tab].Title
+}
+
+// NextTab selects the next sidebar tab, wrapping at the end.
+func (m *Model) NextTab() {
+	if len(m.tabs) <= 1 {
+		return
+	}
+	m.tab = (m.tab + 1) % len(m.tabs)
+	m.syncViewport()
+	m.vp.GotoTop()
+}
+
+// PrevTab selects the previous sidebar tab, wrapping at the beginning.
+func (m *Model) PrevTab() {
+	if len(m.tabs) <= 1 {
+		return
+	}
+	m.tab = (m.tab - 1 + len(m.tabs)) % len(m.tabs)
+	m.syncViewport()
+	m.vp.GotoTop()
+}
 
 // Update handles only half-page scrolling (ctrl+u / ctrl+d); every other
 // message is ignored so the pane never steals navigation or quit keys.
@@ -71,20 +116,74 @@ func (m Model) View() string {
 		Width(m.ctx.PreviewWidth).
 		Align(lipgloss.Right).
 		Render(pct)
-	return lipgloss.JoinVertical(lipgloss.Left, m.vp.View(), indicator)
+	parts := []string{}
+	if tabs := m.tabBar(); tabs != "" {
+		parts = append(parts, tabs)
+	}
+	parts = append(parts, m.vp.View(), indicator)
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
 // resize sizes the viewport to the preview area, reserving one row for the
-// scroll indicator so View()'s total height stays within PreviewHeight.
+// scroll indicator and, when present, one row for tabs so View()'s total height
+// stays within PreviewHeight.
 func (m *Model) resize() {
 	w := m.ctx.PreviewWidth
 	if w < 0 {
 		w = 0
 	}
 	h := m.ctx.PreviewHeight - 1 // reserve the last row for the scroll indicator
+	if len(m.tabs) > 1 {
+		h--
+	}
 	if h < 1 {
 		h = 1
 	}
 	m.vp.SetWidth(w)
 	m.vp.SetHeight(h)
+}
+
+func (m *Model) syncViewport() {
+	if len(m.tabs) == 0 {
+		m.content = ""
+		m.vp.SetContent("")
+		return
+	}
+	if m.tab < 0 || m.tab >= len(m.tabs) {
+		m.tab = 0
+	}
+	m.content = m.tabs[m.tab].Content
+	m.vp.SetContent(m.content)
+}
+
+func (m Model) tabBar() string {
+	if len(m.tabs) <= 1 {
+		return ""
+	}
+	parts := make([]string, 0, len(m.tabs)*2-1)
+	for i, t := range m.tabs {
+		if i > 0 {
+			parts = append(parts, m.ctx.Styles.TabSeparator.Render(" "))
+		}
+		style := m.ctx.Styles.Tab
+		if i == m.tab {
+			style = m.ctx.Styles.ActiveTab
+		}
+		parts = append(parts, style.Render(t.Title))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, parts...)
+}
+
+func compactTabs(tabs []Tab) []Tab {
+	out := make([]Tab, 0, len(tabs))
+	for _, t := range tabs {
+		if t.Title == "" && t.Content == "" {
+			continue
+		}
+		if t.Title == "" {
+			t.Title = "Preview"
+		}
+		out = append(out, t)
+	}
+	return out
 }

--- a/internal/ui/components/sidebar/sidebar_test.go
+++ b/internal/ui/components/sidebar/sidebar_test.go
@@ -68,3 +68,42 @@ func TestCtrlDScrolls(t *testing.T) {
 		t.Fatalf("ctrl+d did not advance scroll: before=%v after=%v", before, after)
 	}
 }
+
+func TestTabsSwitchContent(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+
+	view := m.View()
+	for _, want := range []string{"Overview", "Checks", "overview-token"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("initial tab view missing %q:\n%s", want, view)
+		}
+	}
+
+	m.NextTab()
+	if got := m.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("CurrentTabTitle after NextTab = %q, want Checks", got)
+	}
+	view = m.View()
+	if !strings.Contains(view, "checks-token") || strings.Contains(view, "overview-token") {
+		t.Fatalf("next tab should show checks content only:\n%s", view)
+	}
+
+	m.PrevTab()
+	if got := m.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("CurrentTabTitle after PrevTab = %q, want Overview", got)
+	}
+	view = m.View()
+	if !strings.Contains(view, "overview-token") || strings.Contains(view, "checks-token") {
+		t.Fatalf("prev tab should show overview content only:\n%s", view)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -11,50 +11,52 @@ import (
 // keyMap defines the app-level key bindings. Row navigation is also forwarded
 // to the underlying table widget so configurable builtins reuse table behavior.
 type keyMap struct {
-	Refresh       key.Binding
-	RefreshAll    key.Binding
-	Open          key.Binding
-	Quit          key.Binding
-	Up            key.Binding
-	Down          key.Binding
-	NextSection   key.Binding
-	PrevSection   key.Binding
-	SwitchView    key.Binding
-	Search        key.Binding
-	TogglePreview key.Binding
-	ToggleSmart   key.Binding
-	ScrollUp      key.Binding
-	ScrollDown    key.Binding
-	Expand        key.Binding
-	Comment       key.Binding
-	Assign        key.Binding
-	Unassign      key.Binding
-	Subscribe     key.Binding
-	Unsubscribe   key.Binding
-	AddLabel      key.Binding
-	RemoveLabel   key.Binding
-	Milestone     key.Binding
-	Merge         key.Binding
-	UpdateBranch  key.Binding
-	MarkReady     key.Binding
-	WatchChecks   key.Binding
-	Close         key.Binding
-	Reopen        key.Binding
-	Review        key.Binding
-	ExternalDiff  key.Binding
-	Checkout      key.Binding
-	PushBranch    key.Binding
-	DeleteBranch  key.Binding
-	RerunRun      key.Binding
-	CancelRun     key.Binding
-	CopyNumber    key.Binding
-	CopyURL       key.Binding
-	Help          key.Binding
-	MarkRead      key.Binding
-	MarkUnread    key.Binding
-	MarkAllRead   key.Binding
-	Pin           key.Binding
-	Unpin         key.Binding
+	Refresh        key.Binding
+	RefreshAll     key.Binding
+	Open           key.Binding
+	Quit           key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	NextSection    key.Binding
+	PrevSection    key.Binding
+	SwitchView     key.Binding
+	Search         key.Binding
+	TogglePreview  key.Binding
+	ToggleSmart    key.Binding
+	ScrollUp       key.Binding
+	ScrollDown     key.Binding
+	PrevSidebarTab key.Binding
+	NextSidebarTab key.Binding
+	Expand         key.Binding
+	Comment        key.Binding
+	Assign         key.Binding
+	Unassign       key.Binding
+	Subscribe      key.Binding
+	Unsubscribe    key.Binding
+	AddLabel       key.Binding
+	RemoveLabel    key.Binding
+	Milestone      key.Binding
+	Merge          key.Binding
+	UpdateBranch   key.Binding
+	MarkReady      key.Binding
+	WatchChecks    key.Binding
+	Close          key.Binding
+	Reopen         key.Binding
+	Review         key.Binding
+	ExternalDiff   key.Binding
+	Checkout       key.Binding
+	PushBranch     key.Binding
+	DeleteBranch   key.Binding
+	RerunRun       key.Binding
+	CancelRun      key.Binding
+	CopyNumber     key.Binding
+	CopyURL        key.Binding
+	Help           key.Binding
+	MarkRead       key.Binding
+	MarkUnread     key.Binding
+	MarkAllRead    key.Binding
+	Pin            key.Binding
+	Unpin          key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -114,6 +116,14 @@ func defaultKeyMap() keyMap {
 		ScrollDown: key.NewBinding(
 			key.WithKeys("ctrl+d"),
 			key.WithHelp("ctrl+d", "scroll preview down"),
+		),
+		PrevSidebarTab: key.NewBinding(
+			key.WithKeys("["),
+			key.WithHelp("[", "previous preview tab"),
+		),
+		NextSidebarTab: key.NewBinding(
+			key.WithKeys("]"),
+			key.WithHelp("]", "next preview tab"),
 		),
 		Expand: key.NewBinding(
 			key.WithKeys("e"),
@@ -284,6 +294,10 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.ScrollUp = binding(keyName, "scroll preview up")
 	case "pagedown", "scrolldown":
 		k.ScrollDown = binding(keyName, "scroll preview down")
+	case "prevsidebartab", "previoussidebartab":
+		k.PrevSidebarTab = binding(keyName, "previous preview tab")
+	case "nextsidebartab":
+		k.NextSidebarTab = binding(keyName, "next preview tab")
 	case "summaryviewmore", "expand":
 		k.Expand = binding(keyName, "expand")
 	case "comment":


### PR DESCRIPTION
## Summary
- Split previews into gh-dash-style sidebar tabs for PRs, issues, and Actions.
- Add default [ / ] preview tab navigation plus configurable PR builtins: prevSidebarTab and nextSidebarTab.
- Update README and example config with the new tab navigation bindings.

## Verification
- focused sidebar/keybinding tests: go test ./internal/config ./internal/ui ./internal/ui/components/prview ./internal/ui/components/sidebar -run 'Sidebar|Preview|Keybinding|Keybindings|Tab|Tabs|Builtin' -count=1 -v
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build