### PR TITLE
fix(ci): bump codeql-action init+analyze to v4.37.0 (supersedes #91)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Raised above the default of 5 so a sibling bump (e.g. codeql-action/init)
+    # can't be silently suppressed by the open-PR limit.
+    open-pull-requests-limit: 10
+    groups:
+      # codeql-action init/analyze/upload-sarif MUST move in lockstep — a split
+      # bump leaves init and analyze on mismatched versions and breaks the scan.
+      codeql-action:
+        patterns: ["github/codeql-action*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: go
           build-mode: autobuild
 
-      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:go"


### PR DESCRIPTION
## Why

Dependabot **#91** bumped only `codeql-action/analyze` to v4.37.0 while `init` stayed on v4.36.3. `codeql-action` requires `init` and `analyze` to run the **same version**, so merging #91 alone would deterministically break the analyze step:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.37.0'
```

`codeql.yml` runs on push to `main`, so that would turn the **default-branch CodeQL run red permanently**.

## What this does

- Bumps **both** `init` and `analyze` to the v4.37.0 SHA `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` in `codeql.yml`, in lockstep.
- **Root-cause fix in `dependabot.yml`:** groups `github/codeql-action*` so init/analyze/upload-sarif always move together in one PR, and raises `open-pull-requests-limit` to 10 (the sibling `init` bump had been suppressed by the default limit of 5 — that's why #91 shipped incomplete).

v4.37.0 is a benign minor bump (default CodeQL bundle → 2.26.0); no breaking change affects this repo's `init(languages: go, build-mode: autobuild)` + `analyze(category /language:go)` setup.

**Supersedes #91** (which should be closed).