### PR TITLE
feat(prs): pick reviewers from repo candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ tea-dash --help
 | `u`             | update PR branch from its base branch |
 | `W`             | mark draft PR ready for review |
 | `w`             | show/watch PR checks in the Actions view |
-| `@`             | request PR review from one or more users |
+| `@`             | request PR review from one or more users (picker when the server exposes reviewers) |
 | `m` / `u` / `M` | mark notification read / unread / all read |
 | `b` / `B`       | pin / unpin notification |
 | `x` / `X`       | close / reopen          |

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -478,6 +478,28 @@ func (c *Client) RemovePullReviewers(owner, repo string, index int64, reviewers 
 	return nil
 }
 
+// ListReviewers returns users that can be requested to review pull requests in
+// the repository.
+func (c *Client) ListReviewers(owner, repo string) ([]data.User, error) {
+	var users []*sdk.User
+	err := c.call(func() error {
+		var e error
+		users, _, e = c.sdk.GetReviewers(owner, repo)
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list reviewers for %s/%s: %w", owner, repo, err)
+	}
+	out := make([]data.User, 0, len(users))
+	for _, user := range users {
+		if user == nil || user.UserName == "" {
+			continue
+		}
+		out = append(out, data.User{Login: user.UserName, FullName: user.FullName})
+	}
+	return out, nil
+}
+
 func mapPullReviewEvent(event data.PullReviewEvent) (sdk.ReviewStateType, error) {
 	switch event {
 	case data.PullReviewEventApprove:

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -550,6 +550,35 @@ func TestRemovePullReviewersDeletesReviewerList(t *testing.T) {
 	}
 }
 
+func TestListReviewersMapsRequestableReviewers(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/reviewers" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `[
+			{"login":"alice","full_name":"Alice A."},
+			{"login":"bob"},
+			{"full_name":"No Login"},
+			null
+		]`)
+	})
+
+	got, err := c.ListReviewers("acme", "widgets")
+	if err != nil {
+		t.Fatalf("ListReviewers: %v", err)
+	}
+	want := []data.User{
+		{Login: "alice", FullName: "Alice A."},
+		{Login: "bob"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reviewers = %#v, want %#v", got, want)
+	}
+}
+
 func TestAddCommentWrapsServerError(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/repos/acme/widgets/issues/7/comments" {

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -50,9 +50,10 @@ const (
 type PromptMode string
 
 const (
-	PromptConfirm PromptMode = "confirm"
-	PromptText    PromptMode = "text"
-	PromptPicker  PromptMode = "picker"
+	PromptConfirm     PromptMode = "confirm"
+	PromptText        PromptMode = "text"
+	PromptPicker      PromptMode = "picker"
+	PromptMultiPicker PromptMode = "multi_picker"
 )
 
 // Target is the immutable row/section context for an action.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -90,6 +90,12 @@ type copyResultMsg struct {
 	err   error
 }
 
+type reviewersLoadedMsg struct {
+	intent    actions.Intent
+	reviewers []data.User
+	err       error
+}
+
 // autoRefreshMsg is emitted by the optional background refetch timer.
 type autoRefreshMsg struct{}
 
@@ -369,6 +375,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice = fmt.Sprintf("Copied %s.", msg.value)
 		}
 		return m, nil
+
+	case reviewersLoadedMsg:
+		return m.handleReviewersLoaded(msg), nil
 
 	case actions.ResultMsg:
 		m.notice = ""
@@ -1513,6 +1522,10 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 		return m.dispatchActionIntent(intent)
 	}
 	m.pendingAction = intent
+	if reviewerPickerAction(kind) && m.ctx.Client != nil {
+		m.notice = "Loading reviewers..."
+		return loadReviewersCmd(m.ctx.Client, intent)
+	}
 	m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(kind, target))
 	return nil
 }
@@ -1793,6 +1806,77 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		return cmd
 	}
 	return tea.Batch(cmd, dispatchCmd)
+}
+
+func (m *Model) handleReviewersLoaded(msg reviewersLoadedMsg) Model {
+	if !reviewerPickerAction(msg.intent.Kind) {
+		return *m
+	}
+	if m.pendingAction.Kind != msg.intent.Kind || m.pendingAction.Target != msg.intent.Target {
+		return *m
+	}
+	m.pendingAction = msg.intent
+	if msg.err != nil {
+		m.notice = fmt.Sprintf("Couldn't load reviewers: %v. Enter usernames manually.", msg.err)
+		m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(msg.intent.Kind, msg.intent.Target))
+		return *m
+	}
+	if len(msg.reviewers) == 0 {
+		m.notice = "No requestable reviewers found. Enter usernames manually."
+		m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(msg.intent.Kind, msg.intent.Target))
+		return *m
+	}
+	cfg := reviewerPickerPromptConfig(msg.intent.Kind, msg.intent.Target, msg.reviewers)
+	if len(cfg.Options) == 0 {
+		m.notice = "No requestable reviewers found. Enter usernames manually."
+		m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(msg.intent.Kind, msg.intent.Target))
+		return *m
+	}
+	m.notice = ""
+	m.pendingAction.Prompt.Mode = actions.PromptMultiPicker
+	m.actionPrompt = m.actionPrompt.Focus(cfg)
+	return *m
+}
+
+func reviewerPickerAction(kind actions.Kind) bool {
+	return kind == actions.KindRequestReviewers || kind == actions.KindRemoveReviewers
+}
+
+func loadReviewersCmd(client *gitea.Client, intent actions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		owner, repo, ok := strings.Cut(intent.Target.Repo, "/")
+		if !ok || owner == "" || repo == "" {
+			return reviewersLoadedMsg{intent: intent, err: fmt.Errorf("invalid repository %q", intent.Target.Repo)}
+		}
+		reviewers, err := client.ListReviewers(owner, repo)
+		return reviewersLoadedMsg{intent: intent, reviewers: reviewers, err: err}
+	}
+}
+
+func reviewerPickerPromptConfig(kind actions.Kind, target actions.Target, reviewers []data.User) actionprompt.Config {
+	cfg := promptConfigForAction(kind, target)
+	cfg.Mode = actionprompt.ModeMultiPicker
+	cfg.Placeholder = ""
+	cfg.Options = make([]actionprompt.Option, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		if strings.TrimSpace(reviewer.Login) == "" {
+			continue
+		}
+		cfg.Options = append(cfg.Options, actionprompt.Option{
+			Label: reviewerOptionLabel(reviewer),
+			Value: reviewer.Login,
+		})
+	}
+	return cfg
+}
+
+func reviewerOptionLabel(user data.User) string {
+	fullName := strings.TrimSpace(user.FullName)
+	login := strings.TrimSpace(user.Login)
+	if fullName == "" {
+		return login
+	}
+	return fmt.Sprintf("%s (%s)", fullName, login)
 }
 
 func reviewPromptNeedsBody(value string) bool {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -325,6 +325,62 @@ func TestMouseClickRemoveReviewersActionButtonStartsPromptAction(t *testing.T) {
 	}
 }
 
+func TestRequestReviewersLoadsRepoReviewersIntoMultiPicker(t *testing.T) {
+	var got []actions.Intent
+	client := reviewerClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/gbarany/tea-dash/reviewers" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `[
+			{"login":"alice","full_name":"Alice A."},
+			{"login":"bob","full_name":"Bob B."}
+		]`)
+	})
+	m := New(&config.Config{}, client)
+	m.actionDispatcher = func(intent actions.Intent) tea.Cmd {
+		got = append(got, intent)
+		return nil
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: '@', Text: "@"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("request reviewers should fetch repo reviewers before opening the prompt")
+	}
+	msg := cmd()
+	loaded, ok := msg.(reviewersLoadedMsg)
+	if !ok || loaded.err != nil || len(loaded.reviewers) != 2 {
+		t.Fatalf("reviewer load msg = %#v, want two reviewers", msg)
+	}
+
+	m = update(t, m, loaded)
+	view := m.actionPrompt.View(120)
+	for _, want := range []string{"[ ] Alice A. (alice)", "[ ] Bob B. (bob)"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("reviewer picker missing %q:\n%s", want, view)
+		}
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: ' ', Text: " "})
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = update(t, m, tea.KeyPressMsg{Code: ' ', Text: " "})
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if len(got) != 1 {
+		t.Fatalf("dispatcher calls = %d, want 1", len(got))
+	}
+	if got[0].Kind != actions.KindRequestReviewers || got[0].Prompt.Value != "alice,bob" {
+		t.Fatalf("intent = %+v, want request reviewers for alice,bob", got[0])
+	}
+}
+
 func TestWatchChecksHotkeySwitchesToActionsForSelectedPullRequest(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -3359,6 +3415,28 @@ func (e errBoomType) Error() string { return string(e) }
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+func reviewerClient(t *testing.T, reviewersHandler http.HandlerFunc) *gitea.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	if reviewersHandler != nil {
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/reviewers", reviewersHandler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
 }
 
 func newNotificationActionClient(

--- a/internal/ui/components/actionprompt/actionprompt.go
+++ b/internal/ui/components/actionprompt/actionprompt.go
@@ -13,9 +13,10 @@ import (
 type Mode string
 
 const (
-	ModeConfirm Mode = "confirm"
-	ModeText    Mode = "text"
-	ModePicker  Mode = "picker"
+	ModeConfirm     Mode = "confirm"
+	ModeText        Mode = "text"
+	ModePicker      Mode = "picker"
+	ModeMultiPicker Mode = "multi-picker"
 )
 
 // Option is a selectable picker entry.
@@ -44,10 +45,11 @@ type Result struct {
 
 // Model owns the active prompt state.
 type Model struct {
-	active   bool
-	cfg      Config
-	input    textinput.Model
-	selected int
+	active        bool
+	cfg           Config
+	input         textinput.Model
+	selected      int
+	multiSelected map[int]bool
 }
 
 func New() Model {
@@ -63,6 +65,7 @@ func (m Model) Focus(cfg Config) Model {
 	m.cfg = cfg
 	m.input = newInput(cfg)
 	m.selected = 0
+	m.multiSelected = map[int]bool{}
 	return m
 }
 
@@ -96,7 +99,7 @@ func (m Model) Update(msg tea.Msg) (Model, Result, tea.Cmd) {
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
 		return m, Result{}, cmd
-	case ModePicker:
+	case ModePicker, ModeMultiPicker:
 		switch key.String() {
 		case "j", "down", "right":
 			if m.selected < len(m.cfg.Options)-1 {
@@ -105,6 +108,14 @@ func (m Model) Update(msg tea.Msg) (Model, Result, tea.Cmd) {
 		case "k", "up", "left":
 			if m.selected > 0 {
 				m.selected--
+			}
+		case " ", "space":
+			if m.cfg.Mode == ModeMultiPicker && len(m.cfg.Options) > 0 {
+				if m.multiSelected[m.selected] {
+					delete(m.multiSelected, m.selected)
+				} else {
+					m.multiSelected[m.selected] = true
+				}
 			}
 		}
 	case ModeConfirm:
@@ -137,7 +148,7 @@ func (m Model) View(width int) string {
 			value = m.cfg.Placeholder
 		}
 		lines = append(lines, "> "+value)
-	case ModePicker:
+	case ModePicker, ModeMultiPicker:
 		if len(m.cfg.Options) == 0 {
 			lines = append(lines, "No choices available")
 		}
@@ -146,12 +157,22 @@ func (m Model) View(width int) string {
 			if i == m.selected {
 				prefix = "> "
 			}
+			if m.cfg.Mode == ModeMultiPicker {
+				mark := "[ ] "
+				if m.multiSelected[i] {
+					mark = "[x] "
+				}
+				lines = append(lines, prefix+mark+option.Label)
+				continue
+			}
 			lines = append(lines, prefix+option.Label)
 		}
 	default:
 		lines = append(lines, "enter: confirm | esc: cancel")
 	}
-	if m.cfg.Mode != ModeConfirm {
+	if m.cfg.Mode == ModeMultiPicker {
+		lines = append(lines, "space: toggle | enter: submit | esc: cancel")
+	} else if m.cfg.Mode != ModeConfirm {
 		lines = append(lines, "enter: submit | esc: cancel")
 	}
 	for i, line := range lines {
@@ -185,6 +206,17 @@ func (m Model) result() Result {
 		}
 		option := m.cfg.Options[m.selected]
 		return Result{Submitted: true, Value: option.Value, Label: option.Label}
+	case ModeMultiPicker:
+		var values []string
+		var labels []string
+		for i, option := range m.cfg.Options {
+			if !m.multiSelected[i] {
+				continue
+			}
+			values = append(values, option.Value)
+			labels = append(labels, option.Label)
+		}
+		return Result{Submitted: true, Value: strings.Join(values, ","), Label: strings.Join(labels, ", ")}
 	default:
 		return Result{Submitted: true, Value: "confirm"}
 	}

--- a/internal/ui/components/actionprompt/actionprompt_test.go
+++ b/internal/ui/components/actionprompt/actionprompt_test.go
@@ -98,6 +98,38 @@ func TestPickerSubmitAndCancel(t *testing.T) {
 	}
 }
 
+func TestMultiPickerTogglesAndSubmitsCommaSeparatedValues(t *testing.T) {
+	cfg := Config{
+		Mode:  ModeMultiPicker,
+		Title: "Request reviewers",
+		Options: []Option{
+			{Label: "Alice A. (alice)", Value: "alice"},
+			{Label: "Bob B. (bob)", Value: "bob"},
+			{Label: "Carol C. (carol)", Value: "carol"},
+		},
+	}
+	m := New().Focus(cfg)
+	m, _, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	m, _, _ = m.Update(testKey('j'))
+	m, _, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+
+	view := m.View(120)
+	for _, want := range []string{"[x] Alice A. (alice)", "[x] Bob B. (bob)", "[ ] Carol C. (carol)"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("multi-picker view missing %q:\n%s", want, view)
+		}
+	}
+
+	var result Result
+	m, result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !result.Submitted || result.Value != "alice,bob" || result.Label != "Alice A. (alice), Bob B. (bob)" {
+		t.Fatalf("multi-picker submit = %+v, want alice/bob values and labels", result)
+	}
+	if m.Active() {
+		t.Fatal("prompt should close after multi-picker submit")
+	}
+}
+
 func TestSmallWidthRender(t *testing.T) {
 	m := New().Focus(Config{
 		Mode:        ModeText,


### PR DESCRIPTION
## Summary

- add a reusable multi-select action prompt mode
- list requestable reviewers through Gitea's repository reviewers API
- load reviewer candidates for request/remove reviewer actions and fall back to manual comma-separated entry when unavailable
- document that `@` uses a picker when the server exposes reviewers

## Verification

- `git diff --check`
- `bash scripts/check-public-hygiene.sh`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/tmp/tea-dash-go-cache make check`
- `GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...`
- `GOCACHE=/tmp/tea-dash-go-cache GOMODCACHE=/tmp/tea-dash-go-mod-cache make build`