### PR TITLE
Probe merge capabilities before prompting

### DIFF
--- a/internal/data/merge_capabilities.go
+++ b/internal/data/merge_capabilities.go
@@ -1,0 +1,46 @@
+package data
+
+// MergeCapabilities describes the merge controls that should be offered for a
+// pull request. Strategy fields are usually repository-scoped settings from
+// Gitea/Forgejo; ForceMerge and AutoMerge are server/action capabilities.
+type MergeCapabilities struct {
+	Merge           bool
+	Squash          bool
+	Rebase          bool
+	RebaseMerge     bool
+	FastForwardOnly bool
+	ForceMerge      bool
+	AutoMerge       bool
+}
+
+// DefaultMergeCapabilities preserves the optimistic behavior used when no
+// repository capability probe is available.
+func DefaultMergeCapabilities() MergeCapabilities {
+	return MergeCapabilities{
+		Merge:           true,
+		Squash:          true,
+		Rebase:          true,
+		RebaseMerge:     true,
+		FastForwardOnly: true,
+		ForceMerge:      true,
+		AutoMerge:       true,
+	}
+}
+
+// SupportsStyle reports whether a merge strategy should be offered.
+func (c MergeCapabilities) SupportsStyle(style MergeStyle) bool {
+	switch style {
+	case MergeStyleMerge:
+		return c.Merge
+	case MergeStyleSquash:
+		return c.Squash
+	case MergeStyleRebase:
+		return c.Rebase
+	case MergeStyleRebaseMerge:
+		return c.RebaseMerge
+	case MergeStyleFastForwardOnly:
+		return c.FastForwardOnly
+	default:
+		return false
+	}
+}

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -312,6 +312,38 @@ func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.Merg
 	return merged, nil
 }
 
+// MergeCapabilities returns the merge choices the selected repository advertises.
+func (c *Client) MergeCapabilities(owner, repo string) (data.MergeCapabilities, error) {
+	var repository *sdk.Repository
+	err := c.call(func() error {
+		var e error
+		repository, _, e = c.sdk.GetRepo(owner, repo)
+		return e
+	})
+	if err != nil {
+		return data.DefaultMergeCapabilities(), fmt.Errorf("load merge capabilities for %s/%s: %w", owner, repo, err)
+	}
+	return mergeCapabilitiesFromRepository(repository), nil
+}
+
+func mergeCapabilitiesFromRepository(repo *sdk.Repository) data.MergeCapabilities {
+	caps := data.DefaultMergeCapabilities()
+	if repo == nil {
+		return caps
+	}
+	hasStyleSignal := repo.AllowMerge || repo.AllowSquash || repo.AllowRebase ||
+		repo.AllowRebaseMerge || repo.AllowFastForwardOnlyMerge
+	if !hasStyleSignal {
+		return caps
+	}
+	caps.Merge = repo.AllowMerge
+	caps.Squash = repo.AllowSquash
+	caps.Rebase = repo.AllowRebase
+	caps.RebaseMerge = repo.AllowRebaseMerge
+	caps.FastForwardOnly = repo.AllowFastForwardOnlyMerge
+	return caps
+}
+
 // UpdatePullRequest asks the server to update a PR branch with commits from its
 // base branch.
 func (c *Client) UpdatePullRequest(owner, repo string, index int64) error {

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -342,6 +342,41 @@ func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	}
 }
 
+func TestMergeCapabilitiesMapsRepositorySettings(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/repos/acme/widgets" {
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+		fmt.Fprint(w, `{
+			"id": 1,
+			"name": "widgets",
+			"full_name": "acme/widgets",
+			"allow_merge_commits": true,
+			"allow_squash_merge": false,
+			"allow_rebase": true,
+			"allow_rebase_explicit": false,
+			"allow_fast_forward_only_merge": true
+		}`)
+	})
+
+	got, err := c.MergeCapabilities("acme", "widgets")
+	if err != nil {
+		t.Fatalf("MergeCapabilities: %v", err)
+	}
+	want := data.MergeCapabilities{
+		Merge:           true,
+		Squash:          false,
+		Rebase:          true,
+		RebaseMerge:     false,
+		FastForwardOnly: true,
+		ForceMerge:      true,
+		AutoMerge:       true,
+	}
+	if got != want {
+		t.Fatalf("capabilities = %+v, want %+v", got, want)
+	}
+}
+
 func TestUpdatePullRequestPostsUpdateEndpoint(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -96,6 +96,12 @@ type reviewersLoadedMsg struct {
 	err       error
 }
 
+type mergeCapabilitiesLoadedMsg struct {
+	intent       actions.Intent
+	capabilities data.MergeCapabilities
+	err          error
+}
+
 // autoRefreshMsg is emitted by the optional background refetch timer.
 type autoRefreshMsg struct{}
 
@@ -378,6 +384,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case reviewersLoadedMsg:
 		return m.handleReviewersLoaded(msg), nil
+
+	case mergeCapabilitiesLoadedMsg:
+		return m.handleMergeCapabilitiesLoaded(msg), nil
 
 	case actions.ResultMsg:
 		m.notice = ""
@@ -1526,6 +1535,10 @@ func (m *Model) startAction(kind actions.Kind) tea.Cmd {
 		m.notice = "Loading reviewers..."
 		return loadReviewersCmd(m.ctx.Client, intent)
 	}
+	if kind == actions.KindMerge && m.ctx.Client != nil {
+		m.notice = "Loading merge options..."
+		return loadMergeCapabilitiesCmd(m.ctx.Client, intent)
+	}
 	m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(kind, target))
 	return nil
 }
