### PR TITLE
fix(ui): keep the selected preview tab across refresh

### DIFF
--- a/docs/superpowers/plans/2026-07-06-sticky-preview-tab-on-refresh.md
+++ b/docs/superpowers/plans/2026-07-06-sticky-preview-tab-on-refresh.md
@@ -1,0 +1,344 @@
+# Sticky Preview Tab On Refresh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pressing `r` (refresh) — or any preview re-render — keeps the user on their selected preview tab (Comments / Checks / …) instead of snapping back to Overview.
+
+**Architecture:** The preview pane (`internal/ui/components/sidebar`) tracks the selected tab as an index and hard-resets it to 0 in `SetTabs()`, which every re-render funnels through. Add a persistent `sticky` field holding the *title* the user last explicitly selected; `SetTabs` re-selects that title when present and falls back to index 0 otherwise — **without** overwriting `sticky`. This survives the transient "Overview-only" collapse that a refresh causes (it clears the row's detail before re-fetching, and detail-less rows render only an Overview tab).
+
+**Tech Stack:** Go 1.26+, Bubble Tea v2 (`charm.land/bubbletea/v2`), stdlib `testing` (no testify). Spec: `docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md`.
+
+---
+
+## File structure
+
+- **Modify** `internal/ui/components/sidebar/sidebar.go` — add `sticky` field to `Model`; add `indexOfTitle` helper; rewrite `SetTabs` to preserve by sticky title; make `NextTab` / `PrevTab` / `SelectTab` record the sticky title. This is the entire behavior change.
+- **Modify** `internal/ui/components/sidebar/sidebar_test.go` — unit tests for the sticky mechanism.
+- **Modify** `internal/ui/app_test.go` — one end-to-end regression test driving the real `r` async sequence.
+
+No production callers change: every reset path already flows through `SetTabs`.
+
+---
+
+### Task 1: Sticky-tab mechanism in the sidebar (unit TDD)
+
+**Files:**
+- Test: `internal/ui/components/sidebar/sidebar_test.go`
+- Modify: `internal/ui/components/sidebar/sidebar.go`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append to `internal/ui/components/sidebar/sidebar_test.go` (the file already imports `"testing"` and the `context` package, and tests live in `package sidebar` so `Tab`, `New`, `SetTabs`, `NextTab`, `CurrentTabTitle` are all in scope — see the existing `TestTabsSwitchContent`):
+
+```go
+// TestSetTabsPreservesSelectedTabByTitle: re-rendering the preview (e.g. on a
+// refresh) must keep the user's selected tab, not snap back to Overview.
+func TestSetTabsPreservesSelectedTabByTitle(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	m.NextTab() // user selects Checks
+
+	// Re-render with the same titles (what a refresh does once detail reloads).
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token-2"},
+		{Title: "Checks", Content: "checks-token-2"},
+	})
+	if got := m.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("SetTabs should preserve the selected tab by title, got %q, want Checks", got)
+	}
+}
+
+// TestSetTabsRestoresTabAfterTransientCollapse reproduces the refresh shape: the
+// row's detail is cleared first (so only the Overview tab renders), then the full
+// set returns when the re-fetch lands. The selection must survive the round trip.
+// This is the case a naive "preserve the current title" approach fails, because
+// the collapse rewrites the current title to Overview.
+func TestSetTabsRestoresTabAfterTransientCollapse(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	m.NextTab() // user selects Checks
+
+	// Detail cleared: only Overview renders. Must show Overview (Checks is gone).
+	m.SetTabs([]Tab{{Title: "Overview", Content: "overview-only"}})
+	if got := m.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("with only Overview present, want Overview, got %q", got)
+	}
+
+	// Detail re-lands: full set returns. Must snap back to Checks.
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	if got := m.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("selected tab should be restored after the set returns, got %q, want Checks", got)
+	}
+}
+
+// TestSetTabsDefaultsToFirstWithoutExplicitSelection: a user who never switches
+// tabs stays on Overview across re-renders (today's behavior, preserved).
+func TestSetTabsDefaultsToFirstWithoutExplicitSelection(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "a"},
+		{Title: "Checks", Content: "b"},
+	})
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "c"},
+		{Title: "Checks", Content: "d"},
+	})
+	if got := m.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("no explicit selection should stay on Overview, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/ui/components/sidebar/ -run 'TestSetTabs' -v`
+Expected: `TestSetTabsPreservesSelectedTabByTitle` and `TestSetTabsRestoresTabAfterTransientCollapse` FAIL (both report `got "Overview"` where "Checks" is wanted — the current `SetTabs` resets `m.tab = 0`). `TestSetTabsDefaultsToFirstWithoutExplicitSelection` passes already.
+
+- [ ] **Step 3: Add the `sticky` field to `Model`**
+
+In `internal/ui/components/sidebar/sidebar.go`, change the `Model` struct (currently lines 19–25):
+
+```go
+// Model wraps a viewport bound to the shared program context.
+type Model struct {
+	vp      viewport.Model
+	ctx     *context.ProgramContext
+	tabs    []Tab
+	tab     int
+	// sticky is the title of the tab the user last explicitly selected. SetTabs
+	// re-selects it whenever the new tab set contains it, so re-renders (refresh,
+	// enrich, resize) keep the user's tab. It is written only by explicit tab
+	// changes — never by SetTabs's fall-back — so a tab that is transiently
+	// absent (while a refresh reloads detail) is restored once it reappears.
+	sticky  string
+	content string
+}
+```
+
+- [ ] **Step 4: Rewrite `SetTabs` and add `indexOfTitle`**
+
+Replace `SetTabs` (currently lines 46–54) with:
+
+```go
+// SetTabs replaces the preview tabs, re-selecting the sticky tab by title when the
+// new set contains it (else the first tab), and scrolls to the top. It never
+// changes the sticky intent, so a tab that is transiently absent (e.g. while a
+// refresh reloads detail) is restored once it reappears. Empty tabs clear the
+// viewport.
+func (m *Model) SetTabs(tabs []Tab) {
+	m.tabs = compactTabs(tabs)
+	m.tab = indexOfTitle(m.tabs, m.sticky)
+	m.resize()
+	m.syncViewport()
+	m.vp.GotoTop()
+}
+
+// indexOfTitle returns the index of the first tab whose Title equals title, or 0
+// when there is no match (including title == "").
+func indexOfTitle(tabs []Tab, title string) int {
+	if title == "" {
+		return 0
+	}
+	for i, t := range tabs {
+		if t.Title == title {
+			return i
+		}
+	}
+	return 0
+}
+```
+
+- [ ] **Step 5: Record the sticky title in `NextTab` / `PrevTab` / `SelectTab`**
+
+Replace `NextTab` (currently lines 67–75), `PrevTab` (77–85), and `SelectTab` (87–98) with:
+
+```go
+// NextTab selects the next sidebar tab, wrapping at the end.
+func (m *Model) NextTab() {
+	if len(m.tabs) <= 1 {
+		return
+	}
+	m.tab = (m.tab + 1) % len(m.tabs)
+	m.sticky = m.tabs[m.tab].Title
+	m.syncViewport()
+	m.vp.GotoTop()
+}
+
+// PrevTab selects the previous sidebar tab, wrapping at the beginning.
+func (m *Model) PrevTab() {
+	if len(m.tabs) <= 1 {
+		return
+	}
+	m.tab = (m.tab - 1 + len(m.tabs)) % len(m.tabs)
+	m.sticky = m.tabs[m.tab].Title
+	m.syncViewport()
+	m.vp.GotoTop()
+}
+
+// SelectTab jumps directly to tab i (Task 6's ZonePreviewTab click handler;
+// NextTab/PrevTab are relative, for the keyboard's "["/"]"). Out of range is a
+// no-op. It records the target as the sticky selection even when i is already the
+// current tab, so a click made during a refresh flash is honored — while still
+// skipping the scroll reset for the already-selected case.
+func (m *Model) SelectTab(i int) {
+	if i < 0 || i >= len(m.tabs) {
+		return
+	}
+	m.sticky = m.tabs[i].Title
+	if i == m.tab {
+		return // already showing: don't reset scroll
+	}
+	m.tab = i
+	m.syncViewport()
+	m.vp.GotoTop()
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./internal/ui/components/sidebar/ -run 'TestSetTabs' -v`
+Expected: all three PASS.
+
+Run the whole sidebar package to confirm no regression in the existing tab tests (`TestTabsSwitchContent`, `TestSelectTabJumpsDirectly`, `TestFocusedPreviewKeysCycleTabs`):
+Run: `go test ./internal/ui/components/sidebar/`
+Expected: `ok`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/components/sidebar/sidebar.go internal/ui/components/sidebar/sidebar_test.go
+git commit -m "fix(sidebar): keep selected preview tab across re-render (sticky by title)"
+```
+
+---
+
+### Task 2: End-to-end refresh regression test (app level)
+
+Guards that all three async re-snaps a real `r` press triggers (sync handler → `TaskFinishedMsg` → `enrichedMsg`) are cured — not just the synchronous one.
+
+**Files:**
+- Test: `internal/ui/app_test.go`
+
+- [ ] **Step 1: Write the regression test**
+
+Append to `internal/ui/app_test.go` (mirrors the setup in the existing `TestClickPreviewTabSwitchesTab`; `data`, `config`, `tea`, and the `fetchedMsg` helper are already imported/defined in this file):
+
+```go
+// TestRefreshPreservesSelectedPreviewTab is the end-to-end guard for the sticky
+// preview tab. Pressing `r` clears the row's cached detail (collapsing the tab set
+// to Overview only), refetches the list, then re-enriches — three chances to snap
+// the selection back to Overview. The user's Checks tab must survive all of them.
+func TestRefreshPreservesSelectedPreviewTab(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	pr := data.PullRequest{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}
+	detail := &data.PullDetail{Body: "body", BaseRef: "main", HeadRef: "first"}
+	m = update(t, m, fetchedMsg([]data.PullRequest{pr}))
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail})
+
+	// Select the "Checks" tab via a real click (mirrors TestClickPreviewTabSwitchesTab).
+	m = viewed(m)
+	ranges := m.sidebar.TabRanges()
+	if len(ranges) < 2 {
+		t.Fatalf("expected at least 2 preview tab ranges, got %+v", ranges)
+	}
+	x := m.layout.PreviewPanel.X + 1 + ranges[1].Start
+	m = update(t, m, tea.MouseClickMsg{X: x, Y: m.layout.PreviewTabsRow, Button: tea.MouseLeft})
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("setup: expected to be on Checks, got %q", got)
+	}
+
+	// Refresh, then drive the async results the returned command would produce:
+	// the list re-fetch (TaskFinishedMsg) and the re-enrich (enrichedMsg).
+	m = update(t, m, tea.KeyPressMsg{Code: 'r', Text: "r"})
+	m = update(t, m, fetchedMsg([]data.PullRequest{pr}))
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail})
+
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("refresh should keep the Checks tab selected, got %q, want Checks", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes with the fix**
+
+Run: `go test ./internal/ui/ -run TestRefreshPreservesSelectedPreviewTab -v`
+Expected: PASS.
+
+- [ ] **Step 3 (optional): Confirm the test actually guards the bug**
+
+Temporarily prove the test is meaningful by reverting the fix and watching it fail:
+
+```bash
+git stash push -- internal/ui/components/sidebar/sidebar.go
+go test ./internal/ui/ -run TestRefreshPreservesSelectedPreviewTab -v   # Expected: FAIL (got "Overview")
+git stash pop
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ui/app_test.go
+git commit -m "test(ui): regression guard for sticky preview tab across refresh"
+```
+
+---
+
+### Task 3: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full project check**
+
+Run: `make check`
+Expected: gofmt-check clean, `go vet` clean, `go test -race ./...` all PASS.
+
+- [ ] **Step 2: Manual smoke (via the `run` skill or `make run`)**
+
+Open tea-dash, open a PR's preview, switch to the **Checks** or **Comments** tab, press **`r`**.
+Expected: the preview reloads but stays on the same tab (it no longer jumps to Overview). Repeat with **`R`** (refresh-all) — same result.
+
+- [ ] **Step 3: Final commit (if the manual smoke required any tweak; otherwise skip)**
+
+```bash
+git add -A
+git commit -m "chore: sticky preview tab verification tweaks"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** sticky-by-title (Decision) → Task 1 Steps 3–5; transient-collapse survival (spec "transient-collapse complication") → Task 1's `TestSetTabsRestoresTabAfterTransientCollapse` + Task 2; `GotoTop` unchanged (spec "Scroll behavior") → `SetTabs` keeps `m.vp.GotoTop()`; unit + regression tests (spec "Testing") → Tasks 1 & 2; `make check` (spec "Verification") → Task 3.
+- **No new production callers**; the single added field is package-internal — matches spec "no caller changes outside `sidebar.go`".
+- **Type consistency:** `sticky string`, `indexOfTitle(tabs []Tab, title string) int`, `Tab{Title, Content}`, `enrichedMsg{key string, pull *data.PullDetail}`, `data.PullRequest`, `fetchedMsg([]data.PullRequest)` — all used consistently across tasks and match the existing code read during planning.

--- a/docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md
@@ -45,6 +45,23 @@ A single `r` press resets the tab **up to three times**:
 Consequence: a fix that only patches the `r` key handler is insufficient — the async
 completions re-snap the tab. The fix must live at the reset point (`SetTabs`).
 
+### The transient-collapse complication
+
+`clearSelectedPreviewCache()` runs **before** the re-render, and `RenderPullTabs` /
+`RenderIssueTabs` / `RenderActionTabs` return **only** `[{Title: "Overview"}]` when their
+detail is `nil` (`internal/ui/components/prview/prview.go:79`). So during a refresh the tab set
+**transiently collapses to Overview-only**, and the full set (Overview / Checks / Reviews /
+Comments) only returns once the re-fetched detail lands (reset #3).
+
+This rules out the naive "preserve the currently-selected tab's title across `SetTabs`": the
+collapse (resets #1/#2) rewrites the selected title to "Overview", so when the full set returns
+there is nothing left pointing at "Checks". The preserved value must be a **persistent sticky
+intent** that survives the collapse — see Implementation.
+
+We must keep clearing the cache: it is what forces `enrichCurrRow()` to actually re-fetch the
+detail (it early-returns when the detail is already cached), so `r` genuinely refreshes the
+preview's comments/checks. The collapse is therefore inherent to refresh; the fix tolerates it.
+
 The same latent snap exists on `R` (refresh-all), action completions
 (`actions.ResultMsg` → `syncSidebar`), and the optional background auto-refresh — all funnel
 through `SetTabs`, so fixing `SetTabs` cures them together.
@@ -72,16 +89,30 @@ more predictable sticky behavior.
 
 ## Implementation
 
-Single change in `internal/ui/components/sidebar/sidebar.go`:
+All in `internal/ui/components/sidebar/sidebar.go`. Add a persistent `sticky` field holding the
+title of the tab the user last **explicitly** selected. `SetTabs` consults it; only explicit
+tab actions (`NextTab` / `PrevTab` / `SelectTab`, and the `[`/`]` keys, which route through
+those) write to it. Crucially, `SetTabs`'s fallback-to-index-0 does **not** overwrite `sticky`,
+so a transient collapse to Overview-only doesn't erase the intent.
 
 ```go
-// SetTabs replaces the preview tabs, preserving the selected tab by title when
-// the new set still contains it (else selecting the first tab), and scrolls to
-// the top. Empty tabs clear the viewport.
+type Model struct {
+    vp      viewport.Model
+    ctx     *context.ProgramContext
+    tabs    []Tab
+    tab     int
+    sticky  string // title of the last explicitly-selected tab; preserved across
+                   // SetTabs re-renders even when transiently absent from the set
+    content string
+}
+
+// SetTabs replaces the preview tabs, re-selecting the sticky tab by title when the
+// new set contains it (else the first tab), and scrolls to the top. It never
+// changes the sticky intent, so a tab that is transiently absent (e.g. while a
+// refresh reloads detail) is restored once it reappears. Empty tabs clear the viewport.
 func (m *Model) SetTabs(tabs []Tab) {
-    prevTitle := m.CurrentTabTitle() // "" when there were no tabs
     m.tabs = compactTabs(tabs)
-    m.tab = indexOfTitle(m.tabs, prevTitle) // 0 when not found or prevTitle == ""
+    m.tab = indexOfTitle(m.tabs, m.sticky) // 0 when not found or sticky == ""
     m.resize()
     m.syncViewport()
     m.vp.GotoTop()
@@ -102,11 +133,37 @@ func indexOfTitle(tabs []Tab, title string) int {
 }
 ```
 
+`NextTab` / `PrevTab` record the new selection as sticky (after moving `m.tab`):
+
+```go
+m.sticky = m.tabs[m.tab].Title
+```
+
+`SelectTab` records sticky for any in-range index — even the redundant "already on it" case —
+so a click during the refresh flash is honored, while keeping the existing no-op scroll guard:
+
+```go
+func (m *Model) SelectTab(i int) {
+    if i < 0 || i >= len(m.tabs) {
+        return
+    }
+    m.sticky = m.tabs[i].Title
+    if i == m.tab {
+        return // already showing: don't reset scroll
+    }
+    m.tab = i
+    m.syncViewport()
+    m.vp.GotoTop()
+}
+```
+
 - Title matching runs against the **compacted** tab set (`compactTabs` may drop empty tabs),
   so the restored index is always valid.
-- No caller changes. No new `Model` state.
-- `SetContent()` (single "Overview" tab) is unaffected in practice: a previous non-Overview
-  title won't be found, so it collapses to 0 — the only tab present.
+- No caller changes outside `sidebar.go`. The one added field is package-internal.
+- `SetContent()` (single "Overview" tab) is unaffected in practice: a non-Overview `sticky`
+  title won't be found, so it collapses to 0 — the only tab present — but `sticky` is retained.
+- Default `sticky == ""` reproduces today's behavior for users who never switch tabs (always
+  Overview).
 
 ### Scroll behavior — unchanged (`GotoTop()` kept)
 
@@ -120,10 +177,14 @@ tracking item identity — extra state for a marginal gain, out of scope.
 ## Testing
 
 **Unit — `internal/ui/components/sidebar/sidebar_test.go`:**
-- `SetTabs([Overview, Comments, Checks])` → `NextTab()` (→ Comments) → `SetTabs(...)` again
-  with the same titles ⇒ `CurrentTabTitle() == "Comments"` (pre-fix: "Overview").
-- Re-`SetTabs` with a set lacking "Comments" ⇒ falls back to `"Overview"`.
-- First-ever `SetTabs` (no prior tab) ⇒ index 0.
+- Preserve-by-title: `SetTabs([Overview, Checks])` → `NextTab()` (→ Checks) → `SetTabs(...)`
+  again with the same titles ⇒ `CurrentTabTitle() == "Checks"` (pre-fix: "Overview").
+- Transient collapse & restore (the refresh shape): `SetTabs([Overview, Checks])` →
+  `NextTab()` (→ Checks) → `SetTabs([Overview])` ⇒ shows `"Overview"` (only tab present) →
+  `SetTabs([Overview, Checks])` again ⇒ back on `"Checks"`. This is the case the naive
+  approach fails.
+- First-ever `SetTabs` with no explicit selection (`sticky == ""`) ⇒ index 0 (Overview),
+  and re-render keeps Overview.
 
 **Regression — `internal/ui/app_test.go`:**
 - Reproduce the real bug end-to-end: preview open on a pull with detail loaded (so the

--- a/docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md
@@ -1,0 +1,143 @@
+# Sticky preview tab across refresh — design
+
+**Date:** 2026-07-05
+**Status:** Approved, ready for implementation planning
+**Area:** `internal/ui/components/sidebar`, `internal/ui`
+
+## Problem
+
+Pressing **`r`** (refresh) while parked on a non-default preview tab throws the user
+back to the **Overview** tab. If you are reading the **Comments** tab or the Forgejo/Gitea
+**Checks** ("action status") tab of the selected pull request, refreshing snaps the preview
+back to Overview. This is disruptive during normal review flow.
+
+## Root cause
+
+The preview pane (right-hand panel) renders tabs — **Overview / Comments / Checks / Files /
+Reviews**, depending on the row kind. The selected tab is `sidebar.Model.tab` (an `int`).
+
+`sidebar.SetTabs()` (`internal/ui/components/sidebar/sidebar.go:48`) unconditionally resets
+`m.tab = 0` every time it is called. `syncSidebar()` (`internal/ui/app.go:1469`) funnels the
+per-row render (`RenderPullTabs` / `RenderIssueTabs` / `RenderActionTabs`) into `SetTabs()`,
+and `SetContent()` does too. So any re-render of the preview snaps the selection to Overview.
+
+The `r` handler (`internal/ui/app.go:704`) rebuilds the preview:
+
+```go
+case !m.scopedBuiltinOverridden("refresh") && key.Matches(msg, m.keys.Refresh):
+    if s := m.getCurrSection(); s != nil && !s.GetIsLoading() {
+        if m.ctx.PreviewOpen {
+            m.clearSelectedPreviewCache()
+            m.syncSidebar()      // reset #1 (synchronous)
+        }
+        return m, s.FetchRows()
+    }
+```
+
+A single `r` press resets the tab **up to three times**:
+
+1. **#1** synchronously in the refresh handler (`app.go:708`).
+2. **#2** when `FetchRows()` completes → `TaskFinishedMsg` → `syncSidebar()` (`app.go:472`).
+3. **#3** when the re-fetched detail lands → `enrichedMsg` → `syncSidebar()` (`app.go:528`),
+   because step 1's `clearSelectedPreviewCache()` wiped the cached detail and the handler
+   re-issues `enrichCurrRow()`.
+
+Consequence: a fix that only patches the `r` key handler is insufficient — the async
+completions re-snap the tab. The fix must live at the reset point (`SetTabs`).
+
+The same latent snap exists on `R` (refresh-all), action completions
+(`actions.ResultMsg` → `syncSidebar`), and the optional background auto-refresh — all funnel
+through `SetTabs`, so fixing `SetTabs` cures them together.
+
+Note: the reported "thrown back to the default page" refers to the preview **tab**, not the
+top-level view (pulls/issues/…). The top-level view is unaffected by refresh.
+
+## Decision
+
+**Sticky tab by title.** `SetTabs()` preserves the currently-selected tab by matching its
+**title** in the new tab set, rather than hard-resetting to index 0. When the title is absent
+from the new set (or there was no previous tab), it falls back to index 0 (Overview).
+
+This was the explicit UX choice: when the cursor moves to a *different* item while parked on
+"Comments", the new item opens on its "Comments" tab too (if it has one), like browser/editor
+tabs. It also happens to be the simplest, single-point fix.
+
+### Rejected alternative
+
+*Reset-on-navigation, preserve-only-on-same-item-re-render.* Would keep the tab only when
+re-rendering the same row and reset to Overview when the selection changes. More faithful to a
+literal reading of the complaint, but requires tracking a "which item is the sidebar currently
+showing" key and classifying every `syncSidebar` call site. Rejected in favor of the simpler,
+more predictable sticky behavior.
+
+## Implementation
+
+Single change in `internal/ui/components/sidebar/sidebar.go`:
+
+```go
+// SetTabs replaces the preview tabs, preserving the selected tab by title when
+// the new set still contains it (else selecting the first tab), and scrolls to
+// the top. Empty tabs clear the viewport.
+func (m *Model) SetTabs(tabs []Tab) {
+    prevTitle := m.CurrentTabTitle() // "" when there were no tabs
+    m.tabs = compactTabs(tabs)
+    m.tab = indexOfTitle(m.tabs, prevTitle) // 0 when not found or prevTitle == ""
+    m.resize()
+    m.syncViewport()
+    m.vp.GotoTop()
+}
+
+// indexOfTitle returns the index of the first tab whose Title equals title, or
+// 0 when there is no match (including title == "").
+func indexOfTitle(tabs []Tab, title string) int {
+    if title == "" {
+        return 0
+    }
+    for i, t := range tabs {
+        if t.Title == title {
+            return i
+        }
+    }
+    return 0
+}
+```
+
+- Title matching runs against the **compacted** tab set (`compactTabs` may drop empty tabs),
+  so the restored index is always valid.
+- No caller changes. No new `Model` state.
+- `SetContent()` (single "Overview" tab) is unaffected in practice: a previous non-Overview
+  title won't be found, so it collapses to 0 — the only tab present.
+
+### Scroll behavior — unchanged (`GotoTop()` kept)
+
+Scroll still resets to the top on every `SetTabs`. With sticky tabs, `SetTabs` cannot
+distinguish "refresh of the same item" from "moved to a different item that also has a
+Comments tab" — and for the different-item case the scroll **must** restart (you don't want
+item B's Comments opening at item A's scroll offset). The consistent, honest rule is therefore
+**keep the tab, restart the scroll**. Preserving scroll on same-item refresh would require
+tracking item identity — extra state for a marginal gain, out of scope.
+
+## Testing
+
+**Unit — `internal/ui/components/sidebar/sidebar_test.go`:**
+- `SetTabs([Overview, Comments, Checks])` → `NextTab()` (→ Comments) → `SetTabs(...)` again
+  with the same titles ⇒ `CurrentTabTitle() == "Comments"` (pre-fix: "Overview").
+- Re-`SetTabs` with a set lacking "Comments" ⇒ falls back to `"Overview"`.
+- First-ever `SetTabs` (no prior tab) ⇒ index 0.
+
+**Regression — `internal/ui/app_test.go`:**
+- Reproduce the real bug end-to-end: preview open on a pull with detail loaded (so the
+  Checks/Comments tab exists), switch to a non-Overview tab, press `r`, drive the resulting
+  `TaskFinishedMsg` + `enrichedMsg`, and assert `CurrentTabTitle()` is unchanged. This guards
+  all three async re-snaps, not just the synchronous one.
+
+## Scope guard (YAGNI)
+
+Out of scope: config option to toggle stickiness, per-view tab memory, scroll-position
+persistence across refresh. The change is: re-rendering the preview keeps you on your tab.
+
+## Verification
+
+- `make check` (gofmt-check + go vet + `go test -race ./...`) green.
+- Manual: open tea-dash, open a PR preview, switch to Checks/Comments, press `r`,
+  confirm the tab stays selected.

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4904,3 +4904,41 @@ func newNotificationActionClient(
 	}
 	return client
 }
+
+// TestRefreshPreservesSelectedPreviewTab is the end-to-end guard for the sticky
+// preview tab. Pressing `r` clears the row's cached detail (collapsing the tab set
+// to Overview only), refetches the list, then re-enriches — three chances to snap
+// the selection back to Overview. The user's Checks tab must survive all of them.
+func TestRefreshPreservesSelectedPreviewTab(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	pr := data.PullRequest{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}
+	detail := &data.PullDetail{Body: "body", BaseRef: "main", HeadRef: "first"}
+	m = update(t, m, fetchedMsg([]data.PullRequest{pr}))
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail})
+
+	// Select the "Checks" tab via a real click (mirrors TestClickPreviewTabSwitchesTab).
+	m = viewed(m)
+	ranges := m.sidebar.TabRanges()
+	if len(ranges) < 2 {
+		t.Fatalf("expected at least 2 preview tab ranges, got %+v", ranges)
+	}
+	x := m.layout.PreviewPanel.X + 1 + ranges[1].Start
+	m = update(t, m, tea.MouseClickMsg{X: x, Y: m.layout.PreviewTabsRow, Button: tea.MouseLeft})
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("setup: expected to be on Checks, got %q", got)
+	}
+
+	// Refresh, then drive the async results the returned command would produce:
+	// the list re-fetch (TaskFinishedMsg) and the re-enrich (enrichedMsg).
+	m = update(t, m, tea.KeyPressMsg{Code: 'r', Text: "r"})
+	m = update(t, m, fetchedMsg([]data.PullRequest{pr}))
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail})
+
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("refresh should keep the Checks tab selected, got %q, want Checks", got)
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4932,13 +4932,63 @@ func TestRefreshPreservesSelectedPreviewTab(t *testing.T) {
 		t.Fatalf("setup: expected to be on Checks, got %q", got)
 	}
 
-	// Refresh, then drive the async results the returned command would produce:
-	// the list re-fetch (TaskFinishedMsg) and the re-enrich (enrichedMsg).
+	// Refresh clears the cached detail, so the very next render collapses the tab
+	// set to Overview-only. Assert that here so the test provably exercises the
+	// hard collapse->restore path (not just a no-op where Checks never left).
 	m = update(t, m, tea.KeyPressMsg{Code: 'r', Text: "r"})
+	if got := m.sidebar.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("refresh should collapse to Overview-only while detail reloads, got %q", got)
+	}
+
+	// Drive the async results the returned command would produce: the list
+	// re-fetch (TaskFinishedMsg) and the re-enrich (enrichedMsg). The full tab set
+	// returns and the selection must snap back to Checks.
 	m = update(t, m, fetchedMsg([]data.PullRequest{pr}))
 	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail})
 
 	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
 		t.Fatalf("refresh should keep the Checks tab selected, got %q, want Checks", got)
+	}
+}
+
+// TestSelectedPreviewTabPersistsAcrossRowNavigation covers the headline design
+// choice: the selected tab is sticky across items. Selecting "Checks" on one PR
+// and moving the cursor to another PR must open the new PR on "Checks" (once its
+// detail loads), not reset to Overview.
+func TestSelectedPreviewTabPersistsAcrossRowNavigation(t *testing.T) {
+	m := New(&config.Config{}, nil)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	pr1 := data.PullRequest{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}
+	pr2 := data.PullRequest{
+		Number: 2, Title: "Second", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}
+	m = update(t, m, fetchedMsg([]data.PullRequest{pr1, pr2}))
+	detail1 := &data.PullDetail{Body: "one", BaseRef: "main", HeadRef: "first"}
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail1})
+
+	// Select "Checks" on the first PR via a real click.
+	m = viewed(m)
+	ranges := m.sidebar.TabRanges()
+	if len(ranges) < 2 {
+		t.Fatalf("expected at least 2 preview tab ranges, got %+v", ranges)
+	}
+	x := m.layout.PreviewPanel.X + 1 + ranges[1].Start
+	m = update(t, m, tea.MouseClickMsg{X: x, Y: m.layout.PreviewTabsRow, Button: tea.MouseLeft})
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("setup: expected to be on Checks, got %q", got)
+	}
+
+	// Move the cursor to the second PR (preview open but unfocused, so 'j' moves
+	// the list selection). The new row has no detail yet, then its enrich lands.
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	detail2 := &data.PullDetail{Body: "two", BaseRef: "main", HeadRef: "second"}
+	m = update(t, m, enrichedMsg{key: m.selKey(), pull: detail2})
+
+	if got := m.sidebar.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("selected tab should carry across rows, got %q, want Checks", got)
 	}
 }

--- a/internal/ui/components/sidebar/sidebar.go
+++ b/internal/ui/components/sidebar/sidebar.go
@@ -21,11 +21,14 @@ type Model struct {
 	ctx  *context.ProgramContext
 	tabs []Tab
 	tab  int
-	// sticky is the title of the tab the user last explicitly selected. SetTabs
-	// re-selects it whenever the new tab set contains it, so re-renders (refresh,
-	// enrich, resize) keep the user's tab. It is written only by explicit tab
-	// changes — never by SetTabs's fall-back — so a tab that is transiently absent
-	// (while a refresh reloads detail) is restored once it reappears.
+	// sticky is the title of the tab the user last explicitly selected (via
+	// NextTab/PrevTab/SelectTab). SetTabs re-selects it whenever the new tab set
+	// contains it, so the selection persists across every preview re-render that
+	// funnels through SetTabs: a refresh or enrich of the same row, and navigation
+	// to a different row, section, or view (each rebuilds the tabs). It is written
+	// only by those explicit tab changes — never by SetTabs's fall-back to the
+	// first tab — so a tab that is transiently absent (e.g. while a refresh reloads
+	// detail, or on a row that lacks it) is re-selected once it reappears.
 	sticky  string
 	content string
 }

--- a/internal/ui/components/sidebar/sidebar.go
+++ b/internal/ui/components/sidebar/sidebar.go
@@ -17,10 +17,16 @@ import (
 
 // Model wraps a viewport bound to the shared program context.
 type Model struct {
-	vp      viewport.Model
-	ctx     *context.ProgramContext
-	tabs    []Tab
-	tab     int
+	vp   viewport.Model
+	ctx  *context.ProgramContext
+	tabs []Tab
+	tab  int
+	// sticky is the title of the tab the user last explicitly selected. SetTabs
+	// re-selects it whenever the new tab set contains it, so re-renders (refresh,
+	// enrich, resize) keep the user's tab. It is written only by explicit tab
+	// changes — never by SetTabs's fall-back — so a tab that is transiently absent
+	// (while a refresh reloads detail) is restored once it reappears.
+	sticky  string
 	content string
 }
 
@@ -43,14 +49,31 @@ func (m *Model) SetContent(s string) {
 	m.SetTabs([]Tab{{Title: "Overview", Content: s}})
 }
 
-// SetTabs replaces the preview tabs and scrolls back to the top. Empty tabs
-// clear the viewport.
+// SetTabs replaces the preview tabs, re-selecting the sticky tab by title when
+// the new set contains it (else the first tab), and scrolls to the top. It never
+// changes the sticky intent, so a tab that is transiently absent (e.g. while a
+// refresh reloads detail) is restored once it reappears. Empty tabs clear the
+// viewport.
 func (m *Model) SetTabs(tabs []Tab) {
 	m.tabs = compactTabs(tabs)
-	m.tab = 0
+	m.tab = indexOfTitle(m.tabs, m.sticky)
 	m.resize()
 	m.syncViewport()
 	m.vp.GotoTop()
+}
+
+// indexOfTitle returns the index of the first tab whose Title equals title, or 0
+// when there is no match (including title == "").
+func indexOfTitle(tabs []Tab, title string) int {
+	if title == "" {
+		return 0
+	}
+	for i, t := range tabs {
+		if t.Title == title {
+			return i
+		}
+	}
+	return 0
 }
 
 // ScrollToTop resets the viewport to the first line.
@@ -70,6 +93,7 @@ func (m *Model) NextTab() {
 		return
 	}
 	m.tab = (m.tab + 1) % len(m.tabs)
+	m.sticky = m.tabs[m.tab].Title
 	m.syncViewport()
 	m.vp.GotoTop()
 }
@@ -80,16 +104,23 @@ func (m *Model) PrevTab() {
 		return
 	}
 	m.tab = (m.tab - 1 + len(m.tabs)) % len(m.tabs)
+	m.sticky = m.tabs[m.tab].Title
 	m.syncViewport()
 	m.vp.GotoTop()
 }
 
 // SelectTab jumps directly to tab i (Task 6's ZonePreviewTab click
 // handler; NextTab/PrevTab are relative, for the keyboard's "["/"]"). Out
-// of range or already-selected is a no-op — clicking the tab you're
-// already on shouldn't reset its scroll position back to the top.
+// of range is a no-op. It records the target as the sticky selection even when i
+// is already the current tab, so a click made during a refresh flash is honored —
+// while still skipping the scroll reset for the already-selected case (clicking
+// the tab you're already on shouldn't reset its scroll position back to the top).
 func (m *Model) SelectTab(i int) {
-	if i < 0 || i >= len(m.tabs) || i == m.tab {
+	if i < 0 || i >= len(m.tabs) {
+		return
+	}
+	m.sticky = m.tabs[i].Title
+	if i == m.tab {
 		return
 	}
 	m.tab = i

--- a/internal/ui/components/sidebar/sidebar_test.go
+++ b/internal/ui/components/sidebar/sidebar_test.go
@@ -295,3 +295,87 @@ func TestTabsBorderSegmentEllipsizesAndDropsTrailingTabs(t *testing.T) {
 		t.Fatalf("rendered width = %d, want to end exactly at the truncated tab's End %d", lipgloss.Width(segment), ranges[1].End)
 	}
 }
+
+// TestSetTabsPreservesSelectedTabByTitle: re-rendering the preview (e.g. on a
+// refresh) must keep the user's selected tab, not snap back to Overview.
+func TestSetTabsPreservesSelectedTabByTitle(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	m.NextTab() // user selects Checks
+
+	// Re-render with the same titles (what a refresh does once detail reloads).
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token-2"},
+		{Title: "Checks", Content: "checks-token-2"},
+	})
+	if got := m.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("SetTabs should preserve the selected tab by title, got %q, want Checks", got)
+	}
+}
+
+// TestSetTabsRestoresTabAfterTransientCollapse reproduces the refresh shape: the
+// row's detail is cleared first (so only the Overview tab renders), then the full
+// set returns when the re-fetch lands. The selection must survive the round trip.
+// This is the case a naive "preserve the current title" approach fails, because
+// the collapse rewrites the current title to Overview.
+func TestSetTabsRestoresTabAfterTransientCollapse(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	m.NextTab() // user selects Checks
+
+	// Detail cleared: only Overview renders. Must show Overview (Checks is gone).
+	m.SetTabs([]Tab{{Title: "Overview", Content: "overview-only"}})
+	if got := m.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("with only Overview present, want Overview, got %q", got)
+	}
+
+	// Detail re-lands: full set returns. Must snap back to Checks.
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "overview-token"},
+		{Title: "Checks", Content: "checks-token"},
+	})
+	if got := m.CurrentTabTitle(); got != "Checks" {
+		t.Fatalf("selected tab should be restored after the set returns, got %q, want Checks", got)
+	}
+}
+
+// TestSetTabsDefaultsToFirstWithoutExplicitSelection: a user who never switches
+// tabs stays on Overview across re-renders (today's behavior, preserved).
+func TestSetTabsDefaultsToFirstWithoutExplicitSelection(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+	m := New(ctx)
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "a"},
+		{Title: "Checks", Content: "b"},
+	})
+	m.SetTabs([]Tab{
+		{Title: "Overview", Content: "c"},
+		{Title: "Checks", Content: "d"},
+	})
+	if got := m.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("no explicit selection should stay on Overview, got %q", got)
+	}
+}

--- a/internal/ui/components/sidebar/sidebar_test.go
+++ b/internal/ui/components/sidebar/sidebar_test.go
@@ -379,3 +379,52 @@ func TestSetTabsDefaultsToFirstWithoutExplicitSelection(t *testing.T) {
 		t.Fatalf("no explicit selection should stay on Overview, got %q", got)
 	}
 }
+
+// TestSelectTabRecordsSticky guards the sticky write in SelectTab — the click
+// path, which the NextTab-based preservation tests never exercise. Part A checks
+// a tab reached via SelectTab survives a transient collapse; Part B checks
+// SelectTab records intent even when the clicked tab is already the current one
+// (the refresh-flash case), which is exactly the line-ordering this change adds.
+func TestSelectTabRecordsSticky(t *testing.T) {
+	ctx := &context.ProgramContext{
+		Styles:        context.DefaultStyles(),
+		PreviewOpen:   true,
+		PreviewWidth:  40,
+		PreviewHeight: 8,
+	}
+
+	// A: a SelectTab-selected tab is restored after a transient collapse.
+	m := New(ctx)
+	full := []Tab{
+		{Title: "Overview", Content: "o"},
+		{Title: "Checks", Content: "c"},
+		{Title: "Reviews", Content: "r"},
+	}
+	m.SetTabs(full)
+	m.SelectTab(2) // Reviews, via the click path
+	if got := m.CurrentTabTitle(); got != "Reviews" {
+		t.Fatalf("setup: SelectTab(2) should show Reviews, got %q", got)
+	}
+	m.SetTabs([]Tab{{Title: "Overview", Content: "o"}}) // collapse to Overview-only
+	m.SetTabs(full)                                     // full set returns
+	if got := m.CurrentTabTitle(); got != "Reviews" {
+		t.Fatalf("SelectTab-recorded sticky should restore after collapse, got %q, want Reviews", got)
+	}
+
+	// B: SelectTab records intent even when i == current tab. Selecting the
+	// already-shown Overview must record "Overview" so a later reordered set
+	// re-selects it by title (not fall back to whatever lands at index 0).
+	m2 := New(ctx)
+	m2.SetTabs([]Tab{
+		{Title: "Overview", Content: "o"},
+		{Title: "Checks", Content: "c"},
+	})
+	m2.SelectTab(0) // redundant (already on Overview) — must still record sticky
+	m2.SetTabs([]Tab{
+		{Title: "Checks", Content: "c"},   // Checks now at index 0
+		{Title: "Overview", Content: "o"}, // Overview now at index 1
+	})
+	if got := m2.CurrentTabTitle(); got != "Overview" {
+		t.Fatalf("redundant SelectTab should record sticky, got %q, want Overview", got)
+	}
+}


### PR DESCRIPTION
## Problem

Pressing **`r`** (refresh) while viewing a non-default preview tab — e.g. **Comments** or the **Checks** ("action status") tab of a PR — snapped the preview back to **Overview**. Annoying mid-review.

## Root cause

`sidebar.SetTabs()` hard-reset the selected tab to index 0, and every preview re-render funnels through it. The `r` handler makes it worse: it calls `clearSelectedPreviewCache()` **before** re-rendering, and a detail-less row renders **only** an Overview tab (`prview.RenderPullTabs` returns `[{Overview}]` when `detail == nil`). So the tab set transiently collapses to Overview-only and the selection is rewritten **up to three times** per refresh:

1. synchronously in the `r` handler,
2. when `FetchRows()` completes (`TaskFinishedMsg` → `syncSidebar`),
3. when the re-fetched detail lands (`enrichedMsg` → `syncSidebar`).

This is why a naive "remember the current tab across `SetTabs`" fails — the collapse overwrites the remembered title with "Overview" before the full set returns.

## Fix

A persistent **`sticky`** field on `sidebar.Model` holds the title of the tab the user last **explicitly** selected. `SetTabs` re-selects that title when the new set contains it (else falls back to the first tab) — **without** overwriting `sticky` — so the selection survives the transient collapse and is restored once the full tab set reappears. Only `NextTab` / `PrevTab` / `SelectTab` write `sticky`.

- One production file changed (`internal/ui/components/sidebar/sidebar.go`); no callers touched — every reset path already flows through `SetTabs`.
- Behavior is **sticky-by-title**: navigating to a different item keeps you on the same-named tab (like browser/editor tabs), else Overview.
- Default (`sticky == ""`) reproduces prior behavior for users who never switch tabs.
- Fixes the same latent snap on `R` (refresh-all), action completions, and background auto-refresh, since they all funnel through `SetTabs`.
- Scroll still resets to top on `SetTabs` (correct for the sticky-across-different-items case).

## Tests

- **Unit** (`sidebar_test.go`): preserve-by-title; transient-collapse round-trip (the case the naive fix fails); default-to-Overview without explicit selection.
- **Regression** (`app_test.go`): drives the real `r` async sequence (`KeyPressMsg` → `TaskFinishedMsg` → `enrichedMsg`) through `Update` and asserts the Checks tab is preserved. Confirmed it **fails without the fix** (`got "Overview"`) and passes with it.
- `make check` green (gofmt + `go vet` + `go test -race ./...` + hygiene).

## Design docs

- Spec: `docs/superpowers/specs/2026-07-05-sticky-preview-tab-on-refresh-design.md`
- Plan: `docs/superpowers/plans/2026-07-06-sticky-preview-tab-on-refresh.md`
