### PR TITLE
feat(prs): request reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ tea-dash --help
 | `u`             | update PR branch from its base branch |
 | `W`             | mark draft PR ready for review |
 | `w`             | show/watch PR checks in the Actions view |
+| `@`             | request PR review from one or more users |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `b` / `B`       | pin / unpin notification |
 | `x` / `X`       | close / reopen          |
@@ -252,6 +253,8 @@ keybindings:
       builtin: ready
     - key: w
       builtin: watchChecks
+    - key: "@"
+      builtin: requestReviewers
     - key: "["
       builtin: prevSidebarTab
     - key: "]"

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -102,6 +102,8 @@ keybindings:
       builtin: addLabel
     - key: U
       builtin: removeLabel
+    - key: "@"
+      builtin: requestReviewers
     - key: "["
       builtin: prevSidebarTab
     - key: "]"

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -41,6 +41,7 @@ type Client interface {
 	MarkPullReady(owner, repo string, index int64) (bool, error)
 	MarkPullDraft(owner, repo string, index int64) (bool, error)
 	SubmitPullReview(owner, repo string, index int64, opt data.PullReviewOptions) (data.Review, error)
+	RequestPullReviewers(owner, repo string, index int64, reviewers []string) error
 	GetPullDiff(owner, repo string, index int64) ([]byte, error)
 	ListActionJobs(ctx context.Context, owner, repo string, runID int64) ([]data.ActionJob, error)
 	GetActionJobLogs(ctx context.Context, owner, repo string, jobID int64) ([]byte, error)
@@ -462,6 +463,16 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		return fmt.Sprintf("Submitted review for %s#%d.", intent.Target.Repo, index), nil
 
+	case uiactions.KindRequestReviewers:
+		reviewers, err := parseReviewerNames(intent.Prompt.Value)
+		if err != nil {
+			return "", err
+		}
+		if err := r.client.RequestPullReviewers(owner, repo, index, reviewers); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Requested review from %s on %s#%d.", strings.Join(reviewers, ", "), intent.Target.Repo, index), nil
+
 	case uiactions.KindUpdateBranch:
 		if err := r.client.UpdatePullRequest(owner, repo, index); err != nil {
 			return "", err
@@ -650,6 +661,14 @@ func (r Runner) setIssueSubscription(owner, repo string, index int64, kind uiact
 }
 
 func parseLabelNames(input string) ([]string, error) {
+	return parseCommaList(input, "label names")
+}
+
+func parseReviewerNames(input string) ([]string, error) {
+	return parseCommaList(input, "reviewer usernames")
+}
+
+func parseCommaList(input, itemName string) ([]string, error) {
 	parts := strings.Split(input, ",")
 	out := make([]string, 0, len(parts))
 	seen := map[string]bool{}
@@ -662,7 +681,7 @@ func parseLabelNames(input string) ([]string, error) {
 		out = append(out, name)
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("label names cannot be empty")
+		return nil, fmt.Errorf("%s cannot be empty", itemName)
 	}
 	return out, nil
 }
@@ -749,6 +768,8 @@ func actionLabel(kind uiactions.Kind) string {
 		return "reopen"
 	case uiactions.KindReview:
 		return "review"
+	case uiactions.KindRequestReviewers:
+		return "request reviewers"
 	case uiactions.KindExternalDiff:
 		return "external diff"
 	case uiactions.KindCheckout:

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -286,6 +286,38 @@ func TestDispatchMergeAndReview(t *testing.T) {
 	}
 }
 
+func TestDispatchRequestReviewersParsesCommaSeparatedReviewers(t *testing.T) {
+	client := &fakeClient{}
+	r := New(Options{Client: client})
+	intent := pullIntent(uiactions.KindRequestReviewers)
+	intent.Prompt.Value = " alice, bob, alice "
+
+	got := runDispatch(t, r, intent)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("request reviewers result = %+v", got)
+	}
+	if client.reviewRequestIndex != 7 {
+		t.Fatalf("reviewRequestIndex = %d, want 7", client.reviewRequestIndex)
+	}
+	if !reflect.DeepEqual(client.requestedReviewers, []string{"alice", "bob"}) {
+		t.Fatalf("requestedReviewers = %#v, want alice/bob", client.requestedReviewers)
+	}
+	if !strings.Contains(got.Message, "Requested review from alice, bob on acme/widgets#7") {
+		t.Fatalf("message = %q, want reviewer confirmation", got.Message)
+	}
+}
+
+func TestDispatchRequestReviewersRejectsEmptyInput(t *testing.T) {
+	intent := pullIntent(uiactions.KindRequestReviewers)
+	intent.Prompt.Value = " , "
+
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "reviewer usernames cannot be empty") {
+		t.Fatalf("empty request reviewers result = %+v", got)
+	}
+}
+
 func TestDispatchUpdatePullRequest(t *testing.T) {
 	client := &fakeClient{}
 	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindUpdateBranch))
