### PR TITLE
feat(config): support included YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ sections. A fuller copyable example lives at
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/gbarany/tea-dash/main/schema.json
 
+include:
+  - ./shared-tea-dash.yml # loaded first; this file wins on conflicts
+
 instance:
   login: ""          # tea login profile to use (empty = your default tea login)
   # url:   ""        # override the instance URL (else taken from the tea login)
@@ -318,6 +321,12 @@ keybindings:
 tea-dash publishes a JSON Schema at
 [`schema.json`](schema.json). Add the `yaml-language-server` comment above to
 your config file to get editor validation and autocomplete in YAML-aware editors.
+
+Use `include` to share config across files. Include paths are resolved relative
+to the file declaring them unless they are absolute or start with `~`. Includes
+are loaded first; later includes override earlier includes; the current file
+overrides all included values. Nested maps merge recursively, while arrays and
+scalars replace the previous value.
 
 `filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -5,6 +5,11 @@
 # Copy this to one of tea-dash's config locations and adjust the repo names,
 # local checkout paths, and login name for your environment.
 
+# Optionally share defaults/keybindings/theme across files. Includes are loaded
+# first; this file overrides included values.
+# include:
+#   - ./shared-tea-dash.yml
+
 instance:
   # Empty means "use the default tea login". Set this to a named tea login when
   # you have multiple Gitea/Forgejo instances configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,9 @@ import (
 
 // Config is the user configuration for tea-dash.
 type Config struct {
+	// Include lists YAML files to load before this file. Paths are relative to
+	// the file declaring them unless they are absolute or start with "~".
+	Include []string `yaml:"include"`
 	// Instance overrides / selects the Gitea login (else tea's config is reused).
 	Instance Instance `yaml:"instance"`
 	// Login is a deprecated alias for Instance.Login (tea login profile name).
@@ -684,16 +687,133 @@ func Load(configPath ...string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return &Config{}, nil
-	}
+	raw, err := loadConfigMap(path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+				return &Config{}, nil
+			}
+		}
+		return nil, err
+	}
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("preparing %s: %w", path, err)
 	}
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 	return &cfg, nil
+}
+
+func loadConfigMap(file string, stack []string) (map[string]any, error) {
+	path, err := resolveConfigPath(file)
+	if err != nil {
+		return nil, err
+	}
+	for _, seen := range stack {
+		if seen == path {
+			return nil, fmt.Errorf("include cycle: %s", strings.Join(append(stack, path), " -> "))
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var current map[string]any
+	if err := yaml.Unmarshal(data, &current); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if current == nil {
+		current = map[string]any{}
+	}
+
+	includes, err := includePaths(current["include"])
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	merged := map[string]any{}
+	nextStack := append(stack, path)
+	for _, include := range includes {
+		includePath, err := resolveIncludePath(include, filepath.Dir(path))
+		if err != nil {
+			return nil, fmt.Errorf("%s include %q: %w", path, include, err)
+		}
+		included, err := loadConfigMap(includePath, nextStack)
+		if err != nil {
+			return nil, err
+		}
+		merged = mergeYAMLMaps(merged, included)
+	}
+	return mergeYAMLMaps(merged, current), nil
+}
+
+func resolveConfigPath(file string) (string, error) {
+	expanded, err := ExpandPath(file)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(expanded)
+}
+
+func resolveIncludePath(include, baseDir string) (string, error) {
+	include = strings.TrimSpace(include)
+	if include == "" {
+		return "", errors.New("path is required")
+	}
+	expanded, err := ExpandPath(include)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(expanded) {
+		return expanded, nil
+	}
+	return filepath.Join(baseDir, expanded), nil
+}
+
+func includePaths(v any) ([]string, error) {
+	switch v := v.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil, nil
+		}
+		return []string{v}, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("include[%d] must be a string", i)
+			}
+			if strings.TrimSpace(s) != "" {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	case []string:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("include must be a string or list of strings")
+	}
+}
+
+func mergeYAMLMaps(base, overlay map[string]any) map[string]any {
+	out := make(map[string]any, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		if baseMap, ok := out[k].(map[string]any); ok {
+			if overlayMap, ok := v.(map[string]any); ok {
+				out[k] = mergeYAMLMaps(baseMap, overlayMap)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -774,6 +774,127 @@ func TestLoadUsesRepoRootConfig(t *testing.T) {
 	}
 }
 
+func TestLoadMergesIncludesBeforeCurrentFile(t *testing.T) {
+	dir := t.TempDir()
+	shared := filepath.Join(dir, "shared.yml")
+	if err := os.WriteFile(shared, []byte(`
+defaults:
+  view: issues
+  preview:
+    open: false
+    width: 72
+repos:
+  - acme/shared
+repoPaths:
+  "acme/*": "~/src/acme/{{.Repo}}"
+keybindings:
+  universal:
+    - key: H
+      builtin: help
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := filepath.Join(dir, "tea-dash.yml")
+	if err := os.WriteFile(current, []byte(`
+include:
+  - ./shared.yml
+defaults:
+  view: prs
+  preview:
+    width: 90
+repos:
+  - acme/current
+keybindings:
+  universal:
+    - key: tab
+      builtin: nextSection
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(current)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Defaults.View != "prs" {
+		t.Fatalf("Defaults.View = %q, want current file to override include", cfg.Defaults.View)
+	}
+	if cfg.Defaults.Preview.Open == nil || *cfg.Defaults.Preview.Open {
+		t.Fatalf("Defaults.Preview.Open = %v, want included open=false to survive recursive map merge", cfg.Defaults.Preview.Open)
+	}
+	if cfg.Defaults.Preview.Width != 90 {
+		t.Fatalf("Defaults.Preview.Width = %d, want current file override", cfg.Defaults.Preview.Width)
+	}
+	if len(cfg.Repos) != 1 || cfg.Repos[0] != "acme/current" {
+		t.Fatalf("Repos = %v, want arrays to be replaced by the current file", cfg.Repos)
+	}
+	if got := cfg.RepoPaths["acme/*"]; got != "~/src/acme/{{.Repo}}" {
+		t.Fatalf("RepoPaths[acme/*] = %q, want included map value", got)
+	}
+	if len(cfg.Keybindings.Universal) != 1 || cfg.Keybindings.Universal[0].Key != "tab" {
+		t.Fatalf("Keybindings.Universal = %+v, want arrays to be replaced by current file", cfg.Keybindings.Universal)
+	}
+}
+
+func TestLoadIncludesLaterIncludeOverridesEarlierInclude(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "base.yml"), []byte(`
+defaults:
+  view: issues
+repoPaths:
+  "acme/*": "~/src/base/{{.Repo}}"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "later.yml"), []byte(`
+defaults:
+  view: notifications
+repoPaths:
+  "acme/*": "~/src/later/{{.Repo}}"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := filepath.Join(dir, "tea-dash.yml")
+	if err := os.WriteFile(current, []byte(`
+include:
+  - ./base.yml
+  - ./later.yml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(current)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Defaults.View != "notifications" {
+		t.Fatalf("Defaults.View = %q, want later include to override earlier include", cfg.Defaults.View)
+	}
+	if got := cfg.RepoPaths["acme/*"]; got != "~/src/later/{{.Repo}}" {
+		t.Fatalf("RepoPaths[acme/*] = %q, want later include override", got)
+	}
+}
+
+func TestLoadIncludeCycleErrors(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yml")
+	b := filepath.Join(dir, "b.yml")
+	if err := os.WriteFile(a, []byte("include:\n  - ./b.yml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("include:\n  - ./a.yml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(a)
+	if err == nil {
+		t.Fatal("Load should reject include cycles")
+	}
+	if !strings.Contains(err.Error(), "include cycle") {
+		t.Fatalf("Load error = %v, want include cycle", err)
+	}
+}
+
 func TestExampleConfigParsesAndValidates(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "examples", "tea-dash.yml"))
 	if err != nil {

--- a/schema.json
+++ b/schema.json
@@ -6,6 +6,22 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "include": {
+      "description": "YAML config files to load before this file. Relative paths resolve from the file declaring them. Later includes override earlier includes; this file overrides all includes.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
     "instance": { "$ref": "#/$defs/instance" },
     "login": {
       "type": "string",

--- a/schema_test.go
+++ b/schema_test.go
@@ -52,6 +52,7 @@ func TestConfigSchemaCoversDocumentedTopLevelKeys(t *testing.T) {
 		t.Fatalf("schema properties = %#v, want object", schema["properties"])
 	}
 	for _, key := range []string{
+		"include",
 		"instance",
 		"smartFilteringAtLaunch",
 		"confirmQuit",


### PR DESCRIPTION
## Summary
- add config include support with paths resolved relative to the declaring file
- merge includes before the current file, with later includes overriding earlier includes
- recursively merge maps while replacing arrays and scalar values
- reject include cycles with an actionable error
- document include and add it to schema.json

## Verification
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test ./internal/config . -run 'TestLoad(.*Include|Include)|TestConfigSchema' -v
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make build