### PR TITLE
fix(security): remediate high-severity Scorecard alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     tags:
       - "v*"
 
+# Least-privilege default: the workflow token is read-only. The one job that
+# needs to create the GitHub Release elevates `contents: write` itself.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ go.work.sum
 *.swp
 docs/demo.mp4
 .mcp.json
+
+# Local, potentially token-bearing config — never commit (config lives in
+# ~/.config/tea-dash/; these guard against an accidental in-repo copy).
+config.yml
+*.local.yml
+.env

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.7.8 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
-github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
-github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC4cIk=
 github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Summary

Remediates the two **actionable high-severity** OpenSSF Scorecard code-scanning alerts raised by the security scanner. No criticals existed; the other two high alerts (Maintained, Code-Review) are not code-fixable (repo age / branch-protection policy).

## Changes

| Alert | Fix |
|-------|-----|
| **Vulnerabilities #24** — `goldmark` XSS (`GO-2026-5320` / CVE-2026-5160) | Bump `github.com/yuin/goldmark` v1.7.8 → **v1.7.17**. Confirmed **reachable** via `internal/markdown/markdown.go` (TUI preview renderer). |
| **Token-Permissions #18** — over-broad workflow token | `release.yml` top-level `contents: write` → **`contents: read`**; the `goreleaser` job keeps its own `contents`/`id-token`/`attestations: write`. |
| Defense-in-depth | `.gitignore` now excludes `config.yml`, `*.local.yml`, `.env` so a token-bearing local config can't be accidentally committed. |

## Verification

- **govulncheck**: `Your code is affected by 0 vulnerabilities` (was 1 reachable XSS). The remaining `GO-2026-5932` (`x/crypto/openpgp`) is **not reachable** (`go mod why` → "main module does not need package") and has **no upstream fix** — not remediable, no runtime risk.
- **`make check`**: green — all tests pass under `-race`, gofmt/vet clean.
- **Secret sweep**: full working-tree + git-history scan found **no committed credentials**.
- GitHub Actions semantics verified: job-level `permissions` fully replaces the top-level default, so the release pipeline retains every scope it needs (release upload + build-provenance attestation); the Homebrew-tap PAT is a separate secret, unaffected.

The two fixed Scorecard alerts (#24, #18) will auto-close on the next Scorecard run.