### PR TITLE
fix: show unmergeable PRs and report merge outcomes honestly

### DIFF
--- a/internal/actionrunner/actionrunner.go
+++ b/internal/actionrunner/actionrunner.go
@@ -36,7 +36,7 @@ type Client interface {
 	AddLabels(owner, repo string, index int64, names []string) error
 	RemoveLabels(owner, repo string, index int64, names []string) error
 	SetIssueMilestone(owner, repo string, index int64, title string) error
-	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error)
+	MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (data.MergeOutcome, error)
 	UpdatePullRequest(owner, repo string, index int64) error
 	MarkPullReady(owner, repo string, index int64) (bool, error)
 	MarkPullDraft(owner, repo string, index int64) (bool, error)
@@ -447,12 +447,12 @@ func (r Runner) run(ctx context.Context, intent uiactions.Intent) (string, error
 		}
 		opt.Title = strings.TrimSpace(intent.Prompt.Title)
 		opt.Message = strings.TrimSpace(intent.Prompt.Body)
-		merged, err := r.client.MergePullRequest(owner, repo, index, opt)
+		outcome, err := r.client.MergePullRequest(owner, repo, index, opt)
 		if err != nil {
 			return "", err
 		}
-		if !merged {
-			return fmt.Sprintf("Merge requested for %s#%d.", intent.Target.Repo, index), nil
+		if outcome == data.MergeScheduled {
+			return fmt.Sprintf("Auto-merge scheduled for %s#%d.", intent.Target.Repo, index), nil
 		}
 		return fmt.Sprintf("Merged %s#%d.", intent.Target.Repo, index), nil
 

--- a/internal/actionrunner/actionrunner_test.go
+++ b/internal/actionrunner/actionrunner_test.go
@@ -350,6 +350,29 @@ func TestDispatchMergeAndReview(t *testing.T) {
 	}
 }
 
