### PR TITLE
feat(prs): prompt for merge title and message

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ tea-dash --help
 | `q` / `ctrl+c`  | quit                    |
 
 The merge picker includes each merge strategy plus explicit `+ delete branch`,
-`+ force merge`, and combined variants.
+`with message`, `+ force merge`, and combined variants.
 
 ## Configuration
 

--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -445,6 +445,8 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		if err != nil {
 			return "", err
 		}
+		opt.Title = strings.TrimSpace(intent.Prompt.Title)
+		opt.Message = strings.TrimSpace(intent.Prompt.Body)
 		merged, err := r.client.MergePullRequest(owner, repo, index, opt)
 		if err != nil {
 			return "", err
@@ -746,6 +748,8 @@ func mergeOptions(value string) (data.MergeOptions, error) {
 			deleteBranch = true
 		case "force", "force-merge", "force_merge":
 			forceMerge = true
+		case "message", "edit-message", "edit_message":
+			// UI-only flag: the submitted Prompt carries the actual title/body.
 		case "":
 			// Ignore empty components from accidental trailing separators; the
 			// style parser below still validates the action.

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -305,6 +305,20 @@ func TestDispatchMergeAndReview(t *testing.T) {
 		t.Fatalf("merge options = %+v, want squash with DeleteBranch and ForceMerge", client.merge)
 	}
 
+	message := pullIntent(uiactions.KindMerge)
+	message.Prompt.Value = "squash+message"
+	message.Prompt.Title = "Custom merge title"
+	message.Prompt.Body = "Custom merge body"
+	got = runDispatch(t, r, message)
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("squash merge with message result = %+v", got)
+	}
+	if client.merge.Style != data.MergeStyleSquash ||
+		client.merge.Title != "Custom merge title" ||
+		client.merge.Message != "Custom merge body" {
+		t.Fatalf("merge options = %+v, want squash with custom title/body", client.merge)
+	}
+
 	review := pullIntent(uiactions.KindReview)
 	review.Prompt.Value = "approve"
 	got = runDispatch(t, r, review)

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -77,6 +77,7 @@ type Prompt struct {
 	Mode  PromptMode
 	Value string
 	Label string
+	Title string
 	Body  string
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1759,8 +1759,22 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		m.actionPrompt = m.actionPrompt.Focus(reviewBodyPromptConfig(m.pendingAction.Target, result.Label))
 		return cmd
 	}
+	if m.pendingAction.Kind == actions.KindMerge && m.pendingAction.Prompt.Value == "" && mergePromptNeedsMessage(result.Value) {
+		m.pendingAction.Prompt.Value = result.Value
+		m.pendingAction.Prompt.Label = result.Label
+		m.actionPrompt = m.actionPrompt.Focus(mergeTitlePromptConfig(m.pendingAction.Target))
+		return cmd
+	}
+	if m.pendingAction.Kind == actions.KindMerge && m.pendingAction.Prompt.Value != "" &&
+		mergePromptNeedsMessage(m.pendingAction.Prompt.Value) && m.pendingAction.Prompt.Title == "" {
+		m.pendingAction.Prompt.Title = result.Value
+		m.actionPrompt = m.actionPrompt.Focus(mergeMessagePromptConfig(m.pendingAction.Target))
+		return cmd
+	}
 	intent := m.pendingAction
 	if intent.Kind == actions.KindReview && intent.Prompt.Value != "" && reviewPromptNeedsBody(intent.Prompt.Value) {
+		intent.Prompt.Body = result.Value
+	} else if intent.Kind == actions.KindMerge && intent.Prompt.Value != "" && mergePromptNeedsMessage(intent.Prompt.Value) {
 		intent.Prompt.Body = result.Value
 	} else {
 		intent.Prompt.Value = result.Value
@@ -1790,6 +1804,16 @@ func reviewPromptNeedsBody(value string) bool {
 	}
 }
 
+func mergePromptNeedsMessage(value string) bool {
+	for _, part := range strings.Split(strings.ToLower(value), "+") {
+		switch strings.TrimSpace(part) {
+		case "message", "edit-message", "edit_message":
+			return true
+		}
+	}
+	return false
+}
+
 func reviewBodyPromptConfig(target actions.Target, label string) actionprompt.Config {
 	if label == "" {
 		label = "Review"
@@ -1799,6 +1823,25 @@ func reviewBodyPromptConfig(target actions.Target, label string) actionprompt.Co
 		Title:       fmt.Sprintf("Review message #%d", target.Number),
 		Message:     fmt.Sprintf("%s - %s", target.Repo, target.Title),
 		Placeholder: fmt.Sprintf("%s message", label),
+	}
+}
+
+func mergeTitlePromptConfig(target actions.Target) actionprompt.Config {
+	return actionprompt.Config{
+		Mode:        actionprompt.ModeText,
+		Title:       fmt.Sprintf("Merge title #%d", target.Number),
+		Message:     fmt.Sprintf("%s - %s", target.Repo, target.Title),
+		Placeholder: "Merge title",
+		Initial:     target.Title,
+	}
+}
+
+func mergeMessagePromptConfig(target actions.Target) actionprompt.Config {
+	return actionprompt.Config{
+		Mode:        actionprompt.ModeText,
+		Title:       fmt.Sprintf("Merge message #%d", target.Number),
+		Message:     fmt.Sprintf("%s - %s", target.Repo, target.Title),
+		Placeholder: "Merge message",
 	}
 }
 
@@ -2004,6 +2047,9 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 				{Label: "Rebase", Value: string(data.MergeStyleRebase)},
 				{Label: "Rebase merge", Value: string(data.MergeStyleRebaseMerge)},
 				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
+				{Label: "Merge with message", Value: string(data.MergeStyleMerge) + "+message"},
+				{Label: "Squash with message", Value: string(data.MergeStyleSquash) + "+message"},
+				{Label: "Rebase merge with message", Value: string(data.MergeStyleRebaseMerge) + "+message"},
 				{Label: "Merge + delete branch", Value: string(data.MergeStyleMerge) + "+delete"},
 				{Label: "Squash + delete branch", Value: string(data.MergeStyleSquash) + "+delete"},
 				{Label: "Rebase + delete branch", Value: string(data.MergeStyleRebase) + "+delete"},

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2081,6 +2081,77 @@ func TestMergePromptIncludesForceMergeOptions(t *testing.T) {
 	}
 }
 
