### PR TITLE
feat(prs): add merge delete-branch choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ tea-dash --help
 | `?`             | show / hide full help   |
 | `q` / `ctrl+c`  | quit                    |
 
+The merge picker includes each merge strategy plus a `+ delete branch` variant.
+
 ## Configuration
 
 Optional. tea-dash reads the first config it finds in this order:

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -441,11 +441,11 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		return fmt.Sprintf("Set milestone %q on %s#%d.", title, intent.Target.Repo, index), nil
 
 	case uiactions.KindMerge:
-		style, err := mergeStyle(intent.Prompt.Value)
+		opt, err := mergeOptions(intent.Prompt.Value)
 		if err != nil {
 			return "", err
 		}
-		merged, err := r.client.MergePullRequest(owner, repo, index, data.MergeOptions{Style: style})
+		merged, err := r.client.MergePullRequest(owner, repo, index, opt)
 		if err != nil {
 			return "", err
 		}
@@ -732,6 +732,20 @@ func reviewEvent(value string) (data.PullReviewEvent, error) {
 	default:
 		return "", fmt.Errorf("unsupported review action %q", value)
 	}
+}
+
+func mergeOptions(value string) (data.MergeOptions, error) {
+	v := strings.TrimSpace(strings.ToLower(value))
+	deleteBranch := false
+	if strings.HasSuffix(v, "+delete") {
+		deleteBranch = true
+		v = strings.TrimSuffix(v, "+delete")
+	}
+	style, err := mergeStyle(v)
+	if err != nil {
+		return data.MergeOptions{}, err
+	}
+	return data.MergeOptions{Style: style, DeleteBranch: deleteBranch}, nil
 }
 
 func mergeStyle(value string) (data.MergeStyle, error) {

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -275,6 +275,16 @@ func TestDispatchMergeAndReview(t *testing.T) {
 		t.Fatalf("merge style = %q, want squash", client.merge.Style)
 	}
 
+	deleteBranch := pullIntent(uiactions.KindMerge)
+	deleteBranch.Prompt.Value = "squash+delete"
+	got = runDispatch(t, r, deleteBranch)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("squash delete-branch merge result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleSquash || !client.merge.DeleteBranch {
+		t.Fatalf("merge options = %+v, want squash with DeleteBranch", client.merge)
+	}
+
 	review := pullIntent(uiactions.KindReview)
 	review.Prompt.Value = "approve"
 	got = runDispatch(t, r, review)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2004,6 +2004,11 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 				{Label: "Rebase", Value: string(data.MergeStyleRebase)},
 				{Label: "Rebase merge", Value: string(data.MergeStyleRebaseMerge)},
 				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
+				{Label: "Merge + delete branch", Value: string(data.MergeStyleMerge) + "+delete"},
+				{Label: "Squash + delete branch", Value: string(data.MergeStyleSquash) + "+delete"},
+				{Label: "Rebase + delete branch", Value: string(data.MergeStyleRebase) + "+delete"},
+				{Label: "Rebase merge + delete branch", Value: string(data.MergeStyleRebaseMerge) + "+delete"},
+				{Label: "Fast-forward only + delete branch", Value: string(data.MergeStyleFastForwardOnly) + "+delete"},
 			},
 		}
 	case actions.KindCancelRun:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2041,6 +2041,26 @@ func TestActionKeysDispatchExpectedIntents(t *testing.T) {
 	}
 }
 
+func TestMergePromptIncludesDeleteBranchOptions(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("merge key should open the merge picker")
+	}
+	view := m.actionPrompt.View(120)
+	for _, want := range []string{"Merge + delete branch", "Squash + delete branch", "Fast-forward only + delete branch"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("merge prompt missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestReviewRequestChangesPromptsForBodyBeforeDispatch(t *testing.T) {
 	var got []actions.Intent
 	m := New(&config.Config{}, nil)


### PR DESCRIPTION
## Summary

- add `+ delete branch` variants to the merge picker for every merge strategy
- parse picker values into `MergeOptions.DeleteBranch`
- document the merge picker behavior

## Verification

- git diff --check
- bash scripts/check-public-hygiene.sh
- make check
- go test -race -count=1 ./...
- make build