### PR TITLE
feat(actions): open job logs in pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ tea-dash --help
 | `P`             | push branch in Branches view   |
 | `f` / `F`       | fast-forward / force-push branch in Branches view |
 | `d` / `backspace` | delete branch in Branches view |
-| `R` / `!`       | rerun / cancel Actions run |
+| `L` / `R` / `!` | view logs / rerun / cancel Actions run |
 | `r` / `R`       | refresh section / all sections (`ctrl+r` refreshes all in Actions view) |
 | `?`             | show / hide full help   |
 | `q` / `ctrl+c`  | quit                    |
@@ -288,6 +288,8 @@ keybindings:
     - key: D
       builtin: markAllRead
   actions:
+    - key: L
+      builtin: viewLogs
     - key: a
       command: echo run {{.RunID}} in {{.RepoName}}
   branches:

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -119,6 +119,8 @@ keybindings:
     - key: D
       builtin: markAllRead
   actions:
+    - key: L
+      builtin: viewLogs
     - key: R
       builtin: rerun
   branches:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -42,6 +42,8 @@ type Client interface {
 	MarkPullDraft(owner, repo string, index int64) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
+	ListActionJobs(ctx context.Context, owner, repo string, runID int64) ([]data.ActionJob, error)
+	GetActionJobLogs(ctx context.Context, owner, repo string, jobID int64) ([]byte, error)
 	RerunActionRun(ctx context.Context, owner, repo string, runID int64) error
 	CancelActionRun(ctx context.Context, owner, repo string, runID int64) error
 }
@@ -176,6 +178,9 @@ func (r Runner) Dispatch(intent uiactions.Intent) tea.Cmd {
 	if intent.Kind == uiactions.KindExternalDiff {
 		return r.dispatchExternalDiff(intent)
 	}
+	if intent.Kind == uiactions.KindViewLogs {
+		return r.dispatchActionLogs(intent)
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
@@ -211,6 +216,45 @@ func (r Runner) dispatchExternalDiff(intent uiactions.Intent) tea.Cmd {
 				Intent:  intent,
 				Status:  uiactions.ResultSucceeded,
 				Message: fmt.Sprintf("Viewed diff for %s#%d.", intent.Target.Repo, intent.Target.Number),
+			}
+		})()
+	}
+}
+
+func (r Runner) dispatchActionLogs(intent uiactions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		if r.client == nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("%s is unavailable: no Gitea client", actionLabel(intent.Kind))}
+		}
+		owner, repo, err := splitRepo(intent.Target.Repo)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		runID := targetRunID(intent.Target)
+		jobs, err := r.client.ListActionJobs(ctx, owner, repo, runID)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		if len(jobs) == 0 {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("no jobs found for %s run #%d", intent.Target.Repo, intent.Target.Number)}
+		}
+		job := jobs[0]
+		logs, err := r.client.GetActionJobLogs(ctx, owner, repo, job.ID)
+		if err != nil {
+			return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: err}
+		}
+		command := r.cfg.Pager.DiffCommand()
+		cmd := shell.BuildExecCommand(command, logs, r.cwd)
+		return r.execProcess(cmd, func(err error) tea.Msg {
+			if err != nil {
+				return uiactions.ResultMsg{Intent: intent, Status: uiactions.ResultErrored, Err: fmt.Errorf("run logs pager %q: %w", command, err)}
+			}
+			return uiactions.ResultMsg{
+				Intent:  intent,
+				Status:  uiactions.ResultSucceeded,
+				Message: fmt.Sprintf("Viewed logs for %s run #%d job %s.", intent.Target.Repo, intent.Target.Number, displayJobName(job)),
 			}
 		})()
 	}
@@ -497,6 +541,13 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 	}
 }
 
+func displayJobName(job data.ActionJob) string {
+	if strings.TrimSpace(job.Name) != "" {
+		return job.Name
+	}
+	return fmt.Sprintf("#%d", job.ID)
+}
+
 type customCommandContext struct {
 	RepoName    string
 	RepoPath    string
@@ -716,6 +767,8 @@ func actionLabel(kind uiactions.Kind) string {
 		return "rerun"
 	case uiactions.KindCancelRun:
 		return "cancel run"
+	case uiactions.KindViewLogs:
+		return "view logs"
 	default:
 		return string(kind)
 	}

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -357,6 +357,50 @@ func TestDispatchExternalDiffRunsConfiguredPager(t *testing.T) {
 	}
 }
 
