### PR TITLE
feat: interactive label filter for PR and issue lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ drill into (focus) the preview panel rather than opening a browser.
 | Global | `y` / `Y` | copy row number / URL |
 | Global | `t` | toggle current-repo smart filtering (when launched from a matching git checkout) |
 | Global | `q` / `ctrl+c` | quit |
-| PRs | `c` comment · `a`/`A` assign/unassign · `L`/`U` labels · `m` merge · `u` update branch · `W` ready · `w` checks · `x`/`X` close/reopen · `v` review · `@`/`#` request/remove reviewers · `d`/`ctrl+t` diff · `C`/`space` checkout |
-| Issues | `c` comment · `a`/`A` assign/unassign · `L`/`U` labels · `M` milestone · `b`/`B` subscribe/unsubscribe · `x`/`X` close/reopen · `C`/`space` checkout |
+| PRs | `c` comment · `a`/`A` assign/unassign · `L`/`U` labels · `f` filter labels · `m` merge · `u` update branch · `W` ready · `w` checks · `x`/`X` close/reopen · `v` review · `@`/`#` request/remove reviewers · `d`/`ctrl+t` diff · `C`/`space` checkout |
+| Issues | `c` comment · `a`/`A` assign/unassign · `L`/`U` labels · `f` filter labels · `M` milestone · `b`/`B` subscribe/unsubscribe · `x`/`X` close/reopen · `C`/`space` checkout |
 | Inbox | `m` read · `u` unread · `M` all read · `b` pin/unpin · `B` unpin |
 | CI | `R` rerun · `!` cancel · `L` logs |
 | Branches | `C`/`space`/`enter`\* checkout · `P` push · `f` fast-forward · `F` force-push · `d`/`backspace` delete |
@@ -288,7 +288,7 @@ issuesSections:
     filter:
       state: open
       assignedBy: "@me"
-      labels: [bug, urgent]  # AND-ed
+      labels: [bug, urgent]  # OR-ed by Gitea/Forgejo (any of these labels)
       milestone: v2
 
 notificationsSections:
@@ -413,7 +413,7 @@ are loaded first; later includes override earlier includes; the current file
 overrides all included values. Nested maps merge recursively, while arrays and
 scalars replace the previous value.
 
-`filter` fields: `state`, `labels` (AND-ed), `milestone`, `createdBy`,
+`filter` fields: `state`, `labels` (OR-ed by the Gitea/Forgejo API; `f` opens a live picker), `milestone`, `createdBy`,
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),
 `sort`. PR and issue sections fetch one page at a time; reaching the loaded
 bottom automatically requests the next page until the server total is loaded.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ issuesSections:
     filter:
       state: open
       assignedBy: "@me"
-      labels: [bug, urgent]  # OR-ed by Gitea/Forgejo (any of these labels)
+      labels: [bug, urgent]  # global repos: makes this repo-scoped, so both labels are required
       milestone: v2
 
 notificationsSections:
@@ -413,7 +413,7 @@ are loaded first; later includes override earlier includes; the current file
 overrides all included values. Nested maps merge recursively, while arrays and
 scalars replace the previous value.
 
