### PR TITLE
fix(security): remediate high-severity code-scanning alerts

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -187,14 +187,11 @@ func resolveToken(ov Overrides, login *teaLogin) (string, error) {
 	return loginField(login, func(l teaLogin) string { return l.Token }), nil
 }
 
-// runTokenCommand runs command through the user's $SHELL and returns its
-// trimmed stdout. On failure it includes stderr so the cause is actionable.
+// runTokenCommand runs command via `sh -c` and returns its trimmed stdout.
+// The interpreter is a fixed `sh`, not $SHELL: the process environment is a
+// taint source, and tokenCommand does not need a user-selected shell.
 func runTokenCommand(command string) (string, error) {
-	shell := os.Getenv("SHELL")
-	if shell == "" {
-		shell = "sh"
-	}
-	cmd := exec.Command(shell, "-c", command)
+	cmd := exec.Command("sh", "-c", command)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -158,6 +158,21 @@ func TestResolveTokenCommand(t *testing.T) {
 	}
 }
 
+// tokenCommand must not execute $SHELL: that env var is attacker-controllable
+// in the process environment and is a gosec G702 taint source.
+func TestResolveTokenCommandDoesNotUseSHELL(t *testing.T) {
+	t.Setenv("TEA_DASH_TOKEN", "")
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "not-a-shell"))
+	missing := filepath.Join(t.TempDir(), "none.yml")
+	got, err := ResolveFromFile(missing, Overrides{URL: "https://x.example", TokenCommand: "echo tokfromenv"})
+	if err != nil {
+		t.Fatalf("ResolveFromFile: %v", err)
+	}
+	if got.Token != "tokfromenv" {
+		t.Fatalf("token = %q, want %q even when SHELL is unset/unusable", got.Token, "tokfromenv")
+	}
+}
+
 func TestResolveTokenCommandFailureErrors(t *testing.T) {
 	t.Setenv("TEA_DASH_TOKEN", "")
 	missing := filepath.Join(t.TempDir(), "none.yml")

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,9 @@
+# Scorecard's Vulnerabilities check uses OSV-Scanner. GO-2026-5932 flags the
+# entire golang.org/x/crypto module because the unmaintained openpgp subtree
+# has no patched release. tea-dash does not import that subtree; x/crypto is
+# an indirect dependency for ssh/httpsig via the Gitea SDK. govulncheck
+# (reachability-aware, run in CI) reports the advisory as unused.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "Not reachable: no import of golang.org/x/crypto/openpgp. x/crypto is pulled in for ssh/httpsig only; there is no patched module version."


### PR DESCRIPTION
## Summary

Analysed every open GitHub Security finding for this repo (code scanning, Dependabot, secret scanning, Dependabot/GraphQL vulnerability alerts). There are **no criticals**, **no Dependabot alerts**, and **no secret-scanning alerts**.

This PR remediates the two **actionable high** findings. The other two highs are Scorecard process checks, not code defects.

## Assessment of all open alerts

### Fixed here

| Alert | Tool | Severity | Assessment | Fix |
|-------|------|----------|------------|-----|
| [#1](https://github.com/gbarany/tea-dash/security/code-scanning/1) G702 command injection via taint analysis (`internal/auth/auth.go`) | gosec | **High** | Real taint: `os.Getenv("SHELL")` was used as the `exec.Command` executable. `$SHELL` is a documented G702 source. `tokenCommand` itself is trusted user config (intentional shell command). | Run `tokenCommand` via a fixed `sh -c`, not `$SHELL`. Regression test sets `SHELL` to a missing path and still expects the token. Local gosec: G702 gone; G204 (medium, variable `-c` argument) remains by design. |
| [#24](https://github.com/gbarany/tea-dash/security/code-scanning/24) Scorecard Vulnerabilities — `GO-2026-5932` | Scorecard / OSV | **High** | **Not reachable.** `golang.org/x/crypto` is an indirect dep (ssh / httpsig via the Gitea SDK). Nothing imports `golang.org/x/crypto/openpgp`. There is **no patched module version** (advisory is “unmaintained subtree”). `govulncheck` reports it as unused. | `osv-scanner.toml` ignore with that reason — Scorecard’s documented remediations for a non-affecting vuln. Confirmed with `osv-scanner`: “GO-2026-5932 has been filtered out”. |

### High but not code-fixable

| Alert | Tool | Why we are not changing code |
|-------|------|------------------------------|
| [#22](https://github.com/gbarany/tea-dash/security/code-scanning/22) Maintained | Scorecard | Score is 0 because the repo is **&lt; 90 days old**. Scorecard cannot score maintenance yet. No code change applies; it will self-resolve with continued commits. |
| [#20](https://github.com/gbarany/tea-dash/security/code-scanning/20) Code-Review | Scorecard | 0/5 approved changesets. This is branch-protection / review policy, not an application bug. |

### Medium / low (left alone)

| Alert(s) | Tool | Severity | Assessment |
|----------|------|----------|------------|
| [#2](https://github.com/gbarany/tea-dash/security/code-scanning/2)–[#9](https://github.com/gbarany/tea-dash/security/code-scanning/9) G204 subprocess launched with variable | gosec | Medium | `git`, clipboard, `open`, `tokenCommand`, mock helper. Arguments are local/trusted (user config or our own literals). Not remote injection. |
| [#10](https://github.com/gbarany/tea-dash/security/code-scanning/10)–[#14](https://github.com/gbarany/tea-dash/security/code-scanning/14) G304 file inclusion via variable | gosec | Medium | Config / git file reads of caller-supplied local paths. Expected for a local TUI. |
| [#15](https://github.com/gbarany/tea-dash/security/code-scanning/15) G301 directory permissions 0750 | gosec | Medium | Mock/test helper (`internal/mockgitea`). |
| [#16](https://github.com/gbarany/tea-dash/security/code-scanning/16)–[#17](https://github.com/gbarany/tea-dash/security/code-scanning/17) G104 unhandled errors | gosec | Low | `main.go` cosmetic. |
| [#21](https://github.com/gbarany/tea-dash/security/code-scanning/21) Fuzzing | Scorecard | Medium | No OSS-Fuzz / ClusterFuzzLite. Optional for a TUI; not a defect. |
| [#19](https://github.com/gbarany/tea-dash/security/code-scanning/19) CII-Best-Practices | Scorecard | Low | OpenSSF Best Practices badge not pursued. |

## Verification

- **RED/GREEN:** `TestResolveTokenCommandDoesNotUseSHELL` failed with `fork/exec …/not-a-shell: no such file or directory` against `main`, then passed after the `sh` change.
- **gosec** on `./internal/auth`: G702 gone; remaining G204 + G304 are medium.
- **osv-scanner --lockfile=go.mod .:** `GO-2026-5932 has been filtered out` / `No issues found`.
- **`make check`:** gofmt-check, `go vet`, `go test -race ./...`, public-hygiene — all green.

Alerts #1 and #24 should close after the next gosec / Scorecard runs on `main`.