### PR TITLE
feat(config): publish JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ sections. A fuller copyable example lives at
 [`examples/tea-dash.yml`](examples/tea-dash.yml).
 
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gbarany/tea-dash/main/schema.json
+
 instance:
   login: ""          # tea login profile to use (empty = your default tea login)
   # url:   ""        # override the instance URL (else taken from the tea login)
@@ -312,6 +314,10 @@ keybindings:
     - key: d
       builtin: delete
 ```
+
+tea-dash publishes a JSON Schema at
+[`schema.json`](schema.json). Add the `yaml-language-server` comment above to
+your config file to get editor validation and autocomplete in YAML-aware editors.
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gbarany/tea-dash/main/schema.json
+#
 # tea-dash example configuration.
 #
 # Copy this to one of tea-dash's config locations and adjust the repo names,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.4
 	code.gitea.io/sdk/gitea v0.25.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,336 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gbarany/tea-dash/main/schema.json",
+  "title": "tea-dash configuration",
+  "description": "Configuration schema for tea-dash, a terminal dashboard for Gitea and Forgejo.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "instance": { "$ref": "#/$defs/instance" },
+    "login": {
+      "type": "string",
+      "description": "Deprecated alias for instance.login."
+    },
+    "smartFilteringAtLaunch": {
+      "type": "boolean",
+      "description": "Scope unpinned PR/issue sections to the launch checkout when its remote matches the Gitea instance."
+    },
+    "confirmQuit": {
+      "type": "boolean",
+      "description": "Ask before quitting with q or ctrl+c."
+    },
+    "defaults": { "$ref": "#/$defs/defaults" },
+    "repos": {
+      "type": "array",
+      "description": "Remote Gitea repositories to watch, as owner/name strings.",
+      "items": { "$ref": "#/$defs/repoName" },
+      "uniqueItems": true
+    },
+    "localRepos": {
+      "type": "array",
+      "description": "Local git checkouts shown in the branches view.",
+      "items": { "$ref": "#/$defs/localRepo" }
+    },
+    "pager": { "$ref": "#/$defs/pager" },
+    "repoPaths": {
+      "type": "object",
+      "description": "Map repo names or wildcard patterns to local checkout paths used by checkout and custom commands.",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "git": { "$ref": "#/$defs/git" },
+    "theme": { "$ref": "#/$defs/theme" },
+    "prSections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "issuesSections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "notificationsSections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "actionsSections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "branchSections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "keybindings": { "$ref": "#/$defs/keybindings" }
+  },
+  "$defs": {
+    "instance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "login": {
+          "type": "string",
+          "description": "Named tea login profile to use. Empty means the default tea login."
+        },
+        "url": {
+          "type": "string",
+          "description": "Override the Gitea/Forgejo instance URL.",
+          "minLength": 1
+        },
+        "token": {
+          "type": "string",
+          "description": "Literal API token. Prefer tokenCommand or tokenEnv for shared configs."
+        },
+        "tokenCommand": {
+          "type": "string",
+          "description": "Shell command whose trimmed stdout is used as the API token."
+        },
+        "tokenEnv": {
+          "type": "string",
+          "description": "Environment variable name that contains the API token."
+        },
+        "insecureSkipVerify": {
+          "type": "boolean",
+          "description": "Disable TLS certificate verification."
+        },
+        "caCert": {
+          "type": "string",
+          "description": "Path to a private CA certificate bundle."
+        }
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "view": {
+          "type": "string",
+          "enum": ["prs", "issues", "notifications", "actions", "branches"],
+          "description": "Startup view."
+        },
+        "preview": { "$ref": "#/$defs/preview" },
+        "refetchIntervalMinutes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Auto-refresh interval for the active view. 0 disables background refresh."
+        },
+        "prsLimit": { "$ref": "#/$defs/nonNegativeInteger" },
+        "issuesLimit": { "$ref": "#/$defs/nonNegativeInteger" },
+        "notificationsLimit": { "$ref": "#/$defs/nonNegativeInteger" },
+        "includeReadNotifications": {
+          "type": "boolean",
+          "description": "Include read notification threads in default notification sections."
+        },
+        "actionsLimit": { "$ref": "#/$defs/nonNegativeInteger" },
+        "branchesLimit": { "$ref": "#/$defs/nonNegativeInteger" }
+      }
+    },
+    "preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "open": {
+          "type": "boolean",
+          "description": "Initial preview-pane state."
+        },
+        "width": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Preview pane width in columns. 0 means automatic."
+        }
+      }
+    },
+    "localRepo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["path"]
+    },
+    "pager": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "diff": {
+          "type": "string",
+          "description": "Command that receives PR diff bytes on stdin."
+        }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "remote": { "type": "string" },
+        "prBranchTemplate": { "type": "string" },
+        "issueBranchTemplate": { "type": "string" }
+      }
+    },
+    "theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "colors": { "$ref": "#/$defs/themeColors" }
+      }
+    },
+    "themeColors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "$ref": "#/$defs/themeTextColors" },
+        "background": { "$ref": "#/$defs/themeBackgroundColors" },
+        "border": { "$ref": "#/$defs/themeBorderColors" }
+      }
+    },
+    "themeTextColors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primary": { "$ref": "#/$defs/colorString" },
+        "secondary": { "$ref": "#/$defs/colorString" },
+        "inverted": { "$ref": "#/$defs/colorString" },
+        "faint": { "$ref": "#/$defs/colorString" },
+        "warning": { "$ref": "#/$defs/colorString" },
+        "success": { "$ref": "#/$defs/colorString" },
+        "actor": { "$ref": "#/$defs/colorString" }
+      }
+    },
+    "themeBackgroundColors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "selected": { "$ref": "#/$defs/colorString" }
+      }
+    },
+    "themeBorderColors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primary": { "$ref": "#/$defs/colorString" },
+        "secondary": { "$ref": "#/$defs/colorString" },
+        "faint": { "$ref": "#/$defs/colorString" }
+      }
+    },
+    "section": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Tab title."
+        },
+        "repo": {
+          "$ref": "#/$defs/repoName",
+          "description": "Optional owner/name repo scope for this section."
+        },
+        "filter": { "$ref": "#/$defs/filter" },
+        "limit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rows to fetch per page. 0 falls back to the per-view default."
+        }
+      }
+    },
+    "filter": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["open", "closed", "all"],
+          "description": "Issue or pull-request state."
+        },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "milestone": { "type": "string" },
+        "createdBy": { "$ref": "#/$defs/actorFilter" },
+        "assignedBy": { "$ref": "#/$defs/actorFilter" },
+        "mentioned": { "$ref": "#/$defs/actorFilter" },
+        "reviewRequested": { "$ref": "#/$defs/actorFilter" },
+        "since": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sort": { "type": "string" },
+        "status": { "type": "string" },
+        "branch": { "type": "string" },
+        "event": { "type": "string" },
+        "headSha": { "type": "string" },
+        "actor": { "type": "string" }
+      }
+    },
+    "keybindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "universal": { "$ref": "#/$defs/keybindingList" },
+        "prs": { "$ref": "#/$defs/keybindingList" },
+        "issues": { "$ref": "#/$defs/keybindingList" },
+        "notifications": { "$ref": "#/$defs/keybindingList" },
+        "actions": { "$ref": "#/$defs/keybindingList" },
+        "branches": { "$ref": "#/$defs/keybindingList" }
+      }
+    },
+    "keybindingList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/keybinding" }
+    },
+    "keybinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "builtin": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["key", "builtin"],
+          "not": { "required": ["command"] }
+        },
+        {
+          "required": ["key", "command"],
+          "not": { "required": ["builtin"] }
+        }
+      ]
+    },
+    "repoName": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "actorFilter": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Use @me for cross-repo sections. Plain logins require a repo-scoped section."
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "colorString": {
+      "type": "string",
+      "description": "Terminal color name/index or hex color."
+    }
+  }
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigSchemaValidatesExample(t *testing.T) {
+	schema := loadConfigSchema(t)
+	doc := loadYAMLDocument(t, "examples/tea-dash.yml")
+
+	if err := schema.Validate(doc); err != nil {
+		t.Fatalf("schema should validate examples/tea-dash.yml: %v", err)
+	}
+}
+
+func TestConfigSchemaRejectsUnknownRootField(t *testing.T) {
+	schema := loadConfigSchema(t)
+	doc := loadYAMLBytes(t, []byte(`
+instance:
+  login: ""
+notARealTeaDashSetting: true
+`))
+
+	err := schema.Validate(doc)
+	if err == nil {
+		t.Fatal("schema should reject unknown root fields")
+	}
+	if !strings.Contains(err.Error(), "notARealTeaDashSetting") {
+		t.Fatalf("schema error = %v, want it to mention the unknown field", err)
+	}
+}
+
+func TestConfigSchemaCoversDocumentedTopLevelKeys(t *testing.T) {
+	raw, err := os.ReadFile("schema.json")
+	if err != nil {
+		t.Fatalf("read schema.json: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("schema.json should be valid JSON: %v", err)
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v, want object", schema["properties"])
+	}
+	for _, key := range []string{
+		"instance",
+		"smartFilteringAtLaunch",
+		"confirmQuit",
+		"defaults",
+		"repos",
+		"localRepos",
+		"pager",
+		"repoPaths",
+		"git",
+		"theme",
+		"prSections",
+		"issuesSections",
+		"notificationsSections",
+		"actionsSections",
+		"branchSections",
+		"keybindings",
+	} {
+		if _, ok := props[key]; !ok {
+			t.Fatalf("schema is missing top-level property %q", key)
+		}
+	}
+}
+
+func loadConfigSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	f, err := os.Open("schema.json")
+	if err != nil {
+		t.Fatalf("open schema.json: %v", err)
+	}
+	defer f.Close()
+
+	doc, err := jsonschema.UnmarshalJSON(f)
+	if err != nil {
+		t.Fatalf("parse schema.json: %v", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", doc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	schema, err := compiler.Compile("schema.json")
+	if err != nil {
+		t.Fatalf("compile schema.json: %v", err)
+	}
+	return schema
+}
+
+func loadYAMLDocument(t *testing.T, path string) any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return loadYAMLBytes(t, raw)
+}
+
+func loadYAMLBytes(t *testing.T, raw []byte) any {
+	t.Helper()
+	var doc any
+	if err := yaml.NewDecoder(bytes.NewReader(raw)).Decode(&doc); err != nil {
+		t.Fatalf("parse YAML: %v", err)
+	}
+	return normalizeYAML(doc)
+}
+
+func normalizeYAML(v any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, val := range v {
+			out[k] = normalizeYAML(val)
+		}
+		return out
+	case []any:
+		for i := range v {
+			v[i] = normalizeYAML(v[i])
+		}
+		return v
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
## Summary
- add a public draft 2020-12 JSON Schema for tea-dash config
- add schema validation tests for the example config, unknown root fields, and documented top-level key coverage
- document the yaml-language-server directive in README and the example config

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test . -run 'TestConfigSchema' -v
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make build