+func TestMergePromptIncludesMessageOptions(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if !m.actionPrompt.Active() {
+		t.Fatal("merge key should open the merge picker")
+	}
+	view := m.actionPrompt.View(120)
+	for _, want := range []string{"Merge with message", "Squash with message", "Rebase merge with message"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("merge prompt missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestMergeWithMessagePromptsForTitleAndBodyBeforeDispatch(t *testing.T) {
+	var got []actions.Intent
+	m := New(&config.Config{}, nil)
+	m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+		got = append(got, intent)
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open", HTMLURL: "https://example.test/gbarany/tea-dash/pulls/42",
+	}}))
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'm', Text: "m"})
+	for i := 0; i < 5; i++ {
+		m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if len(got) != 0 {
+		t.Fatalf("merge-with-message picker should not dispatch before title/body, got %+v", got)
+	}
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Merge title") ||
+		!strings.Contains(m.actionPrompt.View(120), "Action row") {
+		t.Fatalf("merge-with-message should open prefilled title prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if len(got) != 0 {
+		t.Fatalf("merge title prompt should not dispatch before body, got %+v", got)
+	}
+	if !m.actionPrompt.Active() || !strings.Contains(m.actionPrompt.View(120), "Merge message") {
+		t.Fatalf("merge title prompt should advance to message prompt, got:\n%s", m.actionPrompt.View(120))
+	}
+	for _, key := range []tea.KeyPressMsg{
+		{Code: 's', Text: "s"}, {Code: 'h', Text: "h"}, {Code: 'i', Text: "i"}, {Code: 'p', Text: "p"},
+		{Code: ' ', Text: " "}, {Code: 'i', Text: "i"}, {Code: 't', Text: "t"},
+	} {
+		m = update(t, m, key)
+	}
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if len(got) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(got))
+	}
+	if got[0].Kind != actions.KindMerge ||
+		got[0].Prompt.Value != "merge+message" ||
+		got[0].Prompt.Title != "Action row" ||
+		got[0].Prompt.Body != "ship it" {
+		t.Fatalf("merge-with-message intent = %+v, want style plus title/body", got[0])
+	}
+}
+
 func TestReviewRequestChangesPromptsForBodyBeforeDispatch(t *testing.T) {
 	var got []actions.Intent
 	m := New(&config.Config{}, nil)


### PR DESCRIPTION
## Summary

- add explicit merge picker choices for editing merge title/message
- collect a prefilled title and message before dispatching those choices
- pass submitted title/body through to MergeOptions

## Verification

- git diff --check
- bash scripts/check-public-hygiene.sh
- make check
- go test -race -count=1 ./...
- make build