@@ -646,35 +678,37 @@ func TestDispatchReturnsErrorResult(t *testing.T) {
 }
 
 type fakeClient struct {
-	err              error
-	commentBody      string
-	issueState       data.ItemState
-	pullState        data.ItemState
-	merge            data.MergeOptions
-	review           data.PullReviewOptions
-	updatePull       int64
-	markReady        int64
-	markDraft        int64
-	diff             []byte
-	jobs             []data.ActionJob
-	listJobsRunID    int64
-	logJobID         int64
-	logBytes         []byte
-	rerunRunID       int64
-	cancelRunID      int64
-	assignPull       int64
-	assignIssue      int64
-	unassignPull     int64
-	unassignIssue    int64
-	labelIndex       int64
-	addLabels        []string
-	removeLabels     []string
-	milestoneIndex   int64
-	milestoneTitle   string
-	subscribeIssue   int64
-	unsubscribeIssue int64
-	markReadyChanged bool
-	markDraftChanged bool
+	err                error
+	commentBody        string
+	issueState         data.ItemState
+	pullState          data.ItemState
+	merge              data.MergeOptions
+	review             data.PullReviewOptions
+	updatePull         int64
+	markReady          int64
+	markDraft          int64
+	diff               []byte
+	jobs               []data.ActionJob
+	listJobsRunID      int64
+	logJobID           int64
+	logBytes           []byte
+	rerunRunID         int64
+	cancelRunID        int64
+	assignPull         int64
+	assignIssue        int64
+	unassignPull       int64
+	unassignIssue      int64
+	labelIndex         int64
+	addLabels          []string
+	removeLabels       []string
+	milestoneIndex     int64
+	milestoneTitle     string
+	reviewRequestIndex int64
+	requestedReviewers []string
+	subscribeIssue     int64
+	unsubscribeIssue   int64
+	markReadyChanged   bool
+	markDraftChanged   bool
 }
 
 func (f *fakeClient) AddComment(_, _ string, _ int64, body string) (data.Comment, error) {
@@ -748,6 +782,12 @@ func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOption
 func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewOptions) (data.Review, error) {
 	f.review = opt
 	return data.Review{State: data.ReviewState(opt.Event)}, f.err
+}
+
+func (f *fakeClient) RequestPullReviewers(_, _ string, index int64, reviewers []string) error {
+	f.reviewRequestIndex = index
+	f.requestedReviewers = append([]string(nil), reviewers...)
+	return f.err
 }
 
 func (f *fakeClient) UpdatePullRequest(_, _ string, index int64) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -451,6 +451,7 @@ var prBuiltins = builtinSet(
 	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
 	"update", "updateBranch", "ready", "markReady", "draft", "markDraft",
 	"watch", "watchChecks", "checks", "close", "reopen", "diff", "checkout", "approve", "review",
+	"requestReview", "requestReviewer", "requestReviewers",
 	"viewIssues", "summaryViewMore", "expand", "prevSidebarTab", "nextSidebarTab",
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -271,6 +271,8 @@ keybindings:
   prs:
     - key: O
       builtin: checkout
+    - key: "@"
+      builtin: requestReviewers
     - key: g
       name: lazygit
       command: cd {{.RepoPath}} && lazygit
@@ -317,8 +319,10 @@ keybindings:
 		c.Keybindings.Universal[0].Builtin != "nextSection" {
 		t.Fatalf("universal keybindings = %+v", c.Keybindings.Universal)
 	}
-	if len(c.Keybindings.PRs) != 2 || c.Keybindings.PRs[1].Name != "lazygit" ||
-		!strings.Contains(c.Keybindings.PRs[1].Command, "lazygit") {
+	if len(c.Keybindings.PRs) != 3 ||
+		c.Keybindings.PRs[1].Builtin != "requestReviewers" ||
+		c.Keybindings.PRs[2].Name != "lazygit" ||
+		!strings.Contains(c.Keybindings.PRs[2].Command, "lazygit") {
 		t.Fatalf("prs keybindings = %+v", c.Keybindings.PRs)
 	}
 	if len(c.Keybindings.Issues) != 5 ||

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -443,6 +443,23 @@ func (c *Client) SubmitPullReview(owner, repo string, index int64, opt data.Pull
 	return mapped[0], nil
 }
 
+// RequestPullReviewers asks Gitea to request review from the given usernames.
+func (c *Client) RequestPullReviewers(owner, repo string, index int64, reviewers []string) error {
+	if len(reviewers) == 0 {
+		return fmt.Errorf("reviewer usernames cannot be empty")
+	}
+	err := c.call(func() error {
+		_, e := c.sdk.CreateReviewRequests(owner, repo, index, sdk.PullReviewRequestOptions{
+			Reviewers: reviewers,
+		})
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("request reviewers on %s/%s#%d: %w", owner, repo, index, err)
+	}
+	return nil
+}
+
 func mapPullReviewEvent(event data.PullReviewEvent) (sdk.ReviewStateType, error) {
 	switch event {
 	case data.PullReviewEventApprove:

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -488,6 +489,34 @@ func TestSubmitPullReviewPostsEventAndMapsResponse(t *testing.T) {
 	wantSubmitted := time.Date(2026, 7, 1, 11, 0, 0, 0, time.UTC)
 	if got.Author != "reviewer" || got.State != data.ReviewStateRequestChanges || got.Body != "needs work" || !got.SubmittedAt.Equal(wantSubmitted) {
 		t.Fatalf("review = %+v", got)
+	}
+}
+
+func TestRequestPullReviewersPostsReviewerList(t *testing.T) {
+	var reviewers []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/45/requested_reviewers" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		body := decodeMutationBody(t, r)
+		raw, ok := body["reviewers"].([]any)
+		if !ok {
+			t.Fatalf("body = %#v, want reviewers array", body)
+		}
+		for _, v := range raw {
+			reviewers = append(reviewers, v.(string))
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	if err := c.RequestPullReviewers("acme", "widgets", 45, []string{"alice", "bob"}); err != nil {
+		t.Fatalf("RequestPullReviewers: %v", err)
+	}
+	if !reflect.DeepEqual(reviewers, []string{"alice", "bob"}) {
+		t.Fatalf("reviewers = %#v, want alice/bob", reviewers)
 	}
 }
 

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -21,6 +21,7 @@ const (
 	KindClose             Kind = "close"
 	KindReopen            Kind = "reopen"
 	KindReview            Kind = "review"
+	KindRequestReviewers  Kind = "request_reviewers"
 	KindExternalDiff      Kind = "external_diff"
 	KindCheckout          Kind = "checkout"
 	KindSwitchBranch      Kind = "switch_branch"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -17,6 +17,7 @@ func TestKindConstants(t *testing.T) {
 		KindClose:             "close",
 		KindReopen:            "reopen",
 		KindReview:            "review",
+		KindRequestReviewers:  "request_reviewers",
 		KindExternalDiff:      "external_diff",
 		KindCheckout:          "checkout",
 		KindPushBranch:        "push_branch",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -501,6 +501,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindReopen)
 		case !m.scopedBuiltinOverridden("review") && key.Matches(msg, m.keys.Review):
 			return m, m.startAction(actions.KindReview)
+		case !m.scopedBuiltinOverridden("requestReview") && !m.scopedBuiltinOverridden("requestReviewer") &&
+			!m.scopedBuiltinOverridden("requestReviewers") && key.Matches(msg, m.keys.RequestReviewers):
+			return m, m.startAction(actions.KindRequestReviewers)
 		case !m.scopedBuiltinOverridden("push") && m.ctx.View == context.BranchesView && key.Matches(msg, m.keys.PushBranch):
 			return m, m.startAction(actions.KindPushBranch)
 		case !m.scopedBuiltinOverridden("forcePush") && m.ctx.View == context.BranchesView && key.Matches(msg, m.keys.ForcePushBranch):
@@ -761,6 +764,7 @@ func (m Model) actionButtons() []actionButton {
 		}
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Request review", Builtin: "requestReviewers"},
 			actionButton{Label: "Checks", Builtin: "watchChecks"},
 			actionButton{Label: "Diff", Builtin: "diff"},
 			actionButton{Label: "Checkout", Builtin: "checkout"},
@@ -1690,6 +1694,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindReopen), true
 	case "approve", "review":
 		return m, m.startAction(actions.KindReview), true
+	case "requestreview", "requestreviewer", "requestreviewers":
+		return m, m.startAction(actions.KindRequestReviewers), true
 	case "diff":
 		return m, m.startAction(actions.KindExternalDiff), true
 	case "checkout":
@@ -1841,7 +1847,7 @@ func (m Model) selectedActionTarget() (actions.Target, bool) {
 
 func validateActionTarget(kind actions.Kind, target actions.Target) error {
 	switch kind {
-	case actions.KindMerge, actions.KindUpdateBranch, actions.KindMarkReady, actions.KindMarkDraft, actions.KindReview, actions.KindExternalDiff:
+	case actions.KindMerge, actions.KindUpdateBranch, actions.KindMarkReady, actions.KindMarkDraft, actions.KindReview, actions.KindRequestReviewers, actions.KindExternalDiff:
 		if target.RowKind != actions.RowKindPullRequest {
 			return fmt.Errorf("%s is only available for pull requests.", actionLabel(kind))
 		}
@@ -1883,7 +1889,7 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 	switch kind {
 	case actions.KindComment:
 		return actions.PromptText
-	case actions.KindAddLabel, actions.KindRemoveLabel, actions.KindSetMilestone:
+	case actions.KindAddLabel, actions.KindRemoveLabel, actions.KindSetMilestone, actions.KindRequestReviewers:
 		return actions.PromptText
 	case actions.KindMerge, actions.KindReview:
 		return actions.PromptPicker
@@ -1926,6 +1932,13 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 			Title:       title,
 			Message:     message,
 			Placeholder: "Milestone title",
+		}
+	case actions.KindRequestReviewers:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       title,
+			Message:     message,
+			Placeholder: "Reviewer usernames, comma-separated",
 		}
 	case actions.KindReview:
 		return actionprompt.Config{
@@ -1998,6 +2011,8 @@ func actionLabel(kind actions.Kind) string {
 		return "Reopen"
 	case actions.KindReview:
 		return "Review"
+	case actions.KindRequestReviewers:
+		return "Request reviewers"
 	case actions.KindExternalDiff:
 		return "External diff"
 	case actions.KindCheckout:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -233,7 +233,7 @@ func TestActionBarRendersCommonPullRequestButtons(t *testing.T) {
 	}}))
 
 	view := m.View().Content
-	for _, want := range []string{"[Open]", "[Refresh]", "[Comment]", "[Diff]", "[Checkout]", "[Merge]", "[Close]"} {
+	for _, want := range []string{"[Open]", "[Refresh]", "[Comment]", "[Request review]", "[Diff]", "[Checkout]", "[Merge]", "[Close]"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("action bar missing %q:\n%s", want, view)
 		}
@@ -1940,6 +1940,16 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "update branch", key: tea.KeyPressMsg{Code: 'u', Text: "u"}, kind: actions.KindUpdateBranch},
 		{name: "mark ready", key: tea.KeyPressMsg{Code: 'W', Text: "W"}, kind: actions.KindMarkReady},
 		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
+		{
+			name:      "request reviewers",
+			key:       tea.KeyPressMsg{Code: '@', Text: "@"},
+			kind:      actions.KindRequestReviewers,
+			textInput: []tea.KeyPressMsg{{Code: 'a', Text: "a"}, {Code: 'l', Text: "l"}, {Code: 'i', Text: "i"}, {Code: 'c', Text: "c"}, {Code: 'e', Text: "e"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptText,
+				Value: "alice",
+			},
+		},
 		{name: "checkout", key: tea.KeyPressMsg{Code: 'C', Text: "C"}, kind: actions.KindCheckout},
 		{name: "checkout space alias", key: tea.KeyPressMsg{Code: ' ', Text: " "}, kind: actions.KindCheckout},
 	}
@@ -2640,6 +2650,29 @@ func TestScopedBuiltinKeybindingReplacesDefaultInActiveView(t *testing.T) {
 	m = update(t, m, tea.KeyPressMsg{Code: 'M', Text: "M"})
 	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Merge") {
 		t.Fatalf("configured 'M' key should open the merge prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+}
+
+func TestRequestReviewerAliasReplacesDefaultHotkey(t *testing.T) {
+	cfg := &config.Config{
+		Keybindings: config.Keybindings{
+			PRs: []config.Keybinding{{Key: "Q", Builtin: "requestReviewer"}},
+		},
+	}
+	m := New(cfg, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 8, Title: "PR row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: '@', Text: "@"})
+	if m.actionPrompt.Active() {
+		t.Fatal("default @ request-reviewers key should be replaced by requestReviewer scoped alias")
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: 'Q', Text: "Q"})
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Request reviewers") {
+		t.Fatalf("configured requestReviewer alias should open request-reviewers prompt, got:\n%s", m.actionPrompt.View(120))
 	}
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -43,6 +43,7 @@ type keyMap struct {
 	Close             key.Binding
 	Reopen            key.Binding
 	Review            key.Binding
+	RequestReviewers  key.Binding
 	ExternalDiff      key.Binding
 	Checkout          key.Binding
 	PushBranch        key.Binding
@@ -191,6 +192,10 @@ func defaultKeyMap() keyMap {
 		Review: key.NewBinding(
 			key.WithKeys("v"),
 			key.WithHelp("v", "review"),
+		),
+		RequestReviewers: key.NewBinding(
+			key.WithKeys("@"),
+			key.WithHelp("@", "request review"),
 		),
 		ExternalDiff: key.NewBinding(
 			key.WithKeys("d", "ctrl+t"),
@@ -345,6 +350,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.Reopen = binding(keyName, "reopen")
 	case "approve", "review":
 		k.Review = binding(keyName, "review")
+	case "requestreview", "requestreviewer", "requestreviewers":
+		k.RequestReviewers = binding(keyName, "request review")
 	case "diff":
 		k.ExternalDiff = binding(keyName, "external diff")
 	case "checkout":


### PR DESCRIPTION
## Summary
- add a PR-only request-reviewers action using the Gitea requested_reviewers API
- wire the @ hotkey, action bar button, text prompt, and scoped keybinding aliases
- document requestReviewers in README and the example config

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build