### PR TITLE
Degrade gracefully when Actions API is unavailable

### DIFF
--- a/internal/gitea/actions.go
+++ b/internal/gitea/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -98,6 +99,9 @@ func (c *Client) ListActionRuns(ctx context.Context, owner, repo string, opts Ac
 
 	var raw json.RawMessage
 	if _, err := c.rawGet(ctx, path, &raw); err != nil {
+		if isHTTPStatus(err, http.StatusNotFound) {
+			return nil, 0, nil
+		}
 		return nil, 0, err
 	}
 	rows, total, err := decodeActionRuns(raw)

--- a/internal/gitea/actions_test.go
+++ b/internal/gitea/actions_test.go
@@ -125,6 +125,27 @@ func TestListActionRunsMapsArrayResponse(t *testing.T) {
 	}
 }
 
+func TestListActionRunsReturnsEmptyWhenActionsEndpointIsMissing(t *testing.T) {
+	srv := actionServer(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		})
+	})
+
+	c, err := NewClient(context.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	runs, total, err := c.ListActionRuns(context.Background(), "acme", "widgets", ActionRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListActionRuns should degrade 404 to an empty unsupported-Actions list, got %v", err)
+	}
+	if total != 0 || len(runs) != 0 {
+		t.Fatalf("got total=%d len=%d, want no runs for missing Actions endpoint", total, len(runs))
+	}
+}
+
 func TestGetActionRunMapsSingleRun(t *testing.T) {
 	srv := actionServer(t, func(mux *http.ServeMux) {
 		mux.HandleFunc("/api/v1/repos/acme/widgets/actions/runs/101", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/gitea/http_error.go
+++ b/internal/gitea/http_error.go
@@ -1,0 +1,24 @@
+package gitea
+
+import (
+	"errors"
+	"fmt"
+)
+
+// HTTPError is returned by raw REST helpers for non-2xx responses.
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("gitea %s %s: %s: %s", e.Method, e.Path, e.Status, e.Body)
+}
+
+func isHTTPStatus(err error, code int) bool {
+	var httpErr *HTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == code
+}

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -489,7 +489,13 @@ func (c *Client) rawGet(ctx context.Context, path string, out any) (http.Header,
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("gitea GET %s: %s: %s", path, resp.Status, truncate(body, 500))
+		return nil, &HTTPError{
+			Method:     http.MethodGet,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       truncate(body, 500),
+		}
 	}
 	if err := json.Unmarshal(body, out); err != nil {
 		return nil, fmt.Errorf("decoding gitea GET %s: %w", path, err)
@@ -522,7 +528,13 @@ func (c *Client) rawGetBytes(ctx context.Context, path string, accept string) ([
 		return nil, nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, fmt.Errorf("gitea GET %s: %s: %s", path, resp.Status, truncate(body, 500))
+		return nil, nil, &HTTPError{
+			Method:     http.MethodGet,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       truncate(body, 500),
+		}
 	}
 	return body, resp.Header, nil
 }
@@ -549,7 +561,13 @@ func (c *Client) rawPost(ctx context.Context, path string) error {
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("gitea POST %s: %s: %s", path, resp.Status, truncate(body, 500))
+		return &HTTPError{
+			Method:     http.MethodPost,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       truncate(body, 500),
+		}
 	}
 	return nil
 }

--- a/internal/ui/components/actionsection/actionsection.go
+++ b/internal/ui/components/actionsection/actionsection.go
@@ -109,7 +109,7 @@ func actionEmptyHint(cfg config.SectionConfig) string {
 	if strings.TrimSpace(cfg.Repo) == "" {
 		return "Add actionsSections with repo: owner/name to your tea-dash config."
 	}
-	return "This board shows repo-scoped Gitea Actions workflow runs."
+	return "This board shows repo-scoped Gitea Actions workflow runs when the server exposes the Actions API."
 }
 
 func actionColumns(mainWidth int) []table.Column {


### PR DESCRIPTION
## Summary
- Adds typed HTTP status errors for raw Gitea REST helpers.
- Treats a missing repo Actions runs endpoint as an empty Actions section instead of a fetch error.
- Updates the Actions empty-state hint to explain that the server must expose the Actions API.

## Verification
- git diff --check
- bash scripts/check-public-hygiene.sh
- make check
- go test -race -count=1 ./...
- make build