@@ -1838,6 +1851,25 @@ func (m *Model) handleReviewersLoaded(msg reviewersLoadedMsg) Model {
 	return *m
 }
 
+func (m *Model) handleMergeCapabilitiesLoaded(msg mergeCapabilitiesLoadedMsg) Model {
+	if msg.intent.Kind != actions.KindMerge {
+		return *m
+	}
+	if m.pendingAction.Kind != msg.intent.Kind || m.pendingAction.Target != msg.intent.Target {
+		return *m
+	}
+	m.pendingAction = msg.intent
+	caps := msg.capabilities
+	if msg.err != nil {
+		m.notice = fmt.Sprintf("Couldn't load merge settings: %v. Showing default merge options.", msg.err)
+		caps = data.DefaultMergeCapabilities()
+	} else {
+		m.notice = ""
+	}
+	m.actionPrompt = m.actionPrompt.Focus(promptConfigForActionWithMergeCapabilities(msg.intent.Kind, msg.intent.Target, caps))
+	return *m
+}
+
 func reviewerPickerAction(kind actions.Kind) bool {
 	return kind == actions.KindRequestReviewers || kind == actions.KindRemoveReviewers
 }
@@ -1850,6 +1882,17 @@ func loadReviewersCmd(client *gitea.Client, intent actions.Intent) tea.Cmd {
 		}
 		reviewers, err := client.ListReviewers(owner, repo)
 		return reviewersLoadedMsg{intent: intent, reviewers: reviewers, err: err}
+	}
+}
+
+func loadMergeCapabilitiesCmd(client *gitea.Client, intent actions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		owner, repo, ok := data.SplitOwnerRepo(intent.Target.Repo)
+		if !ok {
+			return mergeCapabilitiesLoadedMsg{intent: intent, err: fmt.Errorf("invalid repository %q", intent.Target.Repo)}
+		}
+		caps, err := client.MergeCapabilities(owner, repo)
+		return mergeCapabilitiesLoadedMsg{intent: intent, capabilities: caps, err: err}
 	}
 }
 
