### PR TITLE
Configurable PR and issue table columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ theme:
 # to get one open "@me"-authored issues section.
 prSections:
   - title: Open PRs
+    columns:
+      - number
+      - name: title
+        title: Summary
+        width: 52
+      - repo
+      - state
+      - updated
     filter:
       state: open          # open | closed | all (default open)
       createdBy: "@me"     # me-scoped author fields accept "@me" only
@@ -333,6 +341,10 @@ scalars replace the previous value.
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),
 `sort`. PR and issue sections fetch one page at a time; reaching the loaded
 bottom automatically requests the next page until the server total is loaded.
+PR and issue sections can also set `columns` to choose table order and width.
+Supported column names are `number`, `title`, `repo`, `author`, `state`, and
+`updated`; each entry may be a plain string or an object with `name`, optional
+`title`, and optional non-negative `width`.
 When `repos:` is configured, sections without their own `repo:` use the
 repo-scoped endpoint for each listed repo and merge the results by updated time;
 sections with `repo:` query only that repo. With neither `repos:` nor `repo:`,

--- a/examples/tea-dash.yml
+++ b/examples/tea-dash.yml
@@ -47,6 +47,14 @@ git:
 
 prSections:
   - title: Open PRs
+    columns:
+      - number
+      - name: title
+        title: Summary
+        width: 52
+      - repo
+      - state
+      - updated
     filter:
       state: open
       createdBy: "@me"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,10 +261,52 @@ type SectionConfig struct {
 	Title  string        `yaml:"title"`
 	Repo   string        `yaml:"repo"`
 	Filter PrIssueFilter `yaml:"filter"`
+	// Columns optionally selects and orders visible table columns for PR/issue
+	// sections. Entries may be YAML strings or objects with name/title/width.
+	Columns []ColumnConfig `yaml:"columns"`
 	// Limit caps this section's row fetch. 0 falls back to the per-view default
 	// (defaults.prsLimit / defaults.issuesLimit / etc.), which in turn falls back to 50.
 	// Precedence: section Limit -> per-view default -> 50.
 	Limit int `yaml:"limit"`
+}
+
+// ColumnConfig selects one visible PR/issue table column.
+type ColumnConfig struct {
+	Name  string `yaml:"name"`
+	Title string `yaml:"title"`
+	Width int    `yaml:"width"`
+}
+
+var prIssueColumnNames = []string{"number", "title", "repo", "author", "state", "updated"}
+
+var prIssueColumnNameSet = func() map[string]struct{} {
+	out := make(map[string]struct{}, len(prIssueColumnNames))
+	for _, name := range prIssueColumnNames {
+		out[name] = struct{}{}
+	}
+	return out
+}()
+
+// UnmarshalYAML accepts either a terse string entry ("title") or an object:
+// {name: title, width: 42, title: Summary}.
+func (c *ColumnConfig) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		c.Name = strings.TrimSpace(value.Value)
+		return nil
+	case yaml.MappingNode:
+		type rawColumnConfig ColumnConfig
+		var raw rawColumnConfig
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		*c = ColumnConfig(raw)
+		c.Name = strings.TrimSpace(c.Name)
+		c.Title = strings.TrimSpace(c.Title)
+		return nil
+	default:
+		return fmt.Errorf("column must be a string or mapping")
+	}
 }
 
 // LocalRepoConfig describes one local git checkout to include in the branches
@@ -338,21 +380,47 @@ func (f PrIssueFilter) validate(repoScoped bool) error {
 	return nil
 }
 
