### PR TITLE
Balance preview split and show startup loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ defaults:
   refetchIntervalMinutes: 0 # auto-refresh current view every N minutes (0/omitted -> manual only)
   preview:
     open: true           # initial preview pane state (omit to default true)
-    width: 84            # preview pane width in columns (0 or omit -> automatic, capped at 80)
+    width: 84            # preview pane width in columns (0 or omit -> automatic 50/50 split)
   prsLimit: 50           # PR page size; more rows load when you reach the bottom (0 -> 50)
   issuesLimit: 50        # issue page size; more rows load when you reach the bottom (0 -> 50)
   notificationsLimit: 50 # rows fetched per notifications section (0 -> 50)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2598,8 +2598,8 @@ func (m *Model) syncProgramContext() {
 
 // syncMainContentDimensions splits the content area between the section table
 // and the preview pane. When the preview is open it uses defaults.preview.width
-// when configured, otherwise the previous automatic half-width layout capped at
-// 80 columns. When closed, the table gets the full width.
+// when configured, otherwise an automatic near-50/50 split. When closed, the
+// table gets the full width.
 func (m *Model) syncMainContentDimensions() {
 	h := m.ctx.ScreenHeight - 7
 	if h < 3 {
@@ -2648,9 +2648,6 @@ func (m *Model) configuredPreviewWidth() int {
 	if pw > maxPreview {
 		pw = maxPreview
 	}
-	if configured == 0 && pw > 80 {
-		pw = 80
-	}
 	if pw < 0 {
 		pw = 0
 	}
@@ -2659,8 +2656,15 @@ func (m *Model) configuredPreviewWidth() int {
 
 func (m Model) statusLine() string {
 	s := m.getCurrSection()
-	if s == nil || s.GetIsLoading() || s.GetError() != nil {
+	if s == nil || s.GetError() != nil {
 		return ""
+	}
+	if s.GetIsLoading() {
+		title := strings.TrimSpace(s.GetTitle())
+		if title == "" {
+			title = strings.TrimSpace(s.GetItemPlural())
+		}
+		return m.ctx.Styles.DimText.Render("Loading " + title + "…")
 	}
 	total := s.GetTotalCount()
 	shown := s.NumRows()

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1582,6 +1582,28 @@ func TestPreviewStartsOpenAndToggles(t *testing.T) {
 	}
 }
 
+func TestAutomaticPreviewUsesHalfWidthOnWideScreens(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 220, Height: 40})
+
+	if m.ctx.PreviewWidth != 108 {
+		t.Fatalf("automatic preview width = %d, want half of available content width 108", m.ctx.PreviewWidth)
+	}
+	if m.ctx.MainContentWidth != 106 {
+		t.Fatalf("main content width = %d, want balanced 50/50 split after gutter", m.ctx.MainContentWidth)
+	}
+}
+
+func TestStatusLineShowsStartupLoadingState(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	status := m.statusLine()
+	if !strings.Contains(status, "Loading Open Pull Requests") {
+		t.Fatalf("startup status line = %q, want visible loading indicator for current section", status)
+	}
+}
+
 func TestPreviewCanStartClosedFromConfig(t *testing.T) {
 	m := New(&config.Config{Defaults: config.Defaults{Preview: config.PreviewConfig{Open: boolPtr(false)}}}, nil)
 	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})


### PR DESCRIPTION
## Summary
- Remove the automatic 80-column preview cap so wide terminals use a near 50/50 list/preview split.
- Keep explicit defaults.preview.width as the override for users who want a fixed pane width.
- Show a visible status-line loading indicator while the starting section is fetching.

## Test Plan
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test ./internal/ui -run 'TestAutomaticPreviewUsesHalfWidthOnWideScreens|TestStatusLineShowsStartupLoadingState|TestPreviewWidthCanBeConfigured|TestPreviewStartsOpenAndToggles' -v
- git diff --check
- bash scripts/check-public-hygiene.sh
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make check
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache go test -race -count=1 ./...
- GOPATH=/tmp/tea-dash-go-path GOMODCACHE=/tmp/tea-dash-go-path/pkg/mod GOCACHE=/tmp/tea-dash-go-cache make build