@@ -2061,6 +2104,10 @@ func promptModeForAction(kind actions.Kind) actions.PromptMode {
 }
 
 func promptConfigForAction(kind actions.Kind, target actions.Target) actionprompt.Config {
+	return promptConfigForActionWithMergeCapabilities(kind, target, data.DefaultMergeCapabilities())
+}
+
+func promptConfigForActionWithMergeCapabilities(kind actions.Kind, target actions.Target, caps data.MergeCapabilities) actionprompt.Config {
 	title := fmt.Sprintf("%s #%d", actionLabel(kind), target.Number)
 	message := fmt.Sprintf("%s - %s", target.Repo, target.Title)
 	if kind == actions.KindSwitchBranch || kind == actions.KindPushBranch || kind == actions.KindForcePushBranch || kind == actions.KindFastForwardBranch || kind == actions.KindDeleteBranch {
@@ -2125,41 +2172,7 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 			Mode:    actionprompt.ModePicker,
 			Title:   title,
 			Message: message,
-			Options: []actionprompt.Option{
-				{Label: "Merge", Value: string(data.MergeStyleMerge)},
-				{Label: "Squash", Value: string(data.MergeStyleSquash)},
-				{Label: "Rebase", Value: string(data.MergeStyleRebase)},
-				{Label: "Rebase merge", Value: string(data.MergeStyleRebaseMerge)},
-				{Label: "Fast-forward only", Value: string(data.MergeStyleFastForwardOnly)},
-				{Label: "Merge with message", Value: string(data.MergeStyleMerge) + "+message"},
-				{Label: "Squash with message", Value: string(data.MergeStyleSquash) + "+message"},
-				{Label: "Rebase merge with message", Value: string(data.MergeStyleRebaseMerge) + "+message"},
-				{Label: "Merge + delete branch", Value: string(data.MergeStyleMerge) + "+delete"},
-				{Label: "Squash + delete branch", Value: string(data.MergeStyleSquash) + "+delete"},
-				{Label: "Rebase + delete branch", Value: string(data.MergeStyleRebase) + "+delete"},
-				{Label: "Rebase merge + delete branch", Value: string(data.MergeStyleRebaseMerge) + "+delete"},
-				{Label: "Fast-forward only + delete branch", Value: string(data.MergeStyleFastForwardOnly) + "+delete"},
-				{Label: "Merge + force merge", Value: string(data.MergeStyleMerge) + "+force"},
-				{Label: "Squash + force merge", Value: string(data.MergeStyleSquash) + "+force"},
-				{Label: "Rebase + force merge", Value: string(data.MergeStyleRebase) + "+force"},
-				{Label: "Rebase merge + force merge", Value: string(data.MergeStyleRebaseMerge) + "+force"},
-				{Label: "Fast-forward only + force merge", Value: string(data.MergeStyleFastForwardOnly) + "+force"},
-				{Label: "Merge when checks pass", Value: string(data.MergeStyleMerge) + "+auto"},
-				{Label: "Squash when checks pass", Value: string(data.MergeStyleSquash) + "+auto"},
-				{Label: "Rebase when checks pass", Value: string(data.MergeStyleRebase) + "+auto"},
-				{Label: "Rebase merge when checks pass", Value: string(data.MergeStyleRebaseMerge) + "+auto"},
-				{Label: "Fast-forward only when checks pass", Value: string(data.MergeStyleFastForwardOnly) + "+auto"},
-				{Label: "Merge + delete branch when checks pass", Value: string(data.MergeStyleMerge) + "+delete+auto"},
-				{Label: "Squash + delete branch when checks pass", Value: string(data.MergeStyleSquash) + "+delete+auto"},
-				{Label: "Rebase + delete branch when checks pass", Value: string(data.MergeStyleRebase) + "+delete+auto"},
-				{Label: "Rebase merge + delete branch when checks pass", Value: string(data.MergeStyleRebaseMerge) + "+delete+auto"},
-				{Label: "Fast-forward only + delete branch when checks pass", Value: string(data.MergeStyleFastForwardOnly) + "+delete+auto"},
-				{Label: "Merge + delete branch + force merge", Value: string(data.MergeStyleMerge) + "+delete+force"},
-				{Label: "Squash + delete branch + force merge", Value: string(data.MergeStyleSquash) + "+delete+force"},
-				{Label: "Rebase + delete branch + force merge", Value: string(data.MergeStyleRebase) + "+delete+force"},
-				{Label: "Rebase merge + delete branch + force merge", Value: string(data.MergeStyleRebaseMerge) + "+delete+force"},
-				{Label: "Fast-forward only + delete branch + force merge", Value: string(data.MergeStyleFastForwardOnly) + "+delete+force"},
-			},
+			Options: mergePromptOptions(caps),
 		}
 	case actions.KindCancelRun:
 		return actionprompt.Config{
@@ -2174,6 +2187,68 @@ func promptConfigForAction(kind actions.Kind, target actions.Target) actionpromp
 			Message: message,
 		}
 	}