-func validatePrIssueSection(kind string, s SectionConfig, hasGlobalRepos bool) error {
+func validatePrIssueSection(kind string, idx int, s SectionConfig, hasGlobalRepos bool) error {
 	if kind == "issuesSections" && strings.TrimSpace(s.Filter.ReviewRequested) != "" {
 		return fmt.Errorf("%s.filter.reviewRequested is only supported for PR sections", kind)
 	}
 	hasSectionRepo := strings.TrimSpace(s.Repo) != ""
 	if hasSectionRepo {
 		if _, err := ParseRepo(s.Repo); err != nil {
-			return fmt.Errorf("%s.repo: %w", kind, err)
+			return fmt.Errorf("%s[%d].repo: %w", kind, idx, err)
 		}
+	}
+	if err := validateSectionColumns(kind, idx, s.Columns); err != nil {
+		return err
 	}
 	repoScoped := hasSectionRepo || (hasGlobalRepos && strings.TrimSpace(s.Filter.ReviewRequested) == "")
 	if err := s.Filter.validate(repoScoped); err != nil {
-		return err
+		return fmt.Errorf("%s[%d].%w", kind, idx, err)
 	}
 	return nil
+}
+
+func validateSectionColumns(kind string, sectionIndex int, columns []ColumnConfig) error {
+	for i, col := range columns {
+		name := strings.TrimSpace(col.Name)
+		if name == "" {
+			return fmt.Errorf("%s[%d].columns[%d].name is required", kind, sectionIndex, i)
+		}
+		if _, ok := prIssueColumnNameSet[name]; !ok {
+			return fmt.Errorf("%s[%d].columns[%d].name = %q: supported columns are %s", kind, sectionIndex, i, col.Name, strings.Join(prIssueColumnNames, ", "))
+		}
+		if col.Width < 0 {
+			return fmt.Errorf("%s[%d].columns[%d].width must be >= 0", kind, sectionIndex, i)
+		}
+	}
+	return nil
+}
+
+func rejectUnsupportedColumns(kind string, sectionIndex int, columns []ColumnConfig) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s[%d].columns is only supported for prSections and issuesSections", kind, sectionIndex)
 }
 
 // Validate checks the config for unsupported filter values and an invalid
@@ -363,22 +431,28 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("repos[%d]: %w", i, err)
 		}
 	}
