### PR TITLE
Refresh install docs and architecture status

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ See [`docs/architecture.md`](docs/architecture.md) for the details.
 
 ## Install
 
+Homebrew:
+
+```sh
+brew install --cask gbarany/tap/tea-dash
+```
+
+Or with Go:
+
 ```sh
 go install github.com/gbarany/tea-dash@latest
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,8 +78,25 @@ is denormalized — each row from the cross-repo search carries its own
 | `internal/config` | loads `~/.config/tea-dash/config.yml` (instance block, repos)             |
 | `internal/build`  | version metadata injected at link time via `-ldflags`                     |
 
-## Roadmap (next steps)
+## Current feature surface
 
-1. Smart cwd repo detection to preselect or scaffold repo-scoped sections.
-2. Richer table columns / per-column layout configuration.
-3. Capability-probed fallbacks for version-sensitive Actions and review flows.
+- Configurable PR/issue sections with structured filters, repo fan-out,
+  current-repo smart filtering, progressive loading, and configurable table
+  columns.
+- Default-open preview panes with markdown bodies, comments, review summaries,
+  CI/check status, and Actions run detail.
+- Mutations for common PR, issue, notification, Actions, and local branch
+  workflows: comments, labels, assignment, milestones, subscriptions,
+  close/reopen, reviews, reviewer requests, merge variants, branch checkout,
+  branch push/delete, notification read/pin state, and Actions logs/rerun/cancel.
+- Keyboard and mouse interaction shaped after `gh-dash` and `lazygit`, plus
+  configurable built-in/custom keybindings.
+- Public distribution through GitHub releases and the Homebrew tap.
+
+## Future refinements
+
+- Deeper theme coverage beyond the current core text/background/border palette.
+- More capability probes for server-version differences that emerge in the
+  Forgejo/Gitea Actions and review APIs.
+- Optional multi-instance switching inside one running session; today a session
+  connects to one resolved instance.


### PR DESCRIPTION
## Summary
- Document the Homebrew cask install path in the README.
- Replace stale architecture next-step items with the current feature surface.
- Keep future refinements scoped to remaining non-critical polish.

## Test Plan
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check