+}
+
+type mergePromptStyle struct {
+	Label   string
+	Style   data.MergeStyle
+	Message bool
+}
+
+func mergePromptOptions(caps data.MergeCapabilities) []actionprompt.Option {
+	styles := []mergePromptStyle{
+		{Label: "Merge", Style: data.MergeStyleMerge, Message: true},
+		{Label: "Squash", Style: data.MergeStyleSquash, Message: true},
+		{Label: "Rebase", Style: data.MergeStyleRebase},
+		{Label: "Rebase merge", Style: data.MergeStyleRebaseMerge, Message: true},
+		{Label: "Fast-forward only", Style: data.MergeStyleFastForwardOnly},
+	}
+	supported := make([]mergePromptStyle, 0, len(styles))
+	for _, style := range styles {
+		if caps.SupportsStyle(style.Style) {
+			supported = append(supported, style)
+		}
+	}
+	if len(supported) == 0 {
+		caps = data.DefaultMergeCapabilities()
+		supported = styles
+	}
+
+	options := make([]actionprompt.Option, 0, 32)
+	add := func(label string, style data.MergeStyle, suffix string) {
+		options = append(options, actionprompt.Option{Label: label, Value: string(style) + suffix})
+	}
+
+	for _, style := range supported {
+		add(style.Label, style.Style, "")
+	}
+	for _, style := range supported {
+		if style.Message {
+			add(style.Label+" with message", style.Style, "+message")
+		}
+	}
+	for _, style := range supported {
+		add(style.Label+" + delete branch", style.Style, "+delete")
+	}
+	if caps.ForceMerge {
+		for _, style := range supported {
+			add(style.Label+" + force merge", style.Style, "+force")
+		}
+	}
+	if caps.AutoMerge {
+		for _, style := range supported {
+			add(style.Label+" when checks pass", style.Style, "+auto")
+		}
+		for _, style := range supported {
+			add(style.Label+" + delete branch when checks pass", style.Style, "+delete+auto")
+		}
+	}
+	if caps.ForceMerge {
+		for _, style := range supported {
+			add(style.Label+" + delete branch + force merge", style.Style, "+delete+force")
+		}
+	}
+	return options
 }
 
 func actionLabel(kind actions.Kind) string {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -18,6 +18,7 @@ import (
 	localgit "github.com/gbarany/tea-dash/internal/git"
 	"github.com/gbarany/tea-dash/internal/gitea"
 	"github.com/gbarany/tea-dash/internal/ui/actions"
+	"github.com/gbarany/tea-dash/internal/ui/components/actionprompt"
 	"github.com/gbarany/tea-dash/internal/ui/components/actionsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/branchsection"
 	"github.com/gbarany/tea-dash/internal/ui/components/issuesection"
@@ -2157,6 +2158,89 @@ func TestMergePromptIncludesAutoMergeOptions(t *testing.T) {
 	}
 }
 
+func TestMergePromptFiltersUnsupportedCapabilities(t *testing.T) {
+	caps := data.DefaultMergeCapabilities()
+	caps.Squash = false
+	caps.Rebase = false
+	caps.RebaseMerge = false
+	caps.FastForwardOnly = false
+	caps.ForceMerge = false
+	caps.AutoMerge = false
+
+	cfg := promptConfigForActionWithMergeCapabilities(actions.KindMerge, actions.Target{}, caps)
+	labels := optionLabels(cfg.Options)
+	for _, want := range []string{"Merge", "Merge with message", "Merge + delete branch"} {
+		if !strings.Contains(labels, want) {
+			t.Fatalf("merge prompt missing %q in labels:\n%s", want, labels)
+		}
+	}
+	for _, blocked := range []string{"Squash", "Rebase", "Fast-forward", "force merge", "checks pass"} {
+		if strings.Contains(labels, blocked) {
+			t.Fatalf("merge prompt should not include unsupported %q labels:\n%s", blocked, labels)
+		}
+	}
+}
+
+func TestMergePromptLoadsRepositoryCapabilitiesBeforeOpening(t *testing.T) {
+	client := mergeCapabilitiesClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/gbarany/tea-dash" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{
+			"id": 1,
+			"name": "tea-dash",
+			"full_name": "gbarany/tea-dash",
+			"allow_merge_commits": true,
+			"allow_squash_merge": false,
+			"allow_rebase": false,
+			"allow_rebase_explicit": false,
+			"allow_fast_forward_only_merge": false
+		}`)
+	})
+	m := New(&config.Config{}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 42, Title: "Action row", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("merge should fetch repository capabilities before opening the prompt")
+	}
+	if m.actionPrompt.Active() {
+		t.Fatal("merge prompt should wait for capability loading before opening")
+	}
+	msg := cmd()
+	loaded, ok := msg.(mergeCapabilitiesLoadedMsg)
+	if !ok || loaded.err != nil {
+		t.Fatalf("merge capability load msg = %#v, want success", msg)
+	}
+
+	m = update(t, m, loaded)
+	view := m.actionPrompt.View(160)
+	if !strings.Contains(view, "Merge + delete branch") {
+		t.Fatalf("merge prompt should include allowed merge options:\n%s", view)
+	}
+	for _, blocked := range []string{"Squash", "Rebase", "Fast-forward"} {
+		if strings.Contains(view, blocked) {
+			t.Fatalf("merge prompt should hide unsupported %q options:\n%s", blocked, view)
+		}
+	}
+}
+
+func optionLabels(options []actionprompt.Option) string {
+	var labels []string
+	for _, opt := range options {
+		labels = append(labels, opt.Label)
+	}
+	return strings.Join(labels, "\n")
+}
+
 func TestMergePromptIncludesMessageOptions(t *testing.T) {
 	m := New(&config.Config{}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -3428,6 +3512,28 @@ func reviewerClient(t *testing.T, reviewersHandler http.HandlerFunc) *gitea.Clie
 	})
 	if reviewersHandler != nil {
 		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/reviewers", reviewersHandler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func mergeCapabilitiesClient(t *testing.T, repoHandler http.HandlerFunc) *gitea.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	if repoHandler != nil {
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash", repoHandler)
 	}
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)


### PR DESCRIPTION
## Summary
- Adds a domain MergeCapabilities model and maps repository merge strategy settings from Gitea/Forgejo via the SDK.
- Loads merge capabilities before opening the merge picker for live clients.
- Filters unsupported merge strategies from the picker while preserving default behavior when no probe is available.

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- make check
- go test -race -count=1 ./...
- make build