-	for _, s := range c.PRSections {
-		if err := validatePrIssueSection("prSections", s, len(c.Repos) > 0); err != nil {
+	for i, s := range c.PRSections {
+		if err := validatePrIssueSection("prSections", i, s, len(c.Repos) > 0); err != nil {
 			return err
 		}
 	}
-	for _, s := range c.IssuesSections {
-		if err := validatePrIssueSection("issuesSections", s, len(c.Repos) > 0); err != nil {
+	for i, s := range c.IssuesSections {
+		if err := validatePrIssueSection("issuesSections", i, s, len(c.Repos) > 0); err != nil {
 			return err
 		}
 	}
-	for _, s := range c.NotificationsSections {
+	for i, s := range c.NotificationsSections {
+		if err := rejectUnsupportedColumns("notificationsSections", i, s.Columns); err != nil {
+			return err
+		}
 		if err := s.Filter.Validate(); err != nil {
 			return err
 		}
 	}
-	for _, s := range c.ActionsSections {
+	for i, s := range c.ActionsSections {
+		if err := rejectUnsupportedColumns("actionsSections", i, s.Columns); err != nil {
+			return err
+		}
 		if strings.TrimSpace(s.Repo) == "" {
 			continue
 		}
@@ -386,7 +460,10 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("actionsSections.repo: %w", err)
 		}
 	}
-	for _, s := range c.BranchSections {
+	for i, s := range c.BranchSections {
+		if err := rejectUnsupportedColumns("branchSections", i, s.Columns); err != nil {
+			return err
+		}
 		if err := s.Filter.Validate(); err != nil {
 			return err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -91,6 +91,12 @@ defaults:
   branchesLimit: 100
 prSections:
   - title: My PRs
+    columns:
+      - number
+      - name: title
+        title: Summary
+        width: 42
+      - repo
     filter:
       state: open
       createdBy: "@me"
@@ -137,6 +143,12 @@ localRepos:
 	if len(c.PRSections) != 2 || c.PRSections[0].Title != "My PRs" ||
 		c.PRSections[1].Filter.ReviewRequested != "@me" {
 		t.Fatalf("prSections = %+v", c.PRSections)
+	}
+	if cols := c.PRSections[0].Columns; len(cols) != 3 ||
+		cols[0].Name != "number" ||
+		cols[1].Name != "title" || cols[1].Title != "Summary" || cols[1].Width != 42 ||
+		cols[2].Name != "repo" {
+		t.Fatalf("PR section columns = %+v", cols)
 	}
 	if len(c.IssuesSections) != 1 || c.IssuesSections[0].Title != "My Issues" ||
 		c.IssuesSections[0].Filter.CreatedBy != "@me" {
@@ -569,6 +581,54 @@ func TestConfigValidateRejectsBadSectionFilter(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() should reject a section with a non-@me author filter")
+	}
+}
+
+func TestConfigValidateRejectsUnknownColumn(t *testing.T) {
+	cfg := &Config{
+		PRSections: []SectionConfig{
+			{Title: "Bad", Columns: []ColumnConfig{{Name: "unknown"}}},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() should reject an unknown table column")
+	}
+	if !strings.Contains(err.Error(), "prSections[0].columns[0]") || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("Validate() error = %v, want section/column path and column name", err)
+	}
+}
+
+func TestConfigValidateRejectsNegativeColumnWidth(t *testing.T) {
+	cfg := &Config{
+		IssuesSections: []SectionConfig{
+			{Title: "Bad", Columns: []ColumnConfig{{Name: "title", Width: -1}}},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() should reject a negative table column width")
+	}
+	if !strings.Contains(err.Error(), "issuesSections[0].columns[0].width") {
+		t.Fatalf("Validate() error = %v, want section/column width path", err)
+	}
+}
+
+func TestConfigValidateRejectsColumnsOnUnsupportedSections(t *testing.T) {
+	for name, cfg := range map[string]*Config{
+		"notifications": {NotificationsSections: []SectionConfig{{Title: "Inbox", Columns: []ColumnConfig{{Name: "title"}}}}},
+		"actions":       {ActionsSections: []SectionConfig{{Title: "CI", Columns: []ColumnConfig{{Name: "title"}}}}},
+		"branches":      {BranchSections: []SectionConfig{{Title: "Branches", Columns: []ColumnConfig{{Name: "title"}}}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("Validate() should reject columns on unsupported section types")
+			}
+			if !strings.Contains(err.Error(), "columns") {
+				t.Fatalf("Validate() error = %v, want it to mention columns", err)
+			}
+		})
 	}
 }
 

--- a/internal/ui/components/issuesection/issuesection.go
+++ b/internal/ui/components/issuesection/issuesection.go
@@ -27,6 +27,7 @@ type SectionIssuesFetchedMsg = section.RowsFetchedMsg[data.Issue]
 // NewModel builds an issues section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
 	programCtx := ctx
+	columnNames := section.ColumnNamesFromConfig(cfg.Columns, section.DefaultColumnDefinitions(ctx.MainContentWidth))
 	return section.New(section.Options[data.Issue]{
 		Id:           id,
 		Ctx:          ctx,
@@ -49,7 +50,12 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 			}
 			return c.SearchIssuesPage(fetchCtx, f, limit, page)
 		},
-		BuildRow: issueBuildRow,
+		BuildRow: func(issue data.Issue) table.Row {
+			return issueBuildRowWithColumns(issue, columnNames)
+		},
+		Columns: func(width int) []table.Column {
+			return section.ColumnsFromConfig(cfg.Columns, section.DefaultColumnDefinitions(width))
+		},
 	})
 }
 
@@ -63,18 +69,38 @@ func effectiveRepo(ctx *appctx.ProgramContext, cfg config.SectionConfig) string 
 	return ctx.CurrentRepo
 }
 
-// issueBuildRow maps an issue into the table's 6-cell row.
+// issueBuildRow maps an issue into the default table row.
 func issueBuildRow(issue data.Issue) table.Row {
+	return issueBuildRowWithColumns(issue, section.DefaultColumnNames())
+}
+
+func issueBuildRowWithColumns(issue data.Issue, columns []string) table.Row {
+	row := make(table.Row, 0, len(columns))
+	for _, column := range columns {
+		row = append(row, issueColumnValue(issue, column))
+	}
+	return row
+}
+
+func issueColumnValue(issue data.Issue, column string) string {
 	author := ""
 	if issue.Author != "" {
 		author = "@" + issue.Author
 	}
-	return table.Row{
-		fmt.Sprintf("#%d", issue.Number),
-		issue.Title,
-		issue.RepoNameWithOwner,
-		author,
-		issue.State,
-		section.HumanizeTime(issue.UpdatedAt),
+	switch column {
+	case "number":
+		return fmt.Sprintf("#%d", issue.Number)
+	case "title":
+		return issue.Title
+	case "repo":
+		return issue.RepoNameWithOwner
+	case "author":
+		return author
+	case "state":
+		return issue.State
+	case "updated":
+		return section.HumanizeTime(issue.UpdatedAt)
+	default:
+		return ""
 	}
 }

--- a/internal/ui/components/issuesection/issuesection_test.go
+++ b/internal/ui/components/issuesection/issuesection_test.go
@@ -112,6 +112,39 @@ func TestFetchedMsgBuildsRows(t *testing.T) {
 	}
 }
 
+func TestConfiguredColumnsBuildIssueRowsInConfiguredOrder(t *testing.T) {
+	ctx := &context.ProgramContext{Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title: "Compact Issues",
+		Columns: []config.ColumnConfig{
+			{Name: "repo", Width: 20},
+			{Name: "number", Width: 8},
+			{Name: "title", Title: "Summary"},
+		},
+	})
+	if got := m.Columns; len(got) != 3 ||
+		got[0].Title != "Repo" || got[0].Width != 20 ||
+		got[1].Title != "#" || got[1].Width != 8 ||
+		got[2].Title != "Summary" {
+		t.Fatalf("columns = %+v", got)
+	}
+
+	m.SetLastFetchID("t1")
+	next, _ := m.Update(SectionIssuesFetchedMsg{
+		Rows: []data.Issue{{
+			Number: 77, Title: "Bug X", RepoNameWithOwner: "acme/widgets",
+			Author: "octo", State: "open", UpdatedAt: time.Now().Add(-2 * time.Hour),
+		}},
+		TotalCount: 1, TaskId: "t1",
+	})
+	m = next.(*Model)
+	row := m.BuildRows()[0]
+	want := []string{"acme/widgets", "#77", "Bug X"}
+	if strings.Join([]string(row), "|") != strings.Join(want, "|") {
+		t.Fatalf("row = %v, want %v", row, want)
+	}
+}
+
 func TestStaleFetchIgnored(t *testing.T) {
 	m := newModel(t)
 	m.SetLastFetchID("t2") // an in-flight fetch t2 is expected

--- a/internal/ui/components/pullsection/pullsection.go
+++ b/internal/ui/components/pullsection/pullsection.go
@@ -27,6 +27,7 @@ type SectionPullRequestsFetchedMsg = section.RowsFetchedMsg[data.PullRequest]
 // NewModel builds a pull-requests section.
 func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Model {
 	programCtx := ctx
+	columnNames := section.ColumnNamesFromConfig(cfg.Columns, section.DefaultColumnDefinitions(ctx.MainContentWidth))
 	return section.New(section.Options[data.PullRequest]{
 		Id:           id,
 		Ctx:          ctx,
@@ -49,7 +50,12 @@ func NewModel(id int, ctx *appctx.ProgramContext, cfg config.SectionConfig) *Mod
 			}
 			return c.SearchPullsPage(fetchCtx, f, limit, page)
 		},
-		BuildRow: prBuildRow,
+		BuildRow: func(pr data.PullRequest) table.Row {
+			return prBuildRowWithColumns(pr, columnNames)
+		},
+		Columns: func(width int) []table.Column {
+			return section.ColumnsFromConfig(cfg.Columns, section.DefaultColumnDefinitions(width))
+		},
 	})
 }
 
@@ -74,18 +80,38 @@ func prState(pr data.PullRequest) string {
 	return pr.State
 }
 
-// prBuildRow maps a PR into the table's 6-cell row.
+// prBuildRow maps a PR into the default table row.
 func prBuildRow(pr data.PullRequest) table.Row {
+	return prBuildRowWithColumns(pr, section.DefaultColumnNames())
+}
+
+func prBuildRowWithColumns(pr data.PullRequest, columns []string) table.Row {
+	row := make(table.Row, 0, len(columns))
+	for _, column := range columns {
+		row = append(row, prColumnValue(pr, column))
+	}
+	return row
+}
+
+func prColumnValue(pr data.PullRequest, column string) string {
 	author := ""
 	if pr.Author != "" {
 		author = "@" + pr.Author
 	}
-	return table.Row{
-		fmt.Sprintf("#%d", pr.Number),
-		pr.Title,
-		pr.RepoNameWithOwner,
-		author,
-		prState(pr),
-		section.HumanizeTime(pr.UpdatedAt),
+	switch column {
+	case "number":
+		return fmt.Sprintf("#%d", pr.Number)
+	case "title":
+		return pr.Title
+	case "repo":
+		return pr.RepoNameWithOwner
+	case "author":
+		return author
+	case "state":
+		return prState(pr)
+	case "updated":
+		return section.HumanizeTime(pr.UpdatedAt)
+	default:
+		return ""
 	}
 }

--- a/internal/ui/components/pullsection/pullsection_test.go
+++ b/internal/ui/components/pullsection/pullsection_test.go
@@ -144,6 +144,39 @@ func TestFetchedMsgBuildsRows(t *testing.T) {
 	}
 }
 
+func TestConfiguredColumnsBuildPullRowsInConfiguredOrder(t *testing.T) {
+	ctx := &context.ProgramContext{Styles: context.DefaultStyles(), MainContentWidth: 100, MainContentHeight: 20}
+	m := NewModel(0, ctx, config.SectionConfig{
+		Title: "Compact PRs",
+		Columns: []config.ColumnConfig{
+			{Name: "number", Width: 8},
+			{Name: "state", Title: "Status", Width: 12},
+			{Name: "title"},
+		},
+	})
+	if got := m.Columns; len(got) != 3 ||
+		got[0].Title != "#" || got[0].Width != 8 ||
+		got[1].Title != "Status" || got[1].Width != 12 ||
+		got[2].Title != "Title" {
+		t.Fatalf("columns = %+v", got)
+	}
+
+	m.SetLastFetchID("t1")
+	next, _ := m.Update(SectionPullRequestsFetchedMsg{
+		Rows: []data.PullRequest{{
+			Number: 128, Title: "Add wiki CLI", RepoNameWithOwner: "gitea/tea",
+			Author: "lunny", State: "open", UpdatedAt: time.Now().Add(-2 * time.Hour),
+		}},
+		TotalCount: 1, TaskId: "t1",
+	})
+	m = next.(*Model)
+	row := m.BuildRows()[0]
+	want := []string{"#128", "open", "Add wiki CLI"}
+	if strings.Join([]string(row), "|") != strings.Join(want, "|") {
+		t.Fatalf("row = %v, want %v", row, want)
+	}
+}
+
 func TestGetCurrRowNilBeforeFetch(t *testing.T) {
 	m := newModel(t)
 	if m.GetCurrRow() != nil {

--- a/internal/ui/components/section/model.go
+++ b/internal/ui/components/section/model.go
@@ -47,6 +47,7 @@ type Options[T data.RowData] struct {
 
 	Fetch    func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
 	BuildRow func(T) table.Row
+	Columns  func(int) []table.Column
 	Limit    func(*config.Config) int
 	Pageable bool
 }
@@ -58,6 +59,7 @@ type Model[T data.RowData] struct {
 	rows        []T
 	fetch       func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
 	buildRow    func(T) table.Row
+	columns     func(int) []table.Column
 	limitFn     func(*config.Config) int
 	filterKind  string
 	page        int
@@ -82,13 +84,17 @@ func New[T data.RowData](o Options[T]) *Model[T] {
 	if o.Limit == nil {
 		panic("section.New: Options.Limit is required")
 	}
+	columns := o.Columns
+	if columns == nil {
+		columns = DefaultColumns
+	}
 	m := &Model[T]{}
 	m.BaseModel = NewBaseModel(NewOptions{
 		Id:           o.Id,
 		Type:         o.Type,
 		Ctx:          o.Ctx,
 		Config:       o.Config,
-		Columns:      DefaultColumns(o.Ctx.MainContentWidth),
+		Columns:      columns(o.Ctx.MainContentWidth),
 		LoadingText:  o.LoadingText,
 		EmptyText:    o.EmptyText,
 		EmptyHint:    o.EmptyHint,
@@ -97,6 +103,7 @@ func New[T data.RowData](o Options[T]) *Model[T] {
 	})
 	m.fetch = o.Fetch
 	m.buildRow = o.BuildRow
+	m.columns = columns
 	m.limitFn = o.Limit
 	m.filterKind = o.FilterKind
 	m.pageable = o.Pageable
@@ -237,7 +244,7 @@ func (m *Model[T]) Update(msg tea.Msg) (Section, tea.Cmd) {
 // UpdateProgramContext resizes the table and refreshes columns for the new width.
 func (m *Model[T]) UpdateProgramContext(ctx *appctx.ProgramContext) {
 	m.BaseModel.UpdateProgramContext(ctx)
-	m.Columns = DefaultColumns(ctx.MainContentWidth)
+	m.Columns = m.columns(ctx.MainContentWidth)
 	m.Table.SetColumns(m.Columns)
 }
 

--- a/internal/ui/components/section/section.go
+++ b/internal/ui/components/section/section.go
@@ -207,9 +207,89 @@ func (m *BaseModel) View() string {
 	return body
 }
 
-// DefaultColumns defines the shared column widths and title-grow formula for
-// every section (# / Title / Repo / Author / State / Updated).
-func DefaultColumns(mainWidth int) []table.Column {
+// ColumnDefinition is one known table column a section can expose.
+type ColumnDefinition struct {
+	Name  string
+	Title string
+	Width int
+}
+
+// ColumnsFromConfig turns a section's configured column list into table
+// columns. Unknown names are ignored defensively; config validation rejects
+// them before user config reaches the UI.
+func ColumnsFromConfig(configured []config.ColumnConfig, defaults []ColumnDefinition) []table.Column {
+	if len(configured) == 0 {
+		return columnsFromDefinitions(defaults)
+	}
+	byName := make(map[string]ColumnDefinition, len(defaults))
+	for _, def := range defaults {
+		byName[def.Name] = def
+	}
+	out := make([]table.Column, 0, len(configured))
+	for _, col := range configured {
+		def, ok := byName[col.Name]
+		if !ok {
+			continue
+		}
+		title := def.Title
+		if col.Title != "" {
+			title = col.Title
+		}
+		width := def.Width
+		if col.Width > 0 {
+			width = col.Width
+		}
+		out = append(out, table.Column{Title: title, Width: width})
+	}
+	if len(out) == 0 {
+		return columnsFromDefinitions(defaults)
+	}
+	return out
+}
+
+// ColumnNamesFromConfig returns configured column names in render order. It
+// falls back to defaults defensively when no configured names are valid.
+func ColumnNamesFromConfig(configured []config.ColumnConfig, defaults []ColumnDefinition) []string {
+	defaultNames := columnNamesFromDefinitions(defaults)
+	byName := make(map[string]bool, len(defaults))
+	for _, def := range defaults {
+		byName[def.Name] = true
+	}
+	if len(configured) == 0 {
+		return defaultNames
+	}
+	names := make([]string, 0, len(configured))
+	for _, col := range configured {
+		if byName[col.Name] {
+			names = append(names, col.Name)
+		}
+	}
+	if len(names) == 0 {
+		return defaultNames
+	}
+	return names
+}
+
+func columnNamesFromDefinitions(defs []ColumnDefinition) []string {
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Name)
+	}
+	return names
+}
+
+func columnsFromDefinitions(defs []ColumnDefinition) []table.Column {
+	cols := make([]table.Column, 0, len(defs))
+	for _, def := range defs {
+		cols = append(cols, table.Column{Title: def.Title, Width: def.Width})
+	}
+	return cols
+}
+
+// DefaultColumnDefinitions defines the shared column widths and title-grow
+// formula for every PR/issue-like section (# / Title / Repo / Author / State /
+// Updated).
+func DefaultColumnDefinitions(mainWidth int) []ColumnDefinition {
 	const (
 		numW     = 6
 		repoW    = 22
@@ -221,14 +301,24 @@ func DefaultColumns(mainWidth int) []table.Column {
 	if titleW < 20 {
 		titleW = 20
 	}
-	return []table.Column{
-		{Title: "#", Width: numW},
-		{Title: "Title", Width: titleW},
-		{Title: "Repo", Width: repoW},
-		{Title: "Author", Width: authorW},
-		{Title: "State", Width: stateW},
-		{Title: "Updated", Width: updatedW},
+	return []ColumnDefinition{
+		{Name: "number", Title: "#", Width: numW},
+		{Name: "title", Title: "Title", Width: titleW},
+		{Name: "repo", Title: "Repo", Width: repoW},
+		{Name: "author", Title: "Author", Width: authorW},
+		{Name: "state", Title: "State", Width: stateW},
+		{Name: "updated", Title: "Updated", Width: updatedW},
 	}
+}
+
+// DefaultColumns defines the shared table columns for PR/issue-like sections.
+func DefaultColumns(mainWidth int) []table.Column {
+	return columnsFromDefinitions(DefaultColumnDefinitions(mainWidth))
+}
+
+// DefaultColumnNames returns the shared PR/issue column order.
+func DefaultColumnNames() []string {
+	return columnNamesFromDefinitions(DefaultColumnDefinitions(0))
 }
 
 // HumanizeTime renders a coarse "just now / Xm / Xh / Xd ago" relative time,

--- a/schema.json
+++ b/schema.json
@@ -60,11 +60,11 @@
     "theme": { "$ref": "#/$defs/theme" },
     "prSections": {
       "type": "array",
-      "items": { "$ref": "#/$defs/section" }
+      "items": { "$ref": "#/$defs/prIssueSection" }
     },
     "issuesSections": {
       "type": "array",
-      "items": { "$ref": "#/$defs/section" }
+      "items": { "$ref": "#/$defs/prIssueSection" }
     },
     "notificationsSections": {
       "type": "array",
@@ -233,6 +233,31 @@
         "faint": { "$ref": "#/$defs/colorString" }
       }
     },
+    "prIssueSection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Tab title."
+        },
+        "repo": {
+          "$ref": "#/$defs/repoName",
+          "description": "Optional owner/name repo scope for this section."
+        },
+        "filter": { "$ref": "#/$defs/filter" },
+        "columns": {
+          "type": "array",
+          "description": "Visible table columns for PR/issue sections. Use strings for default title/width, or objects with name/title/width.",
+          "items": { "$ref": "#/$defs/column" }
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rows to fetch per page. 0 falls back to the per-view default."
+        }
+      }
+    },
     "section": {
       "type": "object",
       "additionalProperties": false,
@@ -283,6 +308,33 @@
         "headSha": { "type": "string" },
         "actor": { "type": "string" }
       }
+    },
+    "column": {
+      "oneOf": [
+        { "$ref": "#/$defs/columnName" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "$ref": "#/$defs/columnName" },
+            "title": {
+              "type": "string",
+              "description": "Optional display title for this table column."
+            },
+            "width": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional fixed column width. 0 or omitted uses the default width."
+            }
+          },
+          "required": ["name"]
+        }
+      ]
+    },
+    "columnName": {
+      "type": "string",
+      "enum": ["number", "title", "repo", "author", "state", "updated"],
+      "description": "PR/issue table column name."
     },
     "keybindings": {
       "type": "object",

--- a/schema_test.go
+++ b/schema_test.go
@@ -37,6 +37,62 @@ notARealTeaDashSetting: true
 	}
 }
 
+func TestConfigSchemaValidatesSectionColumns(t *testing.T) {
+	schema := loadConfigSchema(t)
+	doc := loadYAMLBytes(t, []byte(`
+prSections:
+  - title: Compact
+    columns:
+      - number
+      - name: title
+        title: Summary
+        width: 48
+      - repo
+    filter:
+      state: open
+`))
+
+	if err := schema.Validate(doc); err != nil {
+		t.Fatalf("schema should validate PR section columns: %v", err)
+	}
+}
+
+func TestConfigSchemaRejectsUnknownSectionColumn(t *testing.T) {
+	schema := loadConfigSchema(t)
+	doc := loadYAMLBytes(t, []byte(`
+issuesSections:
+  - title: Bad
+    columns:
+      - typo
+`))
+
+	err := schema.Validate(doc)
+	if err == nil {
+		t.Fatal("schema should reject unknown section columns")
+	}
+	if !strings.Contains(err.Error(), "/issuesSections/0/columns/0") {
+		t.Fatalf("schema error = %v, want it to identify the bad column entry", err)
+	}
+}
+
+func TestConfigSchemaRejectsColumnsOnUnsupportedSections(t *testing.T) {
+	schema := loadConfigSchema(t)
+	doc := loadYAMLBytes(t, []byte(`
+actionsSections:
+  - title: CI
+    columns:
+      - title
+`))
+
+	err := schema.Validate(doc)
+	if err == nil {
+		t.Fatal("schema should reject columns outside PR/issue sections")
+	}
+	if !strings.Contains(err.Error(), "columns") {
+		t.Fatalf("schema error = %v, want it to mention columns", err)
+	}
+}
+
 func TestConfigSchemaCoversDocumentedTopLevelKeys(t *testing.T) {
 	raw, err := os.ReadFile("schema.json")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add PR/issue section columns config with string and object forms.
- Render configured column order/title/width for PR and issue tables while preserving defaults.
- Publish schema/docs/examples and reject unsupported or invalid column config.

## Test Plan
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make build