-`filter` fields: `state`, `labels` (OR-ed by the Gitea/Forgejo API; `f` opens a live picker), `milestone`, `createdBy`,
+`filter` fields: `state`, `labels` (all required for repo-scoped sections; any match for instance-wide search; `f` opens a live picker), `milestone`, `createdBy`,
 `assignedBy`, `mentioned`, `reviewRequested` (PRs only), `since` (RFC3339),
 `sort`. PR and issue sections fetch one page at a time; reaching the loaded
 bottom automatically requests the next page until the server total is loaded.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,7 +340,7 @@ type LocalRepoConfig struct {
 type PrIssueFilter struct {
 	State     string   `yaml:"state"`     // open | closed | all (default open)
 	Type      string   `yaml:"-"`         // pulls | issues (set by the section)
-	Labels    []string `yaml:"labels"`    // label names (OR-ed by Gitea/Forgejo search)
+	Labels    []string `yaml:"labels"`    // names (repo lists require all; cross-repo search matches any)
 	Milestone string   `yaml:"milestone"` // milestone name
 	// The me-scoped author fields accept "@me" only (a plain login is not
 	// supported by the cross-repo search endpoint, which has no per-login author

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -557,7 +557,7 @@ var universalBuiltins = builtinSet(
 )
 
 var prBuiltins = builtinSet(
-	"comment", "assign", "unassign", "addLabel", "removeLabel", "merge",
+	"comment", "assign", "unassign", "addLabel", "removeLabel", "filterLabels", "filterLabel", "merge",
 	"update", "updateBranch", "ready", "markReady", "draft", "markDraft",
 	"watch", "watchChecks", "checks", "close", "reopen", "diff", "checkout", "approve", "review",
 	"requestReview", "requestReviewer", "requestReviewers",
@@ -566,7 +566,7 @@ var prBuiltins = builtinSet(
 )
 
 var issueBuiltins = builtinSet(
-	"comment", "assign", "unassign", "addLabel", "removeLabel", "close", "reopen",
+	"comment", "assign", "unassign", "addLabel", "removeLabel", "filterLabels", "filterLabel", "close", "reopen",
 	"milestone", "setMilestone", "checkout", "subscribe", "unsubscribe",
 	"milestone", "setMilestone", "checkout", "subscribe", "unsubscribe", "viewPrs",
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,7 +340,7 @@ type LocalRepoConfig struct {
 type PrIssueFilter struct {
 	State     string   `yaml:"state"`     // open | closed | all (default open)
 	Type      string   `yaml:"-"`         // pulls | issues (set by the section)
-	Labels    []string `yaml:"labels"`    // label names (AND-ed via the search endpoint)
+	Labels    []string `yaml:"labels"`    // label names (OR-ed by Gitea/Forgejo search)
 	Milestone string   `yaml:"milestone"` // milestone name
 	// The me-scoped author fields accept "@me" only (a plain login is not
 	// supported by the cross-repo search endpoint, which has no per-login author

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -530,10 +530,12 @@ func TestConfigValidateKeybindingsRequireKeyAndAction(t *testing.T) {
 		{Key: "[", Builtin: "prevSidebarTab"},
 		{Key: "]", Builtin: "nextSidebarTab"},
 		{Key: "i", Builtin: "viewIssues"},
+		{Key: "F", Builtin: "filterLabels"},
 	}, Issues: []Keybinding{
 		{Key: "p", Builtin: "viewPrs"},
 		{Key: "A", Builtin: "unassign"},
 		{Key: "U", Builtin: "removeLabel"},
+		{Key: "F", Builtin: "filterLabel"},
 	}, Notifications: []Keybinding{
 		{Key: "b", Builtin: "toggleBookmark"},
 	}, Actions: []Keybinding{

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -218,40 +218,84 @@ func (c *Client) RemoveLabels(owner, repo string, index int64, names []string) e
 	return nil
 }
 
-// ListRepoLabels returns the repository's label definitions by name.
+const labelPageSize = 50
+
+type labelPageFetcher func(sdk.ListOptions) ([]*sdk.Label, *sdk.Response, error)
+
+// ListRepoLabels returns the repository and organization label definitions by
+// name. Repository-local labels take precedence when both scopes use the same
+// name.
 func (c *Client) ListRepoLabels(owner, repo string) ([]data.Label, error) {
-	var labels []*sdk.Label
-	err := c.call(func() error {
-		var e error
-		labels, _, e = c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{
-			ListOptions: sdk.ListOptions{Page: -1},
-		})
-		return e
+	repoLabels, _, err := c.listAllLabels(func(opt sdk.ListOptions) ([]*sdk.Label, *sdk.Response, error) {
+		return c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{ListOptions: opt})
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list labels for %s/%s: %w", owner, repo, err)
 	}
+
+	orgLabels, resp, err := c.listAllLabels(func(opt sdk.ListOptions) ([]*sdk.Label, *sdk.Response, error) {
+		return c.sdk.ListOrgLabels(owner, sdk.ListOrgLabelsOptions{ListOptions: opt})
+	})
+	if err != nil {
+		// A 404 means either that owner is a user or that the server predates
+		// organization labels. Other failures would make the picker silently
+		// incomplete, so surface them.
+		if resp == nil || resp.Response == nil || resp.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf("list organization labels for %s: %w", owner, err)
+		}
+		orgLabels = nil
+	}
+
+	labels := append(repoLabels, orgLabels...)
 	out := make([]data.Label, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
 	for _, label := range labels {
 		if label == nil || strings.TrimSpace(label.Name) == "" {
 			continue
 		}
+		if _, ok := seen[label.Name]; ok {
+			continue
+		}
+		seen[label.Name] = struct{}{}
 		out = append(out, data.Label{Name: label.Name, Color: label.Color})
 	}
 	return out, nil
+}
+
+// listAllLabels follows the endpoint's X-Total-Count across numbered pages.
+// The label APIs do not consistently emit Link headers, so Page:-1 cannot be
+// used as an unbounded request.
+func (c *Client) listAllLabels(fetch labelPageFetcher) ([]*sdk.Label, *sdk.Response, error) {
+	var all []*sdk.Label
+	for page := 1; ; page++ {
+		var batch []*sdk.Label
+		var resp *sdk.Response
+		err := c.call(func() error {
+			var e error
+			batch, resp, e = fetch(sdk.ListOptions{Page: page, PageSize: labelPageSize})
+			return e
+		})
+		if err != nil {
+			return nil, resp, err
+		}
+
+		all = append(all, batch...)
+		total := totalFromSDKResponse(resp, -1)
+		if total >= 0 && len(all) >= total {
+			return all, resp, nil
+		}
+		if len(batch) == 0 || (total < 0 && len(batch) < labelPageSize) {
+			return all, resp, nil
+		}
+	}
 }
 
 func (c *Client) resolveLabelIDs(owner, repo string, names []string) ([]int64, error) {
 	if len(names) == 0 {
 		return nil, fmt.Errorf("label names cannot be empty")
 	}
-	var labels []*sdk.Label
-	err := c.call(func() error {
-		var e error
-		labels, _, e = c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{
-			ListOptions: sdk.ListOptions{Page: -1},
-		})
-		return e
+	labels, _, err := c.listAllLabels(func(opt sdk.ListOptions) ([]*sdk.Label, *sdk.Response, error) {
+		return c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{ListOptions: opt})
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list labels for %s/%s: %w", owner, repo, err)

--- a/internal/gitea/mutation.go
+++ b/internal/gitea/mutation.go
@@ -218,6 +218,29 @@ func (c *Client) RemoveLabels(owner, repo string, index int64, names []string) e
 	return nil
 }
 
+// ListRepoLabels returns the repository's label definitions by name.
+func (c *Client) ListRepoLabels(owner, repo string) ([]data.Label, error) {
+	var labels []*sdk.Label
+	err := c.call(func() error {
+		var e error
+		labels, _, e = c.sdk.ListRepoLabels(owner, repo, sdk.ListLabelsOptions{
+			ListOptions: sdk.ListOptions{Page: -1},
+		})
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list labels for %s/%s: %w", owner, repo, err)
+	}
+	out := make([]data.Label, 0, len(labels))
+	for _, label := range labels {
+		if label == nil || strings.TrimSpace(label.Name) == "" {
+			continue
+		}
+		out = append(out, data.Label{Name: label.Name, Color: label.Color})
+	}
+	return out, nil
+}
+
 func (c *Client) resolveLabelIDs(owner, repo string, names []string) ([]int64, error) {
 	if len(names) == 0 {
 		return nil, fmt.Errorf("label names cannot be empty")

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -626,6 +626,35 @@ func TestRemovePullReviewersDeletesReviewerList(t *testing.T) {
 	}
 }
 
+func TestListRepoLabelsMapsNames(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/acme/widgets/labels" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `[
+			{"id":1,"name":"bug","color":"ee0000"},
+			{"id":2,"name":"urgent","color":"ffaa00"},
+			{"name":""},
+			null
+		]`)
+	})
+
+	got, err := c.ListRepoLabels("acme", "widgets")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	want := []data.Label{
+		{Name: "bug", Color: "ee0000"},
+		{Name: "urgent", Color: "ffaa00"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+}
+
 func TestListReviewersMapsRequestableReviewers(t *testing.T) {
 	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/internal/gitea/mutation_test.go
+++ b/internal/gitea/mutation_test.go
@@ -631,15 +631,20 @@ func TestListRepoLabelsMapsNames(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("method = %s, want GET", r.Method)
 		}
-		if r.URL.Path != "/api/v1/repos/acme/widgets/labels" {
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/labels":
+			fmt.Fprint(w, `[
+				{"id":1,"name":"bug","color":"ee0000"},
+				{"id":2,"name":"urgent","color":"ffaa00"},
+				{"name":""},
+				null
+			]`)
+		case "/api/v1/orgs/acme/labels":
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"organization not found"}`)
+		default:
 			t.Fatalf("path = %s", r.URL.Path)
 		}
-		fmt.Fprint(w, `[
-			{"id":1,"name":"bug","color":"ee0000"},
-			{"id":2,"name":"urgent","color":"ffaa00"},
-			{"name":""},
-			null
-		]`)
 	})
 
 	got, err := c.ListRepoLabels("acme", "widgets")
@@ -652,6 +657,127 @@ func TestListRepoLabelsMapsNames(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+}
+
+func TestListRepoLabelsFetchesEveryPage(t *testing.T) {
+	var repoPages []string
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/labels":
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "0" {
+				page = "1" // The real endpoint normalizes the SDK's page=0.
+			}
+			repoPages = append(repoPages, page)
+			w.Header().Set("X-Total-Count", "3")
+			switch page {
+			case "1":
+				fmt.Fprint(w, `[
+					{"id":1,"name":"bug","color":"ee0000"},
+					{"id":2,"name":"urgent","color":"ffaa00"}
+				]`)
+			case "2":
+				fmt.Fprint(w, `[{"id":3,"name":"later","color":"00aaee"}]`)
+			default:
+				t.Fatalf("unexpected repo label page %q", page)
+			}
+		case "/api/v1/orgs/acme/labels":
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"organization not found"}`)
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	})
+
+	got, err := c.ListRepoLabels("acme", "widgets")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	want := []data.Label{
+		{Name: "bug", Color: "ee0000"},
+		{Name: "urgent", Color: "ffaa00"},
+		{Name: "later", Color: "00aaee"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(repoPages, []string{"1", "2"}) {
+		t.Fatalf("repo label pages = %#v, want pages 1 and 2", repoPages)
+	}
+}
+
+func TestListRepoLabelsIncludesOrgLabelsWhenRepoHasNone(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Total-Count", "1")
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/labels":
+			w.Header().Set("X-Total-Count", "0")
+			fmt.Fprint(w, `[]`)
+		case "/api/v1/orgs/acme/labels":
+			fmt.Fprint(w, `[{"id":10,"name":"org-wide","color":"8844ee"}]`)
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	})
+
+	got, err := c.ListRepoLabels("acme", "widgets")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	want := []data.Label{{Name: "org-wide", Color: "8844ee"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+}
+
+func TestListRepoLabelsPrefersRepoLabelOnNameCollision(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Total-Count", "2")
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/labels":
+			w.Header().Set("X-Total-Count", "1")
+			fmt.Fprint(w, `[{"id":1,"name":"bug","color":"repo00"}]`)
+		case "/api/v1/orgs/acme/labels":
+			fmt.Fprint(w, `[
+				{"id":10,"name":"bug","color":"org000"},
+				{"id":11,"name":"org-wide","color":"8844ee"}
+			]`)
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	})
+
+	got, err := c.ListRepoLabels("acme", "widgets")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	want := []data.Label{
+		{Name: "bug", Color: "repo00"},
+		{Name: "org-wide", Color: "8844ee"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+}
+
+func TestListRepoLabelsReturnsOrgEndpointErrors(t *testing.T) {
+	c := mutationClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/labels":
+			w.Header().Set("X-Total-Count", "0")
+			fmt.Fprint(w, `[]`)
+		case "/api/v1/orgs/acme/labels":
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"message":"org labels unavailable"}`)
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	})
+
+	_, err := c.ListRepoLabels("acme", "widgets")
+	if err == nil || !strings.Contains(err.Error(), "org labels unavailable") {
+		t.Fatalf("ListRepoLabels error = %v, want org endpoint error", err)
 	}
 }
 

--- a/internal/mockgitea/search_test.go
+++ b/internal/mockgitea/search_test.go
@@ -77,6 +77,45 @@ func TestFilterPullsStableTiesByID(t *testing.T) {
 	}
 }
 
+func TestSearchPullsLabelsMatchAny(t *testing.T) {
+	now := time.Now()
+	s := NewStore()
+	me := s.Me()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	bug := &Label{Name: "bug"}
+	urgent := &Label{Name: "urgent"}
+	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "only bug",
+		State: "open", Author: me, Labels: []*Label{bug}, Updated: now})
+	s.AddPull(&Pull{Number: 2, RepoFullName: "teahouse/kettle", Title: "only urgent",
+		State: "open", Author: me, Labels: []*Label{urgent}, Updated: now})
+	s.AddPull(&Pull{Number: 3, RepoFullName: "teahouse/kettle", Title: "both",
+		State: "open", Author: me, Labels: []*Label{bug, urgent}, Updated: now})
+	s.AddPull(&Pull{Number: 4, RepoFullName: "teahouse/kettle", Title: "none",
+		State: "open", Author: me, Updated: now})
+
+	c := newTestClient(t, s)
+	rows, total, err := c.SearchPullsPage(context.Background(),
+		config.PrIssueFilter{State: "open", Labels: []string{"bug", "urgent"}}, 30, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(rows) != 3 {
+		t.Fatalf("want any-of match for bug|urgent (3 rows), got total=%d rows=%+v", total, rows)
+	}
+	got := map[int64]bool{}
+	for _, r := range rows {
+		got[r.Number] = true
+	}
+	for _, n := range []int64{1, 2, 3} {
+		if !got[n] {
+			t.Fatalf("missing PR #%d in any-of label match: %+v", n, rows)
+		}
+	}
+	if got[4] {
+		t.Fatalf("unlabeled PR #4 should not match: %+v", rows)
+	}
+}
+
 func TestRepoScopedPullsPagination(t *testing.T) {
 	c := newTestClient(t, searchStore(time.Now()))
 	rows, total, err := c.ListRepoPullsPage(context.Background(), "teahouse/kettle",

--- a/internal/mockgitea/search_test.go
+++ b/internal/mockgitea/search_test.go
@@ -71,7 +71,7 @@ func TestFilterPullsStableTiesByID(t *testing.T) {
 		{ID: 101, Number: 1, Title: "a", State: "open", Author: me, Updated: now},
 		{ID: 102, Number: 2, Title: "b", State: "open", Author: me, Updated: now},
 	}
-	got := filterPulls(pulls, url.Values{"state": {"open"}}, "gabor")
+	got := filterPulls(pulls, url.Values{"state": {"open"}}, "gabor", labelMatchAny)
 	if len(got) != 2 || got[0].ID != 101 || got[1].ID != 102 {
 		t.Fatalf("want stable ID-ascending order for equal Updated, got %+v", got)
 	}
@@ -113,6 +113,31 @@ func TestSearchPullsLabelsMatchAny(t *testing.T) {
 	}
 	if got[4] {
 		t.Fatalf("unlabeled PR #4 should not match: %+v", rows)
+	}
+}
+
+func TestRepoScopedPullsLabelsMatchAll(t *testing.T) {
+	now := time.Now()
+	s := NewStore()
+	me := s.Me()
+	s.AddRepo(&Repo{FullName: "teahouse/kettle", Name: "kettle", Owner: &User{Login: "teahouse"}})
+	bug := &Label{Name: "bug"}
+	urgent := &Label{Name: "urgent"}
+	s.AddPull(&Pull{Number: 1, RepoFullName: "teahouse/kettle", Title: "only bug",
+		State: "open", Author: me, Labels: []*Label{bug}, Updated: now})
+	s.AddPull(&Pull{Number: 2, RepoFullName: "teahouse/kettle", Title: "only urgent",
+		State: "open", Author: me, Labels: []*Label{urgent}, Updated: now})
+	s.AddPull(&Pull{Number: 3, RepoFullName: "teahouse/kettle", Title: "both",
+		State: "open", Author: me, Labels: []*Label{bug, urgent}, Updated: now})
+
+	c := newTestClient(t, s)
+	rows, total, err := c.ListRepoPullsPage(context.Background(), "teahouse/kettle",
+		config.PrIssueFilter{State: "open", Labels: []string{"bug", "urgent"}}, 30, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(rows) != 1 || rows[0].Number != 3 {
+		t.Fatalf("want only PR #3 with both labels, got total=%d rows=%+v", total, rows)
 	}
 }
 

--- a/internal/mockgitea/server_search.go
+++ b/internal/mockgitea/server_search.go
@@ -164,8 +164,8 @@ func matchQuery(title, q string) bool {
 	return strings.Contains(strings.ToLower(title), strings.ToLower(q))
 }
 
-// matchLabels reports whether labels contains every name in the comma-joined
-// csv list (an AND match, matching the real search endpoint's labels param).
+// matchLabels reports whether labels contains any name in the comma-joined
+// csv list (an OR match, matching Gitea/Forgejo's labels search param).
 // An empty csv matches everything.
 func matchLabels(labels []*Label, csv string) bool {
 	if csv == "" {
@@ -177,12 +177,18 @@ func matchLabels(labels []*Label, csv string) bool {
 			have[l.Name] = true
 		}
 	}
+	any := false
 	for _, name := range strings.Split(csv, ",") {
-		if !have[strings.TrimSpace(name)] {
-			return false
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		any = true
+		if have[name] {
+			return true
 		}
 	}
-	return true
+	return !any
 }
 
 // matchMilestone reports whether m's title matches the milestones filter. An

--- a/internal/mockgitea/server_search.go
+++ b/internal/mockgitea/server_search.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+type labelMatchMode uint8
+
+const (
+	labelMatchAny labelMatchMode = iota
+	labelMatchAll
+)
+
 // searchRoutes registers the cross-repo search and repo-scoped issue/pull
 // list endpoints that internal/gitea's Search*/ListRepo* client methods
 // consume (see internal/gitea/search.go's buildSearchParamsPage and
@@ -29,9 +36,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	respondList(s, w, func() (rows []map[string]any, total int) {
 		me := s.store.meLocked().Login
 		if q.Get("type") == "issues" {
-			return pageRows(filterIssues(s.store.allIssuesLocked(), q, me), limit, page, issueSearchRow)
+			return pageRows(filterIssues(s.store.allIssuesLocked(), q, me, labelMatchAny), limit, page, issueSearchRow)
 		}
-		return pageRows(filterPulls(s.store.allPullsLocked(), q, me), limit, page, pullSearchRow)
+		return pageRows(filterPulls(s.store.allPullsLocked(), q, me, labelMatchAny), limit, page, pullSearchRow)
 	})
 }
 
@@ -49,9 +56,9 @@ func (s *Server) handleRepoIssues(w http.ResponseWriter, r *http.Request) {
 		}
 		me := s.store.meLocked().Login
 		if q.Get("type") == "pulls" {
-			rows, total = pageRows(filterPulls(s.store.pullsLocked(full), q, me), limit, page, pullSearchRow)
+			rows, total = pageRows(filterPulls(s.store.pullsLocked(full), q, me, labelMatchAll), limit, page, pullSearchRow)
 		} else {
-			rows, total = pageRows(filterIssues(s.store.issuesLocked(full), q, me), limit, page, issueSearchRow)
+			rows, total = pageRows(filterIssues(s.store.issuesLocked(full), q, me, labelMatchAll), limit, page, issueSearchRow)
 		}
 		return rows, total, true
 	})
@@ -59,10 +66,10 @@ func (s *Server) handleRepoIssues(w http.ResponseWriter, r *http.Request) {
 
 // filterPulls returns the pulls matching q, sorted by Updated descending
 // (tea-dash merges multi-repo pages by updated time, newest first).
-func filterPulls(pulls []*Pull, q url.Values, me string) []*Pull {
+func filterPulls(pulls []*Pull, q url.Values, me string, labelMode labelMatchMode) []*Pull {
 	var out []*Pull
 	for _, p := range pulls {
-		if matchPull(p, q, me) {
+		if matchPull(p, q, me, labelMode) {
 			out = append(out, p)
 		}
 	}
@@ -71,10 +78,10 @@ func filterPulls(pulls []*Pull, q url.Values, me string) []*Pull {
 }
 
 // filterIssues is filterPulls for issues.
-func filterIssues(issues []*Issue, q url.Values, me string) []*Issue {
+func filterIssues(issues []*Issue, q url.Values, me string, labelMode labelMatchMode) []*Issue {
 	var out []*Issue
 	for _, i := range issues {
-		if matchIssue(i, q, me) {
+		if matchIssue(i, q, me, labelMode) {
 			out = append(out, i)
 		}
 	}
@@ -87,7 +94,7 @@ func filterIssues(issues []*Issue, q url.Values, me string) []*Issue {
 // assigned=true, review_requested=true) and the repo-scoped endpoint's
 // per-login created_by/assigned_by — a given request only ever sends one set,
 // so checking both here lets one matcher serve both handlers.
-func matchPull(p *Pull, q url.Values, me string) bool {
+func matchPull(p *Pull, q url.Values, me string, labelMode labelMatchMode) bool {
 	if !matchState(p.State, q.Get("state")) {
 		return false
 	}
@@ -109,7 +116,7 @@ func matchPull(p *Pull, q url.Values, me string) bool {
 	if !matchQuery(p.Title, q.Get("q")) {
 		return false
 	}
-	if !matchLabels(p.Labels, q.Get("labels")) {
+	if !matchLabels(p.Labels, q.Get("labels"), labelMode) {
 		return false
 	}
 	if !matchMilestone(p.Milestone, q.Get("milestones")) {
@@ -120,7 +127,7 @@ func matchPull(p *Pull, q url.Values, me string) bool {
 
 // matchIssue is matchPull for issues. Issues have no requested-reviewers
 // concept, so there is no review_requested check.
-func matchIssue(i *Issue, q url.Values, me string) bool {
+func matchIssue(i *Issue, q url.Values, me string, labelMode labelMatchMode) bool {
 	if !matchState(i.State, q.Get("state")) {
 		return false
 	}
@@ -139,7 +146,7 @@ func matchIssue(i *Issue, q url.Values, me string) bool {
 	if !matchQuery(i.Title, q.Get("q")) {
 		return false
 	}
-	if !matchLabels(i.Labels, q.Get("labels")) {
+	if !matchLabels(i.Labels, q.Get("labels"), labelMode) {
 		return false
 	}
 	if !matchMilestone(i.Milestone, q.Get("milestones")) {
@@ -164,10 +171,10 @@ func matchQuery(title, q string) bool {
 	return strings.Contains(strings.ToLower(title), strings.ToLower(q))
 }
 
-// matchLabels reports whether labels contains any name in the comma-joined
-// csv list (an OR match, matching Gitea/Forgejo's labels search param).
-// An empty csv matches everything.
-func matchLabels(labels []*Label, csv string) bool {
+// matchLabels applies the endpoint's label semantics: cross-repository search
+// matches any requested label, while repository-scoped lists require all of
+// them. An empty csv matches everything.
+func matchLabels(labels []*Label, csv string, mode labelMatchMode) bool {
 	if csv == "" {
 		return true
 	}
@@ -177,18 +184,25 @@ func matchLabels(labels []*Label, csv string) bool {
 			have[l.Name] = true
 		}
 	}
-	any := false
+	requested := 0
+	matched := 0
 	for _, name := range strings.Split(csv, ",") {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
-		any = true
+		requested++
 		if have[name] {
-			return true
+			matched++
 		}
 	}
-	return !any
+	if requested == 0 {
+		return true
+	}
+	if mode == labelMatchAll {
+		return matched == requested
+	}
+	return matched > 0
 }
 
 // matchMilestone reports whether m's title matches the milestones filter. An

--- a/internal/ui/actions/actions.go
+++ b/internal/ui/actions/actions.go
@@ -11,6 +11,7 @@ const (
 	KindUnassign          Kind = "unassign"
 	KindAddLabel          Kind = "add_label"
 	KindRemoveLabel       Kind = "remove_label"
+	KindFilterLabels      Kind = "filter_labels"
 	KindSetMilestone      Kind = "set_milestone"
 	KindSubscribe         Kind = "subscribe"
 	KindUnsubscribe       Kind = "unsubscribe"

--- a/internal/ui/actions/actions_test.go
+++ b/internal/ui/actions/actions_test.go
@@ -7,6 +7,7 @@ func TestKindConstants(t *testing.T) {
 		KindComment:           "comment",
 		KindAddLabel:          "add_label",
 		KindRemoveLabel:       "remove_label",
+		KindFilterLabels:      "filter_labels",
 		KindSetMilestone:      "set_milestone",
 		KindSubscribe:         "subscribe",
 		KindUnsubscribe:       "unsubscribe",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2427,7 +2427,7 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 	}
 	m.pendingAction = actions.Intent{}
 	if intent.Kind == actions.KindFilterLabels {
-		return tea.Batch(cmd, m.applyLabelFilter(intent.Prompt.Value))
+		return tea.Batch(cmd, m.applyLabelFilter(intent.Target, intent.Prompt.Value))
 	}
 	if m.actionDispatcher == nil {
 		return tea.Batch(cmd, m.setError("Action not wired yet."))
@@ -2590,7 +2590,7 @@ func (m *Model) handleLabelsLoaded(msg labelsLoadedMsg) (Model, tea.Cmd) {
 	if msg.intent.Kind != actions.KindFilterLabels {
 		return *m, nil
 	}
-	if m.pendingAction.Kind != actions.KindFilterLabels {
+	if m.pendingAction.Kind != msg.intent.Kind || m.pendingAction.Target != msg.intent.Target {
 		return *m, nil
 	}
 	m.pendingAction = msg.intent
@@ -2601,7 +2601,7 @@ func (m *Model) handleLabelsLoaded(msg labelsLoadedMsg) (Model, tea.Cmd) {
 	}
 	m.clearFeedback()
 	selected := []string(nil)
-	if sec := m.getCurrSection(); sec != nil {
+	if sec := m.sectionByTarget(msg.intent.Target); sec != nil {
 		if lf, ok := sec.(labelFilterSection); ok {
 			selected = lf.FilterLabels()
 		}
@@ -2620,8 +2620,8 @@ func (m *Model) handleLabelsLoaded(msg labelsLoadedMsg) (Model, tea.Cmd) {
 	return *m, nil
 }
 
-func (m *Model) applyLabelFilter(value string) tea.Cmd {
-	sec := m.getCurrSection()
+func (m *Model) applyLabelFilter(target actions.Target, value string) tea.Cmd {
+	sec := m.sectionByTarget(target)
 	if sec == nil {
 		return nil
 	}
@@ -2638,6 +2638,26 @@ func (m *Model) applyLabelFilter(value string) tea.Cmd {
 		toast = m.setSuccess("Filtering by labels: " + strings.Join(names, ", ") + ".")
 	}
 	return tea.Batch(toast, sec.FetchRows())
+}
+
+func (m *Model) sectionByTarget(target actions.Target) section.Section {
+	var sections []section.Section
+	switch target.SectionType {
+	case pullsection.SectionType:
+		sections = m.prs
+	case issuesection.SectionType:
+		sections = m.issues
+	case notificationsection.SectionType:
+		sections = m.notifications
+	case actionsection.SectionType:
+		sections = m.actions
+	case branchsection.SectionType:
+		sections = m.branches
+	}
+	if target.SectionID < 0 || target.SectionID >= len(sections) {
+		return nil
+	}
+	return sections[target.SectionID]
 }
 
 func parseFilterLabelNames(value string) []string {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2579,7 +2579,7 @@ func collectRepoLabels(client *gitea.Client, repos []string) ([]data.Label, erro
 			out = append(out, label)
 		}
 	}
-	if len(out) == 0 && firstErr != nil {
+	if firstErr != nil {
 		return nil, firstErr
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4,6 +4,7 @@ package ui
 import (
 	stdctx "context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -173,6 +174,19 @@ type mergeCapabilitiesLoadedMsg struct {
 	intent       actions.Intent
 	capabilities data.MergeCapabilities
 	err          error
+}
+
+type labelsLoadedMsg struct {
+	intent actions.Intent
+	labels []data.Label
+	err    error
+}
+
+type labelFilterSection interface {
+	FilterLabels() []string
+	SetFilterLabels([]string)
+	ResetFilterLabels()
+	SectionRepo() string
 }
 
 // autoRefreshMsg is emitted by the optional background refetch timer.
@@ -489,6 +503,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case mergeCapabilitiesLoadedMsg:
 		return m.handleMergeCapabilitiesLoaded(msg)
 
+	case labelsLoadedMsg:
+		return m.handleLabelsLoaded(msg)
+
 	case actions.ResultMsg:
 		var feedbackCmd tea.Cmd
 		m.actionFeedback, feedbackCmd = m.actionFeedback.Set(feedbackFromActionResult(msg))
@@ -652,6 +669,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.startAction(actions.KindAddLabel)
 		case !m.scopedBuiltinOverridden("removelabel") && key.Matches(msg, m.keys.RemoveLabel):
 			return m, m.startAction(actions.KindRemoveLabel)
+		case !m.scopedBuiltinOverridden("filterLabels") && !m.scopedBuiltinOverridden("filterLabel") &&
+			(m.ctx.View == context.PullsView || m.ctx.View == context.IssuesView) && key.Matches(msg, m.keys.FilterLabels):
+			return m, m.startLabelFilter()
 		case !m.scopedBuiltinOverridden("setMilestone") && m.ctx.View == context.IssuesView && key.Matches(msg, m.keys.Milestone):
 			return m, m.startAction(actions.KindSetMilestone)
 		// Merge/UpdateBranch/MarkReady/WatchChecks/Review/RequestReviewers/
@@ -1258,6 +1278,7 @@ func availableActions(view context.ViewType, row data.RowData) []actionButton {
 	case context.IssuesView:
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Filter labels", Builtin: "filterLabels"},
 			actionButton{Label: "Checkout", Builtin: "checkout"},
 			actionButton{Label: "Subscribe", Builtin: "subscribe"},
 			actionButton{Label: "Unsubscribe", Builtin: "unsubscribe"},
@@ -1275,6 +1296,7 @@ func availableActions(view context.ViewType, row data.RowData) []actionButton {
 		}
 		buttons = append(buttons,
 			actionButton{Label: "Comment", Builtin: "comment"},
+			actionButton{Label: "Filter labels", Builtin: "filterLabels"},
 			actionButton{Label: "Request review", Builtin: "requestReviewers"},
 			actionButton{Label: "Remove reviewers", Builtin: "removeReviewers"},
 			actionButton{Label: "Checks", Builtin: "watchChecks"},
@@ -2298,6 +2320,8 @@ func (m Model) handleBuiltinKeybinding(binding config.Keybinding) (Model, tea.Cm
 		return m, m.startAction(actions.KindAddLabel), true
 	case "removelabel":
 		return m, m.startAction(actions.KindRemoveLabel), true
+	case "filterlabels", "filterlabel":
+		return m, m.startLabelFilter(), true
 	case "milestone", "setmilestone":
 		return m, m.startAction(actions.KindSetMilestone), true
 	case "merge":
@@ -2402,6 +2426,9 @@ func (m *Model) updateActionPrompt(msg tea.Msg) tea.Cmd {
 		intent.Prompt.Label = result.Label
 	}
 	m.pendingAction = actions.Intent{}
+	if intent.Kind == actions.KindFilterLabels {
+		return tea.Batch(cmd, m.applyLabelFilter(intent.Prompt.Value))
+	}
 	if m.actionDispatcher == nil {
 		return tea.Batch(cmd, m.setError("Action not wired yet."))
 	}
@@ -2467,6 +2494,165 @@ func (m *Model) handleMergeCapabilitiesLoaded(msg mergeCapabilitiesLoadedMsg) (M
 	}
 	m.actionPrompt = m.actionPrompt.Focus(promptConfigForActionWithMergeCapabilities(msg.intent.Kind, msg.intent.Target, caps))
 	return *m, cmd
+}
+
+func (m *Model) startLabelFilter() tea.Cmd {
+	if m.ctx.View != context.PullsView && m.ctx.View != context.IssuesView {
+		return m.setInfo("Label filter is only available on pull and issue lists.")
+	}
+	sec := m.getCurrSection()
+	if sec == nil {
+		return m.setInfo("No section selected.")
+	}
+	lf, ok := sec.(labelFilterSection)
+	if !ok {
+		return m.setInfo("This section does not support label filters.")
+	}
+	var configured []string
+	if m.ctx.Config != nil {
+		configured = m.ctx.Config.Repos
+	}
+	repos := labelFilterRepos(lf.SectionRepo(), m.ctx.CurrentRepo, m.ctx.SmartFiltering, configured)
+	if len(repos) == 0 {
+		return m.setInfo("Label filter needs a repo. Set section.repo, repos:, or enable smart-filter in a matching checkout.")
+	}
+	if m.ctx.Client == nil {
+		return m.setError("No Gitea client.")
+	}
+	m.pendingAction = actions.Intent{
+		Kind:   actions.KindFilterLabels,
+		Target: actions.Target{SectionID: sec.GetId(), SectionType: sec.GetType()},
+	}
+	return tea.Batch(m.setStart("Loading labels..."), loadRepoLabelsCmd(m.ctx.Client, repos, m.pendingAction))
+}
+
+func labelFilterRepos(sectionRepo, currentRepo string, smart bool, configuredRepos []string) []string {
+	if repo := strings.TrimSpace(sectionRepo); repo != "" {
+		return []string{repo}
+	}
+	if smart {
+		if repo := strings.TrimSpace(currentRepo); repo != "" {
+			return []string{repo}
+		}
+	}
+	out := make([]string, 0, len(configuredRepos))
+	for _, repo := range configuredRepos {
+		if repo = strings.TrimSpace(repo); repo != "" {
+			out = append(out, repo)
+		}
+	}
+	return out
+}
+
+func loadRepoLabelsCmd(client *gitea.Client, repos []string, intent actions.Intent) tea.Cmd {
+	return func() tea.Msg {
+		labels, err := collectRepoLabels(client, repos)
+		return labelsLoadedMsg{intent: intent, labels: labels, err: err}
+	}
+}
+
+func collectRepoLabels(client *gitea.Client, repos []string) ([]data.Label, error) {
+	seen := map[string]bool{}
+	var out []data.Label
+	var firstErr error
+	for _, full := range repos {
+		owner, repo, ok := data.SplitOwnerRepo(full)
+		if !ok {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("invalid repository %q", full)
+			}
+			continue
+		}
+		labels, err := client.ListRepoLabels(owner, repo)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		for _, label := range labels {
+			name := strings.TrimSpace(label.Name)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, label)
+		}
+	}
+	if len(out) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (m *Model) handleLabelsLoaded(msg labelsLoadedMsg) (Model, tea.Cmd) {
+	if msg.intent.Kind != actions.KindFilterLabels {
+		return *m, nil
+	}
+	if m.pendingAction.Kind != actions.KindFilterLabels {
+		return *m, nil
+	}
+	m.pendingAction = msg.intent
+	if msg.err != nil {
+		cmd := m.setError(fmt.Sprintf("Couldn't load labels: %v. Enter names manually.", msg.err))
+		m.actionPrompt = m.actionPrompt.Focus(promptConfigForAction(msg.intent.Kind, msg.intent.Target))
+		return *m, cmd
+	}
+	m.clearFeedback()
+	selected := []string(nil)
+	if sec := m.getCurrSection(); sec != nil {
+		if lf, ok := sec.(labelFilterSection); ok {
+			selected = lf.FilterLabels()
+		}
+	}
+	cfg := actionprompt.Config{
+		Mode:     actionprompt.ModeMultiPicker,
+		Title:    "Filter labels",
+		Message:  "Space toggles. Enter applies. Empty selection clears the label filter.",
+		Options:  make([]actionprompt.Option, 0, len(msg.labels)),
+		Selected: selected,
+	}
+	for _, label := range msg.labels {
+		cfg.Options = append(cfg.Options, actionprompt.Option{Label: label.Name, Value: label.Name})
+	}
+	m.actionPrompt = m.actionPrompt.Focus(cfg)
+	return *m, nil
+}
+
+func (m *Model) applyLabelFilter(value string) tea.Cmd {
+	sec := m.getCurrSection()
+	if sec == nil {
+		return nil
+	}
+	lf, ok := sec.(labelFilterSection)
+	if !ok {
+		return m.setError("This section does not support label filters.")
+	}
+	names := parseFilterLabelNames(value)
+	lf.SetFilterLabels(names)
+	var toast tea.Cmd
+	if len(names) == 0 {
+		toast = m.setSuccess("Label filter cleared.")
+	} else {
+		toast = m.setSuccess("Filtering by labels: " + strings.Join(names, ", ") + ".")
+	}
+	return tea.Batch(toast, sec.FetchRows())
+}
+
+func parseFilterLabelNames(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func reviewerPickerAction(kind actions.Kind) bool {
@@ -2968,6 +3154,13 @@ func promptConfigForActionWithMergeCapabilities(kind actions.Kind, target action
 			Message:     message,
 			Placeholder: "Label names to remove, comma-separated",
 		}
+	case actions.KindFilterLabels:
+		return actionprompt.Config{
+			Mode:        actionprompt.ModeText,
+			Title:       "Filter labels",
+			Message:     "Comma-separated label names. Empty clears the label filter.",
+			Placeholder: "bug, urgent",
+		}
 	case actions.KindSetMilestone:
 		return actionprompt.Config{
 			Mode:        actionprompt.ModeText,
@@ -3100,6 +3293,8 @@ func actionLabel(kind actions.Kind) string {
 		return "Add label"
 	case actions.KindRemoveLabel:
 		return "Remove label"
+	case actions.KindFilterLabels:
+		return "Filter labels"
 	case actions.KindSetMilestone:
 		return "Set milestone"
 	case actions.KindMerge:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -758,6 +758,46 @@ func TestLabelFilterReposPrefersSectionThenSmartThenConfigured(t *testing.T) {
 	}
 }
 
+func TestCollectRepoLabelsReturnsErrorWhenAnyRepoIsIncomplete(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/good/repo/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Total-Count", "1")
+		fmt.Fprint(w, `[{"id":1,"name":"bug","color":"ee0000"}]`)
+	})
+	mux.HandleFunc("/api/v1/orgs/good/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // good is a user owner
+		fmt.Fprint(w, `{"message":"organization not found"}`)
+	})
+	mux.HandleFunc("/api/v1/repos/broken/repo/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Total-Count", "0")
+		fmt.Fprint(w, `[]`)
+	})
+	mux.HandleFunc("/api/v1/orgs/broken/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message":"organization labels forbidden"}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	labels, err := collectRepoLabels(client, []string{"good/repo", "broken/repo"})
+	if err == nil || !strings.Contains(err.Error(), "organization labels forbidden") {
+		t.Fatalf("collectRepoLabels error = %v, want partial discovery failure", err)
+	}
+	if labels != nil {
+		t.Fatalf("collectRepoLabels labels = %#v, want nil when choices are incomplete", labels)
+	}
+}
+
 func TestFilterLabelsOpensPickerAndAppliesSelection(t *testing.T) {
 	client := labelsClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -709,7 +709,7 @@ func TestMouseClickInPreviewDoesNotChangeSelection(t *testing.T) {
 func TestAvailableActionsIncludeCommonPullRequestButtons(t *testing.T) {
 	row := data.PullRequest{Number: 1, Title: "First", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open"}
 	buttons := availableActions(context.PullsView, row)
-	for _, want := range []string{"Open", "Refresh", "Comment", "Request review", "Remove reviewers", "Diff", "Checkout", "Merge", "Close"} {
+	for _, want := range []string{"Open", "Refresh", "Comment", "Filter labels", "Request review", "Remove reviewers", "Diff", "Checkout", "Merge", "Close"} {
 		if !hasActionLabel(buttons, want) {
 			t.Fatalf("available actions missing %q: %+v", want, buttons)
 		}
@@ -727,7 +727,7 @@ func TestAvailableActionsIncludeReadyButtonForDraftPullRequest(t *testing.T) {
 func TestAvailableActionsIncludeCommonIssueButtons(t *testing.T) {
 	row := data.Issue{Number: 7, Title: "Issue row", RepoNameWithOwner: "gitea/tea", Author: "me", State: "open"}
 	buttons := availableActions(context.IssuesView, row)
-	for _, want := range []string{"Open", "Refresh", "Comment", "Checkout", "Close"} {
+	for _, want := range []string{"Open", "Refresh", "Comment", "Filter labels", "Checkout", "Close"} {
 		if !hasActionLabel(buttons, want) {
 			t.Fatalf("issue available actions missing %q: %+v", want, buttons)
 		}
@@ -741,6 +741,122 @@ func hasActionLabel(buttons []actionButton, label string) bool {
 		}
 	}
 	return false
+}
+
+func TestLabelFilterReposPrefersSectionThenSmartThenConfigured(t *testing.T) {
+	if got := labelFilterRepos("acme/one", "acme/two", true, []string{"acme/three"}); len(got) != 1 || got[0] != "acme/one" {
+		t.Fatalf("section repo = %v, want [acme/one]", got)
+	}
+	if got := labelFilterRepos("", "acme/two", true, []string{"acme/three"}); len(got) != 1 || got[0] != "acme/two" {
+		t.Fatalf("smart current repo = %v, want [acme/two]", got)
+	}
+	if got := labelFilterRepos("", "acme/two", false, []string{"acme/three", "acme/four"}); len(got) != 2 {
+		t.Fatalf("configured repos = %v, want two entries", got)
+	}
+	if got := labelFilterRepos("", "", false, nil); len(got) != 0 {
+		t.Fatalf("no repos = %v, want empty", got)
+	}
+}
+
+func TestFilterLabelsOpensPickerAndAppliesSelection(t *testing.T) {
+	client := labelsClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/repos/gbarany/tea-dash/labels" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `[{"id":1,"name":"bug","color":"ee0000"},{"id":2,"name":"urgent","color":"ffaa00"}]`)
+	})
+	m := New(&config.Config{
+		Repos:      []string{"gbarany/tea-dash"},
+		PRSections: []config.SectionConfig{{Title: "Open PRs", Filter: config.PrIssueFilter{State: "open", Labels: []string{"bug"}}}},
+	}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = update(t, m, fetchedMsg([]data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}))
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("filter labels should fetch repo labels before opening the prompt")
+	}
+	msg := firstNonNilCmd(t, cmd)
+	loaded, ok := msg.(labelsLoadedMsg)
+	if !ok || loaded.err != nil || len(loaded.labels) != 2 {
+		t.Fatalf("label load msg = %#v, want two labels", msg)
+	}
+
+	m = update(t, m, loaded)
+	view := m.actionPrompt.View(120)
+	if !strings.Contains(view, "[x] bug") || !strings.Contains(view, "[ ] urgent") {
+		t.Fatalf("label picker should preselect configured bug:\n%s", view)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = update(t, m, tea.KeyPressMsg{Code: ' ', Text: " "})
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	sec, ok := m.getCurrSection().(labelFilterSection)
+	if !ok {
+		t.Fatal("current section should support label filters")
+	}
+	got := sec.FilterLabels()
+	if len(got) != 2 || got[0] != "bug" || got[1] != "urgent" {
+		t.Fatalf("live filter labels = %v, want [bug urgent]", got)
+	}
+}
+
+func firstNonNilCmd(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var fallback tea.Msg
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			inner := c()
+			if inner == nil {
+				continue
+			}
+			if _, ok := inner.(labelsLoadedMsg); ok {
+				return inner
+			}
+			if fallback == nil {
+				fallback = inner
+			}
+		}
+		if fallback != nil {
+			return fallback
+		}
+		t.Fatal("batch had no non-nil message")
+	}
+	return msg
+}
+
+func labelsClient(t *testing.T, labelsHandler http.HandlerFunc) *gitea.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"version":"1.22.0"}`)
+	})
+	mux.HandleFunc("/api/v1/user", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":1,"login":"me"}`)
+	})
+	if labelsHandler != nil {
+		mux.HandleFunc("/api/v1/repos/gbarany/tea-dash/labels", labelsHandler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := gitea.NewClient(stdctx.Background(), auth.Config{URL: srv.URL, Token: "t"})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
 }
 
 func TestRequestReviewersLoadsRepoReviewersIntoMultiPicker(t *testing.T) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -809,6 +809,127 @@ func TestFilterLabelsOpensPickerAndAppliesSelection(t *testing.T) {
 	}
 }
 
+func TestHandleLabelsLoadedRejectsDifferentSection(t *testing.T) {
+	m := twoSectionLabelFilterModel(t)
+	m, stale := startLabelLoad(t, m)
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'l', Text: "l"})
+	if m.currSectionId != 1 {
+		t.Fatalf("currSectionId = %d, want 1", m.currSectionId)
+	}
+	m, current := startLabelLoad(t, m)
+
+	m = update(t, m, stale)
+	if m.actionPrompt.Active() {
+		t.Fatal("stale labels for section 0 should not open the picker after section 1 started a new request")
+	}
+	if current.intent.Target.SectionID != 1 {
+		t.Fatalf("current load target = %+v, want section 1", current.intent.Target)
+	}
+
+	m = update(t, m, current)
+	if !m.actionPrompt.Active() {
+		t.Fatal("labels for the current section should open the picker")
+	}
+	view := m.actionPrompt.View(120)
+	if !strings.Contains(view, "[ ] bug") || !strings.Contains(view, "[ ] urgent") {
+		t.Fatalf("section 1 has no configured labels, picker should preselect none:\n%s", view)
+	}
+}
+
+func TestApplyLabelFilterUsesTargetSectionNotCurrent(t *testing.T) {
+	m := twoSectionLabelFilterModel(t)
+	m, loaded := startLabelLoad(t, m)
+	m = update(t, m, loaded)
+	if !m.actionPrompt.Active() {
+		t.Fatal("label picker should open for the section that requested it")
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	m = update(t, m, tea.KeyPressMsg{Code: ' ', Text: " "})
+	m.currSectionId = 1
+
+	m = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	sec0, ok := m.prs[0].(labelFilterSection)
+	if !ok {
+		t.Fatal("section 0 should support label filters")
+	}
+	got0 := sec0.FilterLabels()
+	if len(got0) != 2 || got0[0] != "bug" || got0[1] != "urgent" {
+		t.Fatalf("target section 0 labels = %v, want [bug urgent]", got0)
+	}
+	sec1, ok := m.prs[1].(labelFilterSection)
+	if !ok {
+		t.Fatal("section 1 should support label filters")
+	}
+	if got1 := sec1.FilterLabels(); len(got1) != 0 {
+		t.Fatalf("current section 1 labels = %v, want unchanged empty", got1)
+	}
+}
+
+func TestHandleLabelsLoadedPreselectsTargetSection(t *testing.T) {
+	m := twoSectionLabelFilterModel(t)
+	m, loaded := startLabelLoad(t, m)
+	m = update(t, m, tea.KeyPressMsg{Code: 'l', Text: "l"})
+	if m.currSectionId != 1 {
+		t.Fatalf("currSectionId = %d, want 1", m.currSectionId)
+	}
+
+	m = update(t, m, loaded)
+	if !m.actionPrompt.Active() {
+		t.Fatal("in-flight labels for section 0 should still open the picker after a tab change")
+	}
+	view := m.actionPrompt.View(120)
+	if !strings.Contains(view, "[x] bug") || !strings.Contains(view, "[ ] urgent") {
+		t.Fatalf("picker should preselect section 0's filter, not the current section:\n%s", view)
+	}
+}
+
+func twoSectionLabelFilterModel(t *testing.T) Model {
+	t.Helper()
+	client := labelsClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[{"id":1,"name":"bug","color":"ee0000"},{"id":2,"name":"urgent","color":"ffaa00"}]`)
+	})
+	m := New(&config.Config{
+		Repos: []string{"gbarany/tea-dash"},
+		PRSections: []config.SectionConfig{
+			{Title: "Bugs", Filter: config.PrIssueFilter{State: "open", Labels: []string{"bug"}}},
+			{Title: "All", Filter: config.PrIssueFilter{State: "open"}},
+		},
+	}, client)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	row := []data.PullRequest{{
+		Number: 1, Title: "First", RepoNameWithOwner: "gbarany/tea-dash",
+		Author: "me", State: "open",
+	}}
+	m = update(t, m, fetchedMsg(row))
+	m = update(t, m, context.TaskFinishedMsg{
+		SectionId:   1,
+		SectionType: pullsection.SectionType,
+		TaskId:      "t2",
+		Msg: pullsection.SectionPullRequestsFetchedMsg{
+			Rows: row, TotalCount: 1, TaskId: "t2",
+		},
+	})
+	return m
+}
+
+func startLabelLoad(t *testing.T, m Model) (Model, labelsLoadedMsg) {
+	t.Helper()
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("filter labels should fetch repo labels before opening the prompt")
+	}
+	msg := firstNonNilCmd(t, cmd)
+	loaded, ok := msg.(labelsLoadedMsg)
+	if !ok || loaded.err != nil {
+		t.Fatalf("label load msg = %#v", msg)
+	}
+	return m, loaded
+}
+
 func firstNonNilCmd(t *testing.T, cmd tea.Cmd) tea.Msg {
 	t.Helper()
 	msg := cmd()

--- a/internal/ui/components/actionprompt/actionprompt.go
+++ b/internal/ui/components/actionprompt/actionprompt.go
@@ -33,6 +33,7 @@ type Config struct {
 	Placeholder string
 	Options     []Option
 	Initial     string
+	Selected    []string
 }
 
 // Result reports whether a prompt completed and what it submitted.
@@ -66,6 +67,17 @@ func (m Model) Focus(cfg Config) Model {
 	m.input = newInput(cfg)
 	m.selected = 0
 	m.multiSelected = map[int]bool{}
+	if cfg.Mode == ModeMultiPicker && len(cfg.Selected) > 0 {
+		want := map[string]bool{}
+		for _, name := range cfg.Selected {
+			want[name] = true
+		}
+		for i, option := range cfg.Options {
+			if want[option.Value] {
+				m.multiSelected[i] = true
+			}
+		}
+	}
 	return m
 }
 

--- a/internal/ui/components/actionprompt/actionprompt_test.go
+++ b/internal/ui/components/actionprompt/actionprompt_test.go
@@ -130,6 +130,20 @@ func TestMultiPickerTogglesAndSubmitsCommaSeparatedValues(t *testing.T) {
 	}
 }
 
+func TestMultiPickerPreselectsSelectedValues(t *testing.T) {
+	cfg := Config{
+		Mode:     ModeMultiPicker,
+		Title:    "Filter labels",
+		Options:  []Option{{Label: "bug", Value: "bug"}, {Label: "urgent", Value: "urgent"}},
+		Selected: []string{"urgent"},
+	}
+	m := New().Focus(cfg)
+	view := m.View(120)
+	if !strings.Contains(view, "[ ] bug") || !strings.Contains(view, "[x] urgent") {
+		t.Fatalf("preselected picker:\n%s", view)
+	}
+}
+
 func TestSmallWidthRender(t *testing.T) {
 	m := New().Focus(Config{
 		Mode:        ModeText,

--- a/internal/ui/components/section/model.go
+++ b/internal/ui/components/section/model.go
@@ -3,6 +3,7 @@ package section
 import (
 	stdctx "context"
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
@@ -56,15 +57,16 @@ type Options[T data.RowData] struct {
 // views. It embeds BaseModel and holds the per-type seams.
 type Model[T data.RowData] struct {
 	BaseModel
-	rows        []T
-	fetch       func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
-	buildRow    func(T) table.Row
-	columns     func(int) []table.Column
-	limitFn     func(*config.Config) int
-	filterKind  string
-	page        int
-	loadingMore bool
-	pageable    bool
+	rows             []T
+	fetch            func(stdctx.Context, *gitea.Client, config.PrIssueFilter, int, int) ([]T, int, error)
+	buildRow         func(T) table.Row
+	columns          func(int) []table.Column
+	limitFn          func(*config.Config) int
+	filterKind       string
+	configuredLabels []string
+	page             int
+	loadingMore      bool
+	pageable         bool
 }
 
 // compile-time interface assertions
@@ -106,8 +108,31 @@ func New[T data.RowData](o Options[T]) *Model[T] {
 	m.columns = columns
 	m.limitFn = o.Limit
 	m.filterKind = o.FilterKind
+	m.configuredLabels = append([]string(nil), o.Config.Filter.Labels...)
 	m.pageable = o.Pageable
 	return m
+}
+
+// FilterLabels returns the live label filter used for the next fetch.
+func (m *Model[T]) FilterLabels() []string {
+	return append([]string(nil), m.Config.Filter.Labels...)
+}
+
+// SetFilterLabels replaces the live label filter. An empty list means no
+// label constraint.
+func (m *Model[T]) SetFilterLabels(names []string) {
+	m.Config.Filter.Labels = append([]string(nil), names...)
+}
+
+// ResetFilterLabels restores the section's configured YAML labels.
+func (m *Model[T]) ResetFilterLabels() {
+	m.Config.Filter.Labels = append([]string(nil), m.configuredLabels...)
+}
+
+// SectionRepo returns this section's pinned repo, or empty when it is not
+// repo-scoped.
+func (m *Model[T]) SectionRepo() string {
+	return strings.TrimSpace(m.Config.Repo)
 }
 
 // FetchRows fetches the current user's rows across all repos.

--- a/internal/ui/components/section/model_test.go
+++ b/internal/ui/components/section/model_test.go
@@ -111,3 +111,54 @@ func contextStyles(t *testing.T) appctx.Styles {
 	t.Helper()
 	return appctx.DefaultStyles()
 }
+
+func TestLabelFilterSnapshotAndReset(t *testing.T) {
+	ctx := &appctx.ProgramContext{
+		Styles:           contextStyles(t),
+		MainContentWidth: 80, MainContentHeight: 20,
+		Config: &config.Config{Defaults: config.Defaults{PRsLimit: 10}},
+	}
+	m := New(Options[data.PullRequest]{
+		Id:           0,
+		Type:         "pr",
+		FilterKind:   "pulls",
+		Ctx:          ctx,
+		Config:       config.SectionConfig{Title: "Bugs", Repo: "acme/widgets", Filter: config.PrIssueFilter{Labels: []string{"bug"}}},
+		LoadingText:  "Loading…",
+		EmptyText:    "none",
+		EmptyHint:    "",
+		SingularForm: "pr",
+		PluralForm:   "prs",
+		Limit:        func(c *config.Config) int { return c.Defaults.PRsLimit },
+		Fetch: func(_ stdctx.Context, _ *gitea.Client, f config.PrIssueFilter, _ int, _ int) ([]data.PullRequest, int, error) {
+			return nil, 0, nil
+		},
+		BuildRow: func(pr data.PullRequest) table.Row { return table.Row{pr.GetTitle()} },
+	})
+
+	if got := m.FilterLabels(); len(got) != 1 || got[0] != "bug" {
+		t.Fatalf("FilterLabels = %v, want [bug]", got)
+	}
+	if got := m.SectionRepo(); got != "acme/widgets" {
+		t.Fatalf("SectionRepo = %q, want acme/widgets", got)
+	}
+
+	m.SetFilterLabels([]string{"urgent"})
+	if got := m.FilterLabels(); len(got) != 1 || got[0] != "urgent" {
+		t.Fatalf("after SetFilterLabels = %v, want [urgent]", got)
+	}
+
+	m.ResetFilterLabels()
+	if got := m.FilterLabels(); len(got) != 1 || got[0] != "bug" {
+		t.Fatalf("after ResetFilterLabels = %v, want configured [bug]", got)
+	}
+
+	m.SetFilterLabels(nil)
+	if got := m.FilterLabels(); len(got) != 0 {
+		t.Fatalf("cleared FilterLabels = %v, want empty", got)
+	}
+	m.ResetFilterLabels()
+	if got := m.FilterLabels(); len(got) != 1 || got[0] != "bug" {
+		t.Fatalf("reset after clear = %v, want [bug]", got)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -82,6 +82,7 @@ type keyMap struct {
 	Unsubscribe      key.Binding
 	AddLabel         key.Binding
 	RemoveLabel      key.Binding
+	FilterLabels     key.Binding
 	Milestone        key.Binding
 	Merge            key.Binding
 	UpdateBranch     key.Binding
@@ -195,7 +196,7 @@ func (k keyMap) viewScopedGroup(view context.ViewType) BindingGroup {
 	switch view {
 	case context.IssuesView:
 		return BindingGroup{Title: "Issues", Bindings: []key.Binding{
-			k.Comment, k.Assign, k.Unassign, k.AddLabel, k.RemoveLabel, k.Milestone,
+			k.Comment, k.Assign, k.Unassign, k.AddLabel, k.RemoveLabel, k.FilterLabels, k.Milestone,
 			k.Subscribe, k.Unsubscribe, k.Close, k.Reopen, k.Checkout,
 		}}
 	case context.NotificationsView:
@@ -210,7 +211,7 @@ func (k keyMap) viewScopedGroup(view context.ViewType) BindingGroup {
 		}}
 	default:
 		return BindingGroup{Title: "PRs", Bindings: []key.Binding{
-			k.Comment, k.Assign, k.Unassign, k.AddLabel, k.RemoveLabel, k.Merge, k.UpdateBranch,
+			k.Comment, k.Assign, k.Unassign, k.AddLabel, k.RemoveLabel, k.FilterLabels, k.Merge, k.UpdateBranch,
 			k.MarkReady, k.WatchChecks, k.Close, k.Reopen, k.Review, k.RequestReviewers,
 			k.RemoveReviewers, k.ExternalDiff, k.Checkout,
 		}}
@@ -374,6 +375,10 @@ func defaultKeyMap() keyMap {
 		RemoveLabel: key.NewBinding(
 			key.WithKeys("U"),
 			key.WithHelp("U", "remove label"),
+		),
+		FilterLabels: key.NewBinding(
+			key.WithKeys("f"),
+			key.WithHelp("f", "filter labels"),
 		),
 		Milestone: key.NewBinding(
 			key.WithKeys("M"),
@@ -555,6 +560,8 @@ func (k *keyMap) rebindBuiltin(name, keyName string) {
 		k.AddLabel = binding(keyName, "add label")
 	case "removelabel":
 		k.RemoveLabel = binding(keyName, "remove label")
+	case "filterlabels", "filterlabel":
+		k.FilterLabels = binding(keyName, "filter labels")
 	case "milestone", "setmilestone":
 		k.Milestone = binding(keyName, "milestone")
 	case "merge":
@@ -684,6 +691,8 @@ func (k keyMap) bindingForBuiltin(name string) (key.Binding, bool) {
 		return k.ExternalDiff, true
 	case "merge":
 		return k.Merge, true
+	case "filterlabels", "filterlabel":
+		return k.FilterLabels, true
 	default:
 		return key.Binding{}, false
 	}

--- a/internal/ui/keys_test.go
+++ b/internal/ui/keys_test.go
@@ -160,6 +160,7 @@ func TestGroups_ViewScopedGroupChangesWithView(t *testing.T) {
 		title string
 		key   string
 	}{
+		{context.PullsView, "PRs", "f"},
 		{context.PullsView, "PRs", "m"},
 		{context.IssuesView, "Issues", "M"},
 		{context.NotificationsView, "Inbox", "m"},


### PR DESCRIPTION
## Summary

Implements [#102](https://github.com/gbarany/tea-dash/issues/102).

Label filtering was config-only. `/` is still a raw keyword (`q=`), not a GitHub DSL — this codebase already rejected that because Gitea has no issue-search qualifiers.

**What you get**

- `f` on Pulls and Issues (also **Filter labels** in the command palette)
- Multi-select of repo labels (space toggle, enter apply)
- Current live filter is pre-checked
- Empty selection clears the label constraint
- Toast: `Filtering by labels: bug, urgent.` or `Label filter cleared.`
- Repo source: `section.repo`, else smart-filter current repo, else `repos:`
- No `repos:` / no pinned repo → info toast, no picker
- `/` unchanged
- `L`/`U` still add/remove labels on the selected row

Docs now say Gitea `labels=a,b` is **OR**, matching the API (the old AND wording was wrong).

`f` stays **fast-forward** on the Branches view.

## Verification

- `ListRepoLabels` httptest
- Section snapshot / set / reset
- Multi-picker preselect
- App: `f` loads labels, pre-checks configured `bug`, applying `bug+urgent` updates the live filter
- `make check` green

Closes #102