### PR TITLE
feat(cli): add debug log flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ make build      # -> ./bin/tea-dash
 ```sh
 tea-dash            # start the dashboard
 tea-dash --config ./team.tea-dash.yml
+tea-dash --debug    # append debug output to ./debug.log
 tea-dash --version  # print version info
 tea-dash --help
 ```

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -43,6 +44,7 @@ func main() {
 
 type cliOptions struct {
 	configPath  string
+	debug       bool
 	showVersion bool
 	showHelp    bool
 }
@@ -52,6 +54,8 @@ func parseArgs(args []string) (cliOptions, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
+		case arg == "--debug":
+			opts.debug = true
 		case arg == "-v" || arg == "--version" || arg == "version":
 			opts.showVersion = true
 		case arg == "-h" || arg == "--help" || arg == "help":
@@ -76,6 +80,18 @@ func parseArgs(args []string) (cliOptions, error) {
 }
 
 func run(opts cliOptions) error {
+	cwd, _ := os.Getwd()
+	if cwd == "" {
+		cwd = "."
+	}
+	debugLog, err := startDebugLog(opts.debug, cwd)
+	if err != nil {
+		return err
+	}
+	if debugLog != nil {
+		defer debugLog.Close()
+	}
+
 	cfg, err := config.Load(opts.configPath)
 	if err != nil {
 		return err
@@ -104,7 +120,6 @@ func run(opts cliOptions) error {
 		return fmt.Errorf("connecting to %s: %w", authCfg.URL, err)
 	}
 
-	cwd, _ := os.Getwd()
 	model := ui.NewWithOptions(cfg, client, launchOptions(cfg, authCfg.URL, cwd))
 	runner := actionrunner.New(actionrunner.Options{
 		Client:      client,
@@ -117,6 +132,21 @@ func run(opts cliOptions) error {
 	p := tea.NewProgram(model)
 	_, err = p.Run()
 	return err
+}
+
+func startDebugLog(enabled bool, cwd string) (*os.File, error) {
+	if !enabled {
+		return nil, nil
+	}
+	f, err := os.OpenFile(filepath.Join(cwd, "debug.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening debug.log: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "tea-dash debug log started at %s\n", time.Now().Format(time.RFC3339)); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("writing debug.log: %w", err)
+	}
+	return f, nil
 }
 
 func launchOptions(cfg *config.Config, instanceURL, cwd string) ui.Options {
@@ -160,6 +190,7 @@ const usage = `tea-dash — a terminal dashboard for Gitea
 Usage:
   tea-dash                 start the dashboard
   tea-dash --config <path> use a specific config file
+  tea-dash --debug         append debug output to ./debug.log
   tea-dash --version       print version information
   tea-dash --help          show this help
 

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gbarany/tea-dash/internal/config"
@@ -74,6 +75,61 @@ func TestParseArgsVersion(t *testing.T) {
 	}
 	if !opts.showVersion {
 		t.Fatal("showVersion should be true")
+	}
+}
+
+func TestParseArgsDebug(t *testing.T) {
+	opts, err := parseArgs([]string{"--debug", "--config", "custom.yml"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if !opts.debug {
+		t.Fatal("debug should be true")
+	}
+	if opts.configPath != "custom.yml" {
+		t.Fatalf("configPath = %q, want custom.yml", opts.configPath)
+	}
+}
+
+func TestUsageMentionsDebugFlag(t *testing.T) {
+	if !strings.Contains(usage, "--debug") {
+		t.Fatalf("usage should mention --debug:\n%s", usage)
+	}
+}
+
+func TestStartDebugLogCreatesDebugLogInCurrentDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	f, err := startDebugLog(true, cwd)
+	if err != nil {
+		t.Fatalf("startDebugLog: %v", err)
+	}
+	if f == nil {
+		t.Fatal("startDebugLog should return a file when enabled")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close debug log: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(cwd, "debug.log"))
+	if err != nil {
+		t.Fatalf("read debug.log: %v", err)
+	}
+	if !strings.Contains(string(raw), "tea-dash debug log") {
+		t.Fatalf("debug.log = %q, want header", string(raw))
+	}
+}
+
+func TestStartDebugLogDisabledDoesNothing(t *testing.T) {
+	cwd := t.TempDir()
+	f, err := startDebugLog(false, cwd)
+	if err != nil {
+		t.Fatalf("startDebugLog: %v", err)
+	}
+	if f != nil {
+		t.Fatal("startDebugLog should return nil when disabled")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "debug.log")); !os.IsNotExist(err) {
+		t.Fatalf("debug.log should not exist when debug is disabled, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add gh-dash-style --debug parsing
- create/append ./debug.log with a startup header when debug is enabled
- document --debug in usage and README

## Verification
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test . -run 'Test(ParseArgsDebug|UsageMentionsDebugFlag|StartDebugLog)' -v
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make build