### PR TITLE
fix(prs): collect body for non-approve reviews

### DIFF
--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -458,7 +458,11 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		if err != nil {
 			return "", err
 		}
-		if _, err := r.client.SubmitPullReview(owner, repo, index, data.PullReviewOptions{Event: event}); err != nil {
+		body := strings.TrimSpace(intent.Prompt.Body)
+		if event != data.PullReviewEventApprove && body == "" {
+			return "", fmt.Errorf("review body cannot be empty for %s", event)
+		}
+		if _, err := r.client.SubmitPullReview(owner, repo, index, data.PullReviewOptions{Event: event, Body: body}); err != nil {
 			return "", err
 		}
 		return fmt.Sprintf("Submitted review for %s#%d.", intent.Target.Repo, index), nil

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -276,13 +276,40 @@ func TestDispatchMergeAndReview(t *testing.T) {
 	}
 
 	review := pullIntent(uiactions.KindReview)
-	review.Prompt.Value = "request_changes"
+	review.Prompt.Value = "approve"
 	got = runDispatch(t, r, review)
 	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
 		t.Fatalf("review result = %+v", got)
 	}
-	if client.review.Event != data.PullReviewEventRequestChanges {
-		t.Fatalf("review event = %q, want request-changes", client.review.Event)
+	if client.review.Event != data.PullReviewEventApprove {
+		t.Fatalf("review event = %q, want approve", client.review.Event)
+	}
+}
+
+func TestDispatchReviewRequestChangesPassesBody(t *testing.T) {
+	client := &fakeClient{}
+	intent := pullIntent(uiactions.KindReview)
+	intent.Prompt.Value = "request_changes"
+	intent.Prompt.Body = "Needs tests before merge."
+
+	got := runDispatch(t, New(Options{Client: client}), intent)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("review result = %+v", got)
+	}
+	if client.review.Event != data.PullReviewEventRequestChanges || client.review.Body != "Needs tests before merge." {
+		t.Fatalf("review = %+v, want request-changes with body", client.review)
+	}
+}
+
+func TestDispatchReviewRequestChangesRejectsEmptyBody(t *testing.T) {
+	intent := pullIntent(uiactions.KindReview)
+	intent.Prompt.Value = "request_changes"
+	intent.Prompt.Body = "  "
+
+	got := runDispatch(t, New(Options{Client: &fakeClient{}}), intent)
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "review body cannot be empty") {
+		t.Fatalf("empty review body result = %+v", got)
 	}
 }
 

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -76,6 +76,7 @@ type Prompt struct {
 	Mode  PromptMode
 	Value string
 	Label string
+	Body  string
 }
 
 // Intent is the value passed through the app-level dispatcher seam.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4,6 +4,7 @@ package ui
 import (
 	stdctx "context"
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -1749,9 +1750,19 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 	if !result.Submitted {
 		return cmd
 	}
+	if m.pendingAction.Kind == actions.KindReview && m.pendingAction.Prompt.Value == "" && reviewPromptNeedsBody(result.Value) {
+		m.pendingAction.Prompt.Value = result.Value
+		m.pendingAction.Prompt.Label = result.Label
+		m.actionPrompt = m.actionPrompt.Focus(reviewBodyPromptConfig(m.pendingAction.Target, result.Label))
+		return cmd
+	}
 	intent := m.pendingAction
-	intent.Prompt.Value = result.Value
-	intent.Prompt.Label = result.Label
+	if intent.Kind == actions.KindReview && intent.Prompt.Value != "" && reviewPromptNeedsBody(intent.Prompt.Value) {
+		intent.Prompt.Body = result.Value
+	} else {
+		intent.Prompt.Value = result.Value
+		intent.Prompt.Label = result.Label
+	}
 	m.pendingAction = actions.Intent{}
 	if m.actionDispatcher == nil {
 		m.notice = "Action not wired yet."
@@ -1765,6 +1776,27 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		return cmd
 	}
 	return tea.Batch(cmd, dispatchCmd)
+}
+
+func reviewPromptNeedsBody(value string) bool {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "approve", "approved":
+		return false
+	default:
+		return true
+	}
+}
+
+func reviewBodyPromptConfig(target actions.Target, label string) actionprompt.Config {
+	if label == "" {
+		label = "Review"
+	}
+	return actionprompt.Config{
+		Mode:        actionprompt.ModeText,
+		Title:       fmt.Sprintf("Review message #%d", target.Number),
+		Message:     fmt.Sprintf("%s - %s", target.Repo, target.Title),
+		Placeholder: fmt.Sprintf("%s message", label),
+	}
 }
 
 func (m Model) quitOrConfirm() (Model, tea.Cmd) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1939,7 +1939,17 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 		{name: "reopen", key: tea.KeyPressMsg{Code: 'X', Text: "X"}, kind: actions.KindReopen},
 		{name: "update branch", key: tea.KeyPressMsg{Code: 'u', Text: "u"}, kind: actions.KindUpdateBranch},
 		{name: "mark ready", key: tea.KeyPressMsg{Code: 'W', Text: "W"}, kind: actions.KindMarkReady},
-		{name: "review", key: tea.KeyPressMsg{Code: 'v', Text: "v"}, kind: actions.KindReview},
+		{
+			name:        "approve review",
+			key:         tea.KeyPressMsg{Code: 'v', Text: "v"},
+			kind:        actions.KindReview,
+			beforeEnter: []tea.KeyPressMsg{{Code: 'j', Text: "j"}},
+			wantPrompt: actions.Prompt{
+				Mode:  actions.PromptPicker,
+				Value: "approve",
+				Label: "Approve",
+			},
+		},
 		{
 			name:      "request reviewers",
 			key:       tea.KeyPressMsg{Code: '@', Text: "@"},
@@ -2007,6 +2017,48 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 				t.Fatalf("prompt = %+v, want %+v", got[0].Prompt, tt.wantPrompt)
 			}
 		})
+	}
+}
+
+func TestReviewRequestChangesPromptsForBodyBeforeDispatch(t *testing.T) {
+	var got []actions.Intent
+	m := New(&config.Config{}, nil)
+	m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+		got = append(got, intent)
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'v', Text: "v"})
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if len(got) != 0 {
+		t.Fatalf("review request-changes picker should not dispatch before body, got %+v", got)
+	}
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Review message") {
+		t.Fatalf("request-changes should open a review body prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+	for _, key := range []tea.KeyPressMsg{
+		{Code: 'n', Text: "n"}, {Code: 'e', Text: "e"}, {Code: 'e', Text: "e"}, {Code: 'd', Text: "d"}, {Code: 's', Text: "s"},
+		{Code: ' ', Text: " "}, {Code: 'w', Text: "w"}, {Code: 'o', Text: "o"}, {Code: 'r', Text: "r"}, {Code: 'k', Text: "k"},
+	} {
+		m = update(t, m, key)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if len(got) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(got))
+	}
+	if got[0].Kind != actions.KindReview ||
+		got[0].Prompt.Value != "request_changes" ||
+		got[0].Prompt.Label != "Request changes" ||
+		got[0].Prompt.Body != "needs work" {
+		t.Fatalf("intent prompt = %+v, want request_changes body", got[0].Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make approve reviews dispatch directly, but require a review body for comment/request-changes reviews
- add a second prompt for review message entry after choosing Comment or Request changes
- pass the collected body through action intents into the Gitea review mutation

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check
- GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build