+func TestDispatchMergeScheduledMessage(t *testing.T) {
+	client := &fakeClient{mergeOutcome: data.MergeScheduled}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultSucceeded || got.Err != nil {
+		t.Fatalf("scheduled merge result = %+v", got)
+	}
+	if !strings.Contains(got.Message, "Auto-merge scheduled for acme/widgets#7") {
+		t.Fatalf("message = %q, want scheduled confirmation", got.Message)
+	}
+}
+
+func TestDispatchMergeRejectedIsAnError(t *testing.T) {
+	client := &fakeClient{err: errors.New("Pull Request is not mergeable")}
+	got := runDispatch(t, New(Options{Client: client}), pullIntent(uiactions.KindMerge))
+	if got.Status != uiactions.ResultErrored || got.Err == nil ||
+		!strings.Contains(got.Err.Error(), "not mergeable") {
+		t.Fatalf("rejected merge result = %+v", got)
+	}
+	if strings.Contains(got.Message, "Merge requested") {
+		t.Fatalf("rejected merge still used the old success wording: %q", got.Message)
+	}
+}
+
 func TestDispatchReviewRequestChangesPassesBody(t *testing.T) {
 	client := &fakeClient{}
 	intent := pullIntent(uiactions.KindReview)
@@ -883,6 +906,7 @@ type fakeClient struct {
 	issueState         data.ItemState
 	pullState          data.ItemState
 	merge              data.MergeOptions
+	mergeOutcome       data.MergeOutcome
 	review             data.PullReviewOptions
 	updatePull         int64
 	markReady          int64
@@ -975,9 +999,12 @@ func (f *fakeClient) SetIssueMilestone(_, _ string, index int64, title string) e
 	return f.err
 }
 
-func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOptions) (bool, error) {
+func (f *fakeClient) MergePullRequest(_, _ string, _ int64, opt data.MergeOptions) (data.MergeOutcome, error) {
 	f.merge = opt
-	return f.err == nil, f.err
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.mergeOutcome, nil
 }
 
 func (f *fakeClient) SubmitPullReview(_, _ string, _ int64, opt data.PullReviewOptions) (data.Review, error) {

--- a/internal/data/mutation.go
+++ b/internal/data/mutation.go
@@ -46,6 +46,15 @@ type MergeOptions struct {
 	HeadCommitID string
 }
 
+// MergeOutcome is Gitea's answer to POST .../pulls/{n}/merge.
+// 200 means the PR was merged; 201 means auto-merge was scheduled.
+type MergeOutcome int
+
+const (
+	MergeCompleted MergeOutcome = iota
+	MergeScheduled
+)
+
 // PullReviewEvent is the user's review action. The transport maps these event
 // names onto Gitea's submitted review states.
 type PullReviewEvent string

--- a/internal/data/mutation_test.go
+++ b/internal/data/mutation_test.go
@@ -9,6 +9,9 @@ func TestMutationDomainConstants(t *testing.T) {
 	if ItemStateOpen != "open" || ItemStateClosed != "closed" {
 		t.Fatalf("item states = %q/%q, want open/closed", ItemStateOpen, ItemStateClosed)
 	}
+	if MergeCompleted == MergeScheduled {
+		t.Fatal("MergeCompleted and MergeScheduled must be distinct")
+	}
 	if MergeStyleMerge != "merge" ||
 		MergeStyleRebase != "rebase" ||
 		MergeStyleRebaseMerge != "rebase-merge" ||

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -1,7 +1,11 @@
 package gitea
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	sdk "code.gitea.io/sdk/gitea"
@@ -289,27 +293,51 @@ func (c *Client) SetIssueMilestone(owner, repo string, index int64, title string
 }
 
 // MergePullRequest merges a pull request with the requested strategy and
-// optional server-side controls.
-func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (bool, error) {
+// optional server-side controls. It talks to Gitea over the raw HTTP
+// escape hatch so 200 (merged), 201 (auto-merge scheduled), and 405/409
+// (rejected, reason in the body) stay distinguishable. The typed SDK
+// collapses all of those to (bool, nil).
+func (c *Client) MergePullRequest(owner, repo string, index int64, opt data.MergeOptions) (data.MergeOutcome, error) {
 	deleteBranch := opt.DeleteBranch
-	var merged bool
-	err := c.call(func() error {
-		var e error
-		merged, _, e = c.sdk.MergePullRequest(owner, repo, index, sdk.MergePullRequestOption{
-			Style:                  sdk.MergeStyle(opt.Style),
-			Title:                  opt.Title,
-			Message:                opt.Message,
-			DeleteBranchAfterMerge: &deleteBranch,
-			ForceMerge:             opt.ForceMerge,
-			HeadCommitId:           opt.HeadCommitID,
-			MergeWhenChecksSucceed: opt.AutoMerge,
-		})
-		return e
+	status, err := c.rawPostJSON(context.Background(), fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, index), sdk.MergePullRequestOption{
+		Style:                  sdk.MergeStyle(opt.Style),
+		Title:                  opt.Title,
+		Message:                opt.Message,
+		DeleteBranchAfterMerge: &deleteBranch,
+		ForceMerge:             opt.ForceMerge,
+		HeadCommitId:           opt.HeadCommitID,
+		MergeWhenChecksSucceed: opt.AutoMerge,
 	})
 	if err != nil {
-		return false, fmt.Errorf("merge pull %s/%s#%d: %w", owner, repo, index, err)
+		return 0, fmt.Errorf("merge pull %s/%s#%d: %s", owner, repo, index, mergeErrorText(err))
 	}
-	return merged, nil
+	if status == http.StatusCreated {
+		return data.MergeScheduled, nil
+	}
+	return data.MergeCompleted, nil
+}
+
+func mergeErrorText(err error) string {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if msg := giteaMessage(httpErr.Body); msg != "" {
+			return msg
+		}
+		if httpErr.Body != "" {
+			return httpErr.Body
+		}
+	}
+	return err.Error()
+}
+
+func giteaMessage(body string) string {
+	var wrap struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal([]byte(body), &wrap) != nil || wrap.Message == "" {
+		return ""
+	}
+	return wrap.Message
 }
 
 // MergeCapabilities returns the merge choices the selected repository advertises.

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -325,7 +325,7 @@ func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	merged, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{
+	got, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{
 		Style:        data.MergeStyleSquash,
 		Title:        "merge title",
 		Message:      "merge message",
@@ -337,8 +337,49 @@ func TestMergePullRequestPostsOptionsAndReturnsMerged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MergePullRequest: %v", err)
 	}
-	if !merged {
-		t.Fatal("merged = false, want true")
+	if got != data.MergeCompleted {
+		t.Fatalf("outcome = %v, want MergeCompleted", got)
+	}
+}
+
+func TestMergePullRequestSchedulesOn201(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/repos/acme/widgets/pulls/44/merge" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	got, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{Style: data.MergeStyleMerge, AutoMerge: true})
+	if err != nil {
+		t.Fatalf("MergePullRequest: %v", err)
+	}
+	if got != data.MergeScheduled {
+		t.Fatalf("outcome = %v, want MergeScheduled", got)
+	}
+}
+
+func TestMergePullRequestRejectionSurfacesBody(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprint(w, `{"message":"Pull Request is not mergeable"}`)
+	})
+
+	_, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{Style: data.MergeStyleMerge})
+	if err == nil || !strings.Contains(err.Error(), "not mergeable") {
+		t.Fatalf("error = %v, want the Gitea rejection reason", err)
+	}
+}
+
+func TestMergePullRequestConflictSurfacesBody(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"message":"head out of date"}`)
+	})
+
+	_, err := c.MergePullRequest("acme", "widgets", 44, data.MergeOptions{Style: data.MergeStyleMerge})
+	if err == nil || !strings.Contains(err.Error(), "head out of date") {
+		t.Fatalf("error = %v, want the Gitea 409 reason", err)
 	}
 }
 

--- a/internal/gitea/search.go
+++ b/internal/gitea/search.go
@@ -1,6 +1,7 @@
 package gitea
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -570,6 +571,44 @@ func (c *Client) rawPost(ctx context.Context, path string) error {
 		}
 	}
 	return nil
+}
+
+// rawPostJSON POSTs an authenticated JSON body to {baseURL}/api/v1{path}.
+// It returns the HTTP status for 2xx responses so callers can distinguish
+// 200 from 201. Non-2xx responses become an HTTPError that includes the body.
+func (c *Client) rawPostJSON(ctx context.Context, path string, payload any) (int, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1"+path, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "token "+c.token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, &HTTPError{
+			Method:     http.MethodPost,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       truncate(respBody, 500),
+		}
+	}
+	return resp.StatusCode, nil
 }
 
 // truncate returns b as a string, clipped to max bytes with an ellipsis marker

--- a/internal/mockgitea/mutations.go
+++ b/internal/mockgitea/mutations.go
@@ -2,6 +2,8 @@ package mockgitea
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -220,9 +222,8 @@ func hasWIPPrefix(title string) bool {
 	return strings.HasPrefix(trimmed, "wip:") || strings.HasPrefix(trimmed, "[wip]")
 }
 
-// handleMergePull serves POST .../pulls/{index}/merge. MergePullRequest
-// (the real client) determines success purely from the HTTP status code —
-// 200 or 201 — and never inspects the response body, so no body is written.
+// handleMergePull serves POST .../pulls/{index}/merge. 200 means merged,
+// 201 means auto-merge scheduled, 405 means not mergeable (reason in body).
 func (s *Server) handleMergePull(w http.ResponseWriter, r *http.Request) {
 	full := r.PathValue("owner") + "/" + r.PathValue("repo")
 	idx, ok := parsePathInt64(r.PathValue("index"))
@@ -233,14 +234,26 @@ func (s *Server) handleMergePull(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Do                     string `json:"Do"`
 		DeleteBranchAfterMerge *bool  `json:"delete_branch_after_merge"`
+		MergeWhenChecksSucceed bool   `json:"merge_when_checks_succeed"`
 	}
 	if err := decodeJSONBody(r, &body); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	deleteBranch := body.DeleteBranchAfterMerge != nil && *body.DeleteBranchAfterMerge
-	if err := s.store.MergePull(full, idx, body.Do, deleteBranch); err != nil {
+	scheduled, err := s.store.MergePull(full, idx, body.Do, deleteBranch, body.MergeWhenChecksSucceed)
+	if err != nil {
+		if errors.Is(err, errMergeNotAllowed) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprint(w, `{"message":"pull request is not mergeable"}`)
+			return
+		}
 		notFound(w, r)
+		return
+	}
+	if scheduled {
+		w.WriteHeader(http.StatusCreated)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/internal/mockgitea/mutations_test.go
+++ b/internal/mockgitea/mutations_test.go
@@ -81,9 +81,9 @@ func TestMutationsRoundTrip(t *testing.T) {
 func TestMergeRemovesFromOpenSearch(t *testing.T) {
 	s := detailStore(time.Now())
 	c := newTestClient(t, s)
-	merged, err := c.MergePullRequest("teahouse", "kettle", 1, data.MergeOptions{Style: data.MergeStyleSquash})
-	if err != nil || !merged {
-		t.Fatalf("merge: %v merged=%v", err, merged)
+	got, err := c.MergePullRequest("teahouse", "kettle", 1, data.MergeOptions{Style: data.MergeStyleSquash})
+	if err != nil || got != data.MergeCompleted {
+		t.Fatalf("merge: %v outcome=%v", err, got)
 	}
 	rows, _, err := c.SearchPullsPage(context.Background(),
 		config.PrIssueFilter{State: "open", CreatedBy: "@me"}, 30, 1)
@@ -94,6 +94,37 @@ func TestMergeRemovesFromOpenSearch(t *testing.T) {
 		if r.Number == 1 {
 			t.Fatal("merged PR still in open search")
 		}
+	}
+}
+
+func TestMergeUnmergeableReturnsError(t *testing.T) {
+	s := NewStore()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	s.AddPull(&Pull{Number: 6, RepoFullName: "teahouse/kettle", Title: "conflict", State: "open", Mergeable: false})
+	c := newTestClient(t, s)
+	_, err := c.MergePullRequest("teahouse", "kettle", 6, data.MergeOptions{Style: data.MergeStyleMerge})
+	if err == nil || !strings.Contains(err.Error(), "not mergeable") {
+		t.Fatalf("error = %v, want not mergeable", err)
+	}
+	if p := s.Pull("teahouse/kettle", 6); p == nil || p.Merged {
+		t.Fatalf("rejected merge should leave the PR open, got %+v", p)
+	}
+}
+
+func TestMergeAutoMergeSchedulesWhenChecksFail(t *testing.T) {
+	s := NewStore()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	s.AddPull(&Pull{
+		Number: 2, RepoFullName: "teahouse/kettle", Title: "ci", State: "open", Mergeable: true,
+		Statuses: []*CommitStatus{{Status: "failure", Context: "ci/build"}},
+	})
+	c := newTestClient(t, s)
+	got, err := c.MergePullRequest("teahouse", "kettle", 2, data.MergeOptions{Style: data.MergeStyleMerge, AutoMerge: true})
+	if err != nil || got != data.MergeScheduled {
+		t.Fatalf("outcome=%v err=%v, want MergeScheduled", got, err)
+	}
+	if p := s.Pull("teahouse/kettle", 2); p == nil || p.Merged {
+		t.Fatalf("scheduled auto-merge should leave the PR open, got %+v", p)
 	}
 }
 

--- a/internal/mockgitea/search_test.go
+++ b/internal/mockgitea/search_test.go
@@ -15,7 +15,7 @@ func searchStore(now time.Time) *Store {
 	s.AddUser(mei)
 	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
 	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "fix: login flow",
-		State: "open", Author: s.Me(), Updated: now})
+		State: "open", Mergeable: true, Author: s.Me(), Updated: now})
 	s.AddPull(&Pull{Number: 2, RepoFullName: "teahouse/kettle", Title: "feat: rate limits",
 		State: "open", Author: mei, Reviewers: []*User{s.Me()}, Updated: now.Add(-time.Hour)})
 	s.AddPull(&Pull{Number: 3, RepoFullName: "teahouse/kettle", Title: "old fix",

--- a/internal/mockgitea/store.go
+++ b/internal/mockgitea/store.go
@@ -5,6 +5,7 @@
 package mockgitea
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -612,22 +613,42 @@ func (s *Store) MarkAllNotificationsRead() {
 	}
 }
 
+// errMergeNotAllowed is returned when Gitea would answer 405 (WIP, conflict,
+// or mergeable=false). The HTTP handler maps it to that status.
+var errMergeNotAllowed = errors.New("pull request is not mergeable")
+
 // MergePull marks a pull request merged and closed. It errors if the pull is
-// unknown. style and deleteBranch are accepted (and currently unused) for
-// later tasks — e.g. an HTTP handler that echoes the merge style back, or
-// simulated branch deletion.
-func (s *Store) MergePull(repo string, num int64, style string, deleteBranch bool) error {
+// unknown or not mergeable. autoMerge + failing/pending checks returns
+// scheduled=true without flipping Merged, matching Gitea's 201.
+func (s *Store) MergePull(repo string, num int64, style string, deleteBranch, autoMerge bool) (scheduled bool, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, p := range s.pulls[repo] {
-		if p.Number == num {
-			p.Merged = true
-			p.State = "closed"
-			p.Updated = time.Now()
-			return nil
+		if p.Number != num {
+			continue
+		}
+		if !p.Mergeable {
+			return false, errMergeNotAllowed
+		}
+		if autoMerge && pullHasBlockingChecks(p) {
+			return true, nil
+		}
+		p.Merged = true
+		p.State = "closed"
+		p.Updated = time.Now()
+		return false, nil
+	}
+	return false, fmt.Errorf("mockgitea: unknown pull %s#%d", repo, num)
+}
+
+func pullHasBlockingChecks(p *Pull) bool {
+	for _, st := range p.Statuses {
+		switch st.Status {
+		case "failure", "pending", "error":
+			return true
 		}
 	}
-	return fmt.Errorf("mockgitea: unknown pull %s#%d", repo, num)
+	return false
 }
 
 // SetPullState opens or closes a pull request. It errors if the pull is

--- a/internal/mockgitea/store_test.go
+++ b/internal/mockgitea/store_test.go
@@ -9,8 +9,8 @@ import (
 func TestMergePullFlipsState(t *testing.T) {
 	s := NewStore()
 	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
-	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "fix", State: "open"})
-	if err := s.MergePull("teahouse/kettle", 1, "merge", false); err != nil {
+	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "fix", State: "open", Mergeable: true})
+	if _, err := s.MergePull("teahouse/kettle", 1, "merge", false, false); err != nil {
 		t.Fatalf("MergePull: %v", err)
 	}
 	p := s.Pull("teahouse/kettle", 1)
@@ -95,8 +95,38 @@ func TestNotificationReadPin(t *testing.T) {
 func TestMergePullUnknownPullErrors(t *testing.T) {
 	s := NewStore()
 	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
-	if err := s.MergePull("teahouse/kettle", 404, "merge", false); err == nil {
+	if _, err := s.MergePull("teahouse/kettle", 404, "merge", false, false); err == nil {
 		t.Fatal("want error merging unknown pull, got nil")
+	}
+}
+
+func TestMergePullRejectsUnmergeable(t *testing.T) {
+	s := NewStore()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	s.AddPull(&Pull{Number: 6, RepoFullName: "teahouse/kettle", Title: "conflict", State: "open", Mergeable: false})
+	if _, err := s.MergePull("teahouse/kettle", 6, "merge", false, false); err == nil {
+		t.Fatal("want error merging an unmergeable pull")
+	}
+	p := s.Pull("teahouse/kettle", 6)
+	if p == nil || p.Merged || p.State != "open" {
+		t.Fatalf("unmergeable pull should stay open, got %+v", p)
+	}
+}
+
+func TestMergePullSchedulesWhenChecksFail(t *testing.T) {
+	s := NewStore()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	s.AddPull(&Pull{
+		Number: 2, RepoFullName: "teahouse/kettle", Title: "ci", State: "open", Mergeable: true,
+		Statuses: []*CommitStatus{{Status: "failure", Context: "ci/build"}},
+	})
+	scheduled, err := s.MergePull("teahouse/kettle", 2, "merge", false, true)
+	if err != nil || !scheduled {
+		t.Fatalf("scheduled=%v err=%v, want scheduled auto-merge", scheduled, err)
+	}
+	p := s.Pull("teahouse/kettle", 2)
+	if p == nil || p.Merged || p.State != "open" {
+		t.Fatalf("auto-merge should leave the PR open, got %+v", p)
 	}
 }
 
@@ -156,7 +186,7 @@ func TestAllPullsAndAllIssuesSortedByID(t *testing.T) {
 func TestConcurrentMarshalWithLock(t *testing.T) {
 	s := NewStore()
 	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
-	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "fix", State: "open"})
+	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "fix", State: "open", Mergeable: true})
 
 	const iterations = 300
 	var wg sync.WaitGroup
@@ -166,7 +196,7 @@ func TestConcurrentMarshalWithLock(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
 			_ = s.SetPullState("teahouse/kettle", 1, "open")
-			_ = s.MergePull("teahouse/kettle", 1, "merge", false)
+			_, _ = s.MergePull("teahouse/kettle", 1, "merge", false, false)
 		}
 	}()
 

--- a/internal/ui/components/prview/prview.go
+++ b/internal/ui/components/prview/prview.go
@@ -238,6 +238,9 @@ func pullHeader(row data.PullRequest, detail *data.PullDetail, width int, styles
 	} else {
 		header = append(header, statePill(rowState(row.State), stateLabel(row.State), styles, set))
 	}
+	if detail != nil && !detail.Merged && !detail.Mergeable && !row.Draft {
+		header = append(header, statePill(icons.Failure, "NOT MERGEABLE", styles, set))
+	}
 	if detail != nil {
 		header = append(header,
 			subtleRef.Render(fmt.Sprintf("%s ← %s", detail.BaseRef, detail.HeadRef)),

--- a/internal/ui/components/prview/prview_test.go
+++ b/internal/ui/components/prview/prview_test.go
@@ -46,6 +46,7 @@ func TestRenderPullWithDetail(t *testing.T) {
 		Body:         "This body has a **unique-token-xyz** phrase.",
 		BaseRef:      "main",
 		HeadRef:      "feature",
+		Mergeable:    true,
 		Additions:    10,
 		Deletions:    3,
 		ChangedFiles: 2,
@@ -76,6 +77,27 @@ func TestRenderPullFoldVsExpanded(t *testing.T) {
 	}
 	if strings.Contains(expanded, "read more") {
 		t.Fatalf("expanded body should not show read-more hint:\n%s", expanded)
+	}
+}
+
+func TestRenderPullNotMergeablePill(t *testing.T) {
+	detail := &data.PullDetail{Mergeable: false, BaseRef: "main", HeadRef: "feat"}
+	out := RenderPull(samplePull(), detail, 60, false, appctx.DefaultStyles(), icons.Unicode)
+	if !strings.Contains(out, "NOT MERGEABLE") {
+		t.Fatalf("unmergeable preview missing NOT MERGEABLE pill:\n%s", out)
+	}
+
+	draft := samplePull()
+	draft.Draft = true
+	draftOut := RenderPull(draft, detail, 60, false, appctx.DefaultStyles(), icons.Unicode)
+	if strings.Contains(draftOut, "NOT MERGEABLE") {
+		t.Fatalf("draft preview should not add NOT MERGEABLE:\n%s", draftOut)
+	}
+
+	merged := &data.PullDetail{Mergeable: false, Merged: true, BaseRef: "main", HeadRef: "feat"}
+	mergedOut := RenderPull(samplePull(), merged, 60, false, appctx.DefaultStyles(), icons.Unicode)
+	if strings.Contains(mergedOut, "NOT MERGEABLE") {
+		t.Fatalf("merged preview should not add NOT MERGEABLE:\n%s", mergedOut)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [#103](https://github.com/gbarany/tea-dash/issues/103). Two independent gaps:

1. **Unmergeable PRs looked mergeable.** `PullDetail.Mergeable` was fetched and dropped. Preview now adds a `NOT MERGEABLE` pill when the flag is false. It is **not** labeled “conflict” — Gitea also uses the flag for still-checking, error, and WIP. Drafts stay `DRAFT`-only. Branch-protection / failed required checks stay on the existing Checks tab (`CIStatus`).

2. **Every rejection said “Merge requested”.** The SDK’s `MergePullRequest` never maps status codes: 405/409 become `false, nil`, and 201 (auto-merge scheduled) becomes `true`. Merge now goes through the raw POST helper so:
   - `200` → `Merged repo#n.`
   - `201` → `Auto-merge scheduled for repo#n.`
   - `405`/`409` → error toast with Gitea’s `message` (no more success wording)

The mock server matches that contract: `Mergeable: false` → 405; auto-merge + failing/pending checks → 201 without flipping `Merged`. `--mock` kettle PR #6 is the unmergeable demo case.

## Verification

- Client: 200 / 201 / 405 / 409 httptest coverage
- Action runner: scheduled success vs rejected error (no “Merge requested”)
- Preview: pill present for unmergeable, absent for draft/merged
- Mock store + HTTP round-trip
- `make check` green (including `TestE2EMergeRoundTrip`)

Closes #103