+func TestDispatchActionLogsOpensFirstJobLogInPager(t *testing.T) {
+	client := &fakeClient{logBytes: []byte("job log token\n")}
+	execProcess := &fakeExecProcess{}
+	r := New(Options{
+		Client:      client,
+		Config:      &config.Config{Pager: config.Pager{Diff: "less -R"}},
+		CWD:         "/tmp/repo",
+		ExecProcess: execProcess.Run,
+	})
+
+	got := runDispatch(t, r, actionRunIntent(uiactions.KindViewLogs))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("logs result = %+v", got)
+	}
+	if client.listJobsRunID != 101 || client.logJobID != 201 {
+		t.Fatalf("listJobsRunID=%d logJobID=%d, want run 101 job 201", client.listJobsRunID, client.logJobID)
+	}
+	if execProcess.cmd == nil {
+		t.Fatal("exec process was not called")
+	}
+	if !reflect.DeepEqual(execProcess.cmd.Args[1:], []string{"-c", "less -R"}) {
+		t.Fatalf("shell args = %#v, want shell -c less -R", execProcess.cmd.Args)
+	}
+	stdin, err := io.ReadAll(execProcess.cmd.Stdin)
+	if err != nil {
+		t.Fatalf("read pager stdin: %v", err)
+	}
+	if string(stdin) != "job log token\n" || execProcess.cmd.Dir != "/tmp/repo" {
+		t.Fatalf("exec command stdin=%q dir=%q, want logs in /tmp/repo", string(stdin), execProcess.cmd.Dir)
+	}
+	if !strings.Contains(got.Message, "Viewed logs for acme/widgets run #77 job build") {
+		t.Fatalf("message = %q, want logs confirmation", got.Message)
+	}
+}
+
+func TestDispatchActionLogsErrorsWhenRunHasNoJobs(t *testing.T) {
+	client := &fakeClient{jobs: []data.ActionJob{}}
+	got := runDispatch(t, New(Options{Client: client}), actionRunIntent(uiactions.KindViewLogs))
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "no jobs found") {
+		t.Fatalf("logs result = %+v, want no-jobs error", got)
+	}
+}
+
 func TestDispatchCustomCommandRendersSelectedRowTemplate(t *testing.T) {
 	execProcess := &fakeExecProcess{}
 	r := New(Options{
@@ -612,6 +656,10 @@ type fakeClient struct {
 	markReady        int64
 	markDraft        int64
 	diff             []byte
+	jobs             []data.ActionJob
+	listJobsRunID    int64
+	logJobID         int64
+	logBytes         []byte
 	rerunRunID       int64
 	cancelRunID      int64
 	assignPull       int64
@@ -719,6 +767,19 @@ func (f *fakeClient) MarkPullDraft(_, _ string, index int64) (bool, error) {
 
 func (f *fakeClient) GetPullDiff(_, _ string, _ int64) ([]byte, error) {
 	return f.diff, f.err
+}
+
+func (f *fakeClient) ListActionJobs(_ context.Context, _, _ string, runID int64) ([]data.ActionJob, error) {
+	f.listJobsRunID = runID
+	if f.jobs != nil {
+		return f.jobs, f.err
+	}
+	return []data.ActionJob{{ID: 201, RunID: runID, Name: "build"}}, f.err
+}
+
+func (f *fakeClient) GetActionJobLogs(_ context.Context, _, _ string, jobID int64) ([]byte, error) {
+	f.logJobID = jobID
+	return f.logBytes, f.err
 }
 
 func (f *fakeClient) RerunActionRun(_ context.Context, _, _ string, runID int64) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -466,7 +466,7 @@ var notificationBuiltins = builtinSet(
 	"markAllAsDone", "markAllDone", "pin", "unpin", "togglePin", "togglePinned", "toggleBookmark",
 )
 
-var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun")
+var actionBuiltins = builtinSet("rerun", "rerunRun", "cancel", "cancelRun", "logs", "viewLogs")
 
 var branchBuiltins = builtinSet("checkout", "push", "forcePush", "fastForward", "delete")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -446,6 +446,8 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "U", Builtin: "removeLabel"},
 	}, Notifications: []Keybinding{
 		{Key: "b", Builtin: "toggleBookmark"},
+	}, Actions: []Keybinding{
+		{Key: "L", Builtin: "viewLogs"},
 	}, Branches: []Keybinding{
 		{Key: "P", Builtin: "push"},
 		{Key: "F", Builtin: "forcePush"},

--- a/internal/gitea/actions.go
+++ b/internal/gitea/actions.go
@@ -142,6 +142,15 @@ func (c *Client) ListActionJobs(ctx context.Context, owner, repo string, runID i
 	return jobs, nil
 }
 
+// GetActionJobLogs downloads the plain-text log payload for one Actions job.
+func (c *Client) GetActionJobLogs(ctx context.Context, owner, repo string, jobID int64) ([]byte, error) {
+	body, _, err := c.rawGetBytes(ctx, actionJobLogsPath(owner, repo, jobID), "text/plain, */*")
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
 // RerunActionRun asks the server to rerun one repo-scoped Actions workflow run.
 func (c *Client) RerunActionRun(ctx context.Context, owner, repo string, runID int64) error {
 	if err := c.rawPost(ctx, actionRunControlPath(owner, repo, runID, "rerun")); err != nil {
@@ -328,6 +337,10 @@ func actionRunPath(owner, repo string, runID int64) string {
 
 func actionJobsPath(owner, repo string, runID int64) string {
 	return actionRunPath(owner, repo, runID) + "/jobs"
+}
+
+func actionJobLogsPath(owner, repo string, jobID int64) string {
+	return "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/actions/jobs/" + strconv.FormatInt(jobID, 10) + "/logs"
 }
 
 func actionRunControlPath(owner, repo string, runID int64, control string) string {

--- a/internal/gitea/actions_test.go
+++ b/internal/gitea/actions_test.go
@@ -211,6 +211,40 @@ func TestListActionJobsMapsWrappedResponse(t *testing.T) {
 	}
 }
 
+func TestGetActionJobLogsDownloadsPlainText(t *testing.T) {
+	const want = "log line one\nlog line two\n"
+	var called bool
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/jobs/201/logs", func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("method = %s, want GET", r.Method)
+			}
+			if r.Header.Get("Authorization") != "token t" {
+				t.Fatalf("Authorization header = %q, want token auth", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, want)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	got, err := c.GetActionJobLogs(context.Background(), "acme", "widgets", 201)
+	if err != nil {
+		t.Fatalf("GetActionJobLogs: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("logs = %q, want %q", string(got), want)
+	}
+	if !called {
+		t.Fatal("logs endpoint was not called")
+	}
+}
+
 func TestRerunActionRunPostsRunControlEndpoint(t *testing.T) {
 	called := false
 	srv := actionServer(t, func(mux *http.ServeMux) {

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -497,6 +497,36 @@ func (c *Client) rawGet(ctx context.Context, path string, out any) (http.Header,
 	return resp.Header, nil
 }
 
+// rawGetBytes issues an authenticated GET against {baseURL}/api/v1{path} and
+// returns the response body without JSON decoding it. It is used for endpoints
+// such as Actions job logs that serve text/plain or archive payloads.
+func (c *Client) rawGetBytes(ctx context.Context, path string, accept string) ([]byte, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1"+path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Authorization", "token "+c.token)
+	if accept == "" {
+		accept = "*/*"
+	}
+	req.Header.Set("Accept", accept)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, nil, fmt.Errorf("gitea GET %s: %s: %s", path, resp.Status, truncate(body, 500))
+	}
+	return body, resp.Header, nil
+}
+
 // rawPost issues an authenticated POST against {baseURL}/api/v1{path} using the
 // shared HTTP client and token. It accepts any 2xx response and ignores the
 // body, which matches control endpoints that often return 202 or 204.

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -30,6 +30,7 @@ const (
 	KindDeleteBranch      Kind = "delete_branch"
 	KindRerunRun          Kind = "rerun_run"
 	KindCancelRun         Kind = "cancel_run"
+	KindViewLogs          Kind = "view_logs"
 	KindCustomCommand     Kind = "custom_command"
 )
 

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -25,6 +25,7 @@ func TestKindConstants(t *testing.T) {
 		KindDeleteBranch:      "delete_branch",
 		KindRerunRun:          "rerun_run",
 		KindCancelRun:         "cancel_run",
+		KindViewLogs:          "view_logs",
 	}
 	for got, want := range tests {
 		if string(got) != want {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -468,6 +468,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindRerunRun)
 		case !m.scopedBuiltinOverridden("cancel") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.CancelRun):
 			return m, m.startAction(actions.KindCancelRun)
+		case !m.scopedBuiltinOverridden("logs") && m.ctx.View == context.ActionsView && key.Matches(msg, m.keys.ViewLogs):
+			return m, m.startAction(actions.KindViewLogs)
 		case !m.scopedBuiltinOverridden("comment") && key.Matches(msg, m.keys.Comment):
 			return m, m.startAction(actions.KindComment)
 		case !m.scopedBuiltinOverridden("assign") && key.Matches(msg, m.keys.Assign):
@@ -726,6 +728,7 @@ func (m Model) actionButtons() []actionButton {
 		buttons = append(buttons, actionButton{Label: "All read", Builtin: "markAllRead"})
 	case context.ActionsView:
 		buttons = append(buttons,
+			actionButton{Label: "Logs", Builtin: "viewLogs"},
 			actionButton{Label: "Rerun", Builtin: "rerun"},
 			actionButton{Label: "Cancel", Builtin: "cancel"},
 		)
@@ -1706,6 +1709,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindRerunRun), true
 	case "cancel", "cancelrun":
 		return m, m.startAction(actions.KindCancelRun), true
+	case "logs", "viewlogs":
+		return m, m.startAction(actions.KindViewLogs), true
 	default:
 		m.notice = fmt.Sprintf("Unknown builtin keybinding %q.", binding.Builtin)
 		return m, nil, true
@@ -1852,7 +1857,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 		if target.RowKind != actions.RowKindIssue {
 			return fmt.Errorf("%s is only available for issues.", actionLabel(kind))
 		}
-	case actions.KindRerunRun, actions.KindCancelRun:
+	case actions.KindRerunRun, actions.KindCancelRun, actions.KindViewLogs:
 		if target.RowKind != actions.RowKindActionRun {
 			return fmt.Errorf("%s is only available for action runs.", actionLabel(kind))
 		}
@@ -1868,6 +1873,7 @@ func validateActionTarget(kind actions.Kind, target actions.Target) error {
 
 func actionDispatchesDirectly(kind actions.Kind) bool {
 	return kind == actions.KindRerunRun ||
+		kind == actions.KindViewLogs ||
 		kind == actions.KindSubscribe ||
 		kind == actions.KindUnsubscribe ||
 		kind == actions.KindExternalDiff
@@ -2010,6 +2016,8 @@ func actionLabel(kind actions.Kind) string {
 		return "Rerun"
 	case actions.KindCancelRun:
 		return "Cancel run"
+	case actions.KindViewLogs:
+		return "View logs"
 	case actions.KindCustomCommand:
 		return "Custom command"
 	default:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2341,6 +2341,25 @@ func TestBranchActionButtonsIncludeLocalOps(t *testing.T) {
 	}
 }
 
+func TestActionsActionButtonsIncludeRunControlsAndLogs(t *testing.T) {
+	m := New(&config.Config{Defaults: config.Defaults{View: "actions"}}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, actionFetchedMsg([]data.ActionRun{{
+		ID: 101, RunNumber: 77, DisplayTitle: "Action row", WorkflowName: "CI",
+		RepoNameWithOwner: "gbarany/tea-dash",
+	}}))
+
+	found := map[string]bool{}
+	for _, b := range m.actionButtons() {
+		found[b.Label] = true
+	}
+	for _, label := range []string{"Logs", "Rerun", "Cancel"} {
+		if !found[label] {
+			t.Fatalf("actions action button %q not found in %+v", label, m.actionButtons())
+		}
+	}
+}
+
 func TestActionsViewRunControlKeysDispatchExpectedIntents(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -2353,6 +2372,12 @@ func TestActionsViewRunControlKeysDispatchExpectedIntents(t *testing.T) {
 			name:   "rerun",
 			key:    tea.KeyPressMsg{Code: 'R', Text: "R"},
 			kind:   actions.KindRerunRun,
+			direct: true,
+		},
+		{
+			name:   "logs",
+			key:    tea.KeyPressMsg{Code: 'L', Text: "L"},
+			kind:   actions.KindViewLogs,
 			direct: true,
 		},
 		{

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -51,6 +51,7 @@ type keyMap struct {
 	DeleteBranch      key.Binding
 	RerunRun          key.Binding
 	CancelRun         key.Binding
+	ViewLogs          key.Binding
 	CopyNumber        key.Binding
 	CopyURL           key.Binding
 	Help              key.Binding
@@ -223,6 +224,10 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("!"),
 			key.WithHelp("!", "cancel run"),
 		),
+		ViewLogs: key.NewBinding(
+			key.WithKeys("L"),
+			key.WithHelp("L", "view logs"),
+		),
 		CopyNumber: key.NewBinding(
 			key.WithKeys("y"),
 			key.WithHelp("y", "copy number"),
@@ -356,6 +361,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.RerunRun = binding(keyName, "rerun")
 	case "cancel", "cancelrun":
 		k.CancelRun = binding(keyName, "cancel run")
+	case "logs", "viewlogs":
+		k.ViewLogs = binding(keyName, "view logs")
 	case "copyurl":
 		k.CopyURL = binding(keyName, "copy URL")
 	case "copynumber":


### PR DESCRIPTION
## Summary
- add an Actions view `L` hotkey and clickable `Logs` action for viewing job logs
- download Actions job logs via the Gitea/Forgejo API and pipe them to the configured pager
- document the `viewLogs` scoped builtin in README and the example config

## Test Plan
- `git diff --check HEAD~1..HEAD`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`