### PR TITLE
docs: add contribution policy and community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something in tea-dash misbehaves
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this.
+
+        **Before you paste anything:** tea-dash talks to your own Gitea/Forgejo
+        instance, so terminal output can contain your instance hostname, private
+        repository names, and usernames. Redact those (and a token, in the
+        unlikely event one ever shows up) before submitting.
+
+        If you think you have found a *security* problem, do not open an issue —
+        use [private vulnerability reporting](https://github.com/gbarany/tea-dash/security/advisories/new)
+        instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what you expected instead
+      description: Both halves, please. "The Actions view showed no runs; I expected the three runs I can see in the web UI."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Start from launching tea-dash. Include the keys you pressed — this is a keyboard-driven TUI, so the exact key sequence is usually the reproduction.
+      value: |
+        1. Run `tea-dash`
+        2. Press
+        3.
+    validations:
+      required: true
+  - type: dropdown
+    id: reproduces-with-mock
+    attributes:
+      label: Does it reproduce with `tea-dash --mock`?
+      description: >-
+        The single most useful answer in this form. `--mock` runs the full
+        dashboard against an in-process fake Gitea with demo data — no network,
+        no login, no token. If the bug reproduces there it is a UI bug and can be
+        fixed without any access to your server; if it does not, it is about how
+        your instance answers the API, and the details below matter a lot more.
+      options:
+        - Yes, it reproduces with --mock
+        - No, only against my real instance
+        - Have not tried it yet
+    validations:
+      required: true
+  - type: input
+    id: tea-dash-version
+    attributes:
+      label: tea-dash version
+      description: The output of `tea-dash --version`.
+      placeholder: "e.g. 0.3.7 (commit abcdef0, built 2026-01-01T00:00:00Z)"
+    validations:
+      required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: Gitea or Forgejo server version
+      description: >-
+        Shown in your instance's page footer, or from its /api/v1/version
+        endpoint. Leave blank if you only reproduced this with --mock.
+      placeholder: "whatever your instance reports, e.g. Gitea 1.24.3"
+    validations:
+      required: false
+  - type: input
+    id: os-and-terminal
+    attributes:
+      label: OS and terminal emulator
+      description: Terminal emulator and multiplexer matter for rendering, mouse, and key-decoding bugs.
+      placeholder: "macOS 15.5, Ghostty 1.1 (inside tmux 3.5)"
+    validations:
+      required: false
+  - type: textarea
+    id: output
+    attributes:
+      label: Error or terminal output
+      description: >-
+        Whatever tea-dash printed to the terminal, plus any error text shown
+        inside the dashboard. If you ran `tea-dash --debug`, include ./debug.log
+        as well (that flag appends to ./debug.log in the current directory).
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: >-
+        The section, filter, keybinding, or theme entry involved, if any. Trim it
+        to the part that matters and replace real repo names with placeholders.
+      render: yaml
+    validations:
+      required: false
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Before you submit
+      options:
+        - label: I have removed anything private from what I pasted above — tokens, my instance hostname, and private repository or user names.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# Discussions are not enabled on this repository, so issues are the only
+# channel — blank issues stay available for questions and for anything that
+# fits neither form.
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/gbarany/tea-dash/security/advisories/new
+    about: "Please report privately through GitHub Private Vulnerability Reporting rather than opening a public issue. SECURITY.md has the policy and the expected response time."
+  - name: Usage and configuration questions
+    url: https://github.com/gbarany/tea-dash#configuration
+    about: "The README documents every flag, keybinding, and config field. Running tea-dash --mock gives you the whole dashboard on demo data with no Gitea server, token, or login."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,85 @@
+name: Feature request
+description: Suggest a new capability, or a change to an existing one
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        tea-dash is a spare-time project with one maintainer, so the most useful
+        thing you can do here is describe the *problem* precisely. A well-argued
+        problem often gets solved differently — and better — than the fix that
+        first came to mind.
+
+        Worth knowing: a good idea can still be declined simply because it is not
+        something the maintainer wants to support forever.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem you are trying to solve
+      description: >-
+        What are you doing today, and where does tea-dash get in the way?
+        Describe the workflow rather than the fix — how often it happens, and
+        what you do instead right now.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: >-
+        What should tea-dash do instead? If it involves a keybinding, name the
+        key. If it involves configuration, sketch the YAML. If it changes a view,
+        say which one (pull requests, issues, notifications, Actions, branches)
+        and what a row or the preview pane would show.
+    validations:
+      required: true
+  - type: dropdown
+    id: gh-dash-equivalent
+    attributes:
+      label: Does gh-dash have an equivalent?
+      description: >-
+        tea-dash is modelled on gh-dash (https://github.com/dlvhdr/gh-dash), so
+        an existing gh-dash behaviour is strong precedent — the design question
+        is largely settled and only the mapping onto Gitea's API is open. Say so
+        below either way; "Gitea has this concept and GitHub does not" is just as
+        useful an answer.
+      options:
+        - Yes, gh-dash does something like this
+        - No, this is specific to Gitea/Forgejo
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: gh-dash-details
+    attributes:
+      label: gh-dash details
+      description: If gh-dash has an equivalent, name the keybinding, config key, or view — and say where it should differ for Gitea/Forgejo.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >-
+        Existing configuration, a different keybinding, a custom command, a shell
+        alias, or just doing it in the Gitea web UI — what did you try, and why
+        was it not enough?
+    validations:
+      required: false
+  - type: input
+    id: tea-dash-version
+    attributes:
+      label: tea-dash version
+      description: The output of `tea-dash --version` — useful so nobody proposes something that already shipped.
+      placeholder: "e.g. 0.3.7 (commit abcdef0, built 2026-01-01T00:00:00Z)"
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Would you like to work on this?
+      description: Entirely optional, and not a condition for the request being considered.
+      options:
+        - label: I would be willing to open a pull request for this
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- Thanks for sending this. The full guide is in CONTRIBUTING.md.
+     Typos, docs and an obvious bug fix: just open the PR. A new key binding, a new
+     config field, or a change to what a view shows: please open an issue first.
+     Title it like a commit subject, e.g. `fix(ui): keep column widths after a resize`. -->
+
+## What and why
+
+<!-- One or two sentences: what this changes, and the problem it solves. -->
+
+Fixes #
+
+<!-- Fixes / Closes / Resolves #123 closes the issue on merge. Delete the line if there is no issue. -->
+
+## How I tested it
+
+<!-- `make check` is the baseline. Say what you exercised by hand too:
+     `go run . --mock` boots the dashboard on built-in demo data, with no Gitea
+     server, token or `tea` login needed. -->
+
+## Checklist
+
+- [ ] `make check` passes (gofmt, `go vet`, `go test -race ./...`, public-hygiene)
+- [ ] Added a test, or explained above why one does not fit
+- [ ] Updated the docs if behaviour changed (README, plus `schema.json` and `examples/tea-dash.yml` for a new config field)
+
+<!-- Optional but appreciated: leave "Allow edits by maintainers" ticked, so small
+     fixups do not need a round trip. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,8 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+      # Same gate as `make check`: fails on committed home-directory paths,
+      # macOS per-user temp paths, and secret-manager item routes.
+      - name: Public hygiene
+        run: make public-hygiene

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ docs/demo.mp4
 config.yml
 *.local.yml
 .env
+# ...but the GitHub issue-template chooser config is not one of those: the bare
+# `config.yml` rule above matches at any depth, which would silently drop it.
+!.github/ISSUE_TEMPLATE/config.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ HTTP escape hatch. Reuses your `tea` CLI login for auth.
 ## Build / test / run
 
 ```bash
-make check      # gofmt-check + go vet + go test -race ./...   (run before every commit)
+make check      # gofmt-check + go vet + go test -race + public-hygiene  (run before every commit)
 make build      # -> ./bin/tea-dash (ldflags stamp version/commit/date)
 make run        # go run .
 ```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the maintainer, [@gbarany](https://github.com/gbarany), through this repository's [private report form][private-report]. Reports sent there are visible only to the repository maintainer. That form is GitHub's private vulnerability reporting channel, which this project also uses for security issues, so please say in the title that your report is a conduct report rather than a vulnerability.
+
+If your concern involves the maintainer, or you would rather not use that form, report it to GitHub instead using their [report abuse form][report-abuse]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[private-report]: https://github.com/gbarany/tea-dash/security/advisories/new
+[report-abuse]: https://github.com/contact/report-abuse
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,274 @@
+# Contributing to tea-dash
+
+**Contributions are welcome — pull requests included.** If you use tea-dash and
+something is broken, missing, or awkward, I'd rather hear about it than not.
+
+tea-dash is maintained by one person in their spare time, so this guide exists
+to make your contribution land smoothly: what to send, how to run the thing
+locally, and the handful of invariants that will bite you if nobody mentions
+them.
+
+## Ways to contribute
+
+- **Bug reports.** The most valuable thing you can send. Include your OS,
+  terminal, and Gitea/Forgejo version — and, this one really helps, whether the
+  bug also reproduces under `tea-dash --mock`. If it does, I can fix it without
+  access to your server.
+- **Feature ideas.** Describe the workflow you're trying to get through, not
+  just the feature. tea-dash is opinionated, and the "why" is what decides
+  whether something fits.
+- **Documentation.** README wording, config examples, the architecture doc.
+  Doc-only PRs need no issue and no ceremony.
+- **Code.** See below.
+
+Everything goes through [GitHub issues](https://github.com/gbarany/tea-dash/issues).
+
+### Where to start
+
+- [`good first issue`](https://github.com/gbarany/tea-dash/labels/good%20first%20issue)
+  — small, self-contained, and described well enough to pick up cold.
+- [`help wanted`](https://github.com/gbarany/tea-dash/labels/help%20wanted)
+  — things I'd genuinely like a hand with.
+
+If both lists are empty, any open issue is fair game — comment on it first so we
+don't both write the same patch.
+
+## Before you start
+
+**Just open the PR** — no issue needed — for:
+
+- typos, wording, and documentation fixes;
+- an obvious bug fix that comes with a regression test;
+- dependency and CI maintenance.
+
+**Open an issue first** for anything that changes the shape of the app:
+
+- a new key binding, or a change to an existing one;
+- a new config field — `internal/config/config.go`, `examples/tea-dash.yml` and
+  `schema.json` all move together (plus the README's annotated config block,
+  which nothing enforces), so the name is worth agreeing on before you spend an
+  evening on it;
+- changing what a view shows, or adding a view or section type;
+- anything that changes how the Gitea API is called.
+
+This isn't bureaucracy. It's so we agree on the design before you build it, and
+so I never have to turn down finished work.
+
+## Development setup
+
+You need **Go 1.26+** (matching `go.mod` and the Gitea SDK's own `go 1.26`) and
+`git` on your `PATH`. You do **not** need a Gitea server, a token, or the `tea`
+CLI to work on tea-dash.
+
+```sh
+git clone https://github.com/gbarany/tea-dash
+cd tea-dash
+
+make run        # go run .
+make build      # -> ./bin/tea-dash
+make check      # run this before you push (see below)
+make help       # list every target
+```
+
+Run the whole dashboard with no server, no login, and no network:
+
+```sh
+go run . --mock
+```
+
+`--mock` boots an in-process fake Gitea preloaded with a fictional `teahouse`
+org. Every view is populated and actions really mutate the demo data. It also
+seeds a throwaway local git repo for the Branches view, which is why `git` is
+required. Caveats are listed under
+[Try it without a Gitea instance](README.md#try-it-without-a-gitea-instance).
+
+### The one command
+
+```sh
+make check      # gofmt-check + go vet + go test -race ./... + public-hygiene
+```
+
+CI additionally runs `go mod download` and `go build ./...`, so
+**`make check && go build ./...` gets you close enough to a green `ci` run.** The
+public-hygiene step goes the other way: it is a local gate only — CI does not run
+it today, so please don't skip `make check`.
+
+While you work:
+
+```sh
+go test ./internal/gitea/                        # one package
+go test -run TestSearchPulls ./internal/gitea/   # one test (-run takes a regex)
+go test -race ./...                              # what CI runs
+```
+
+`make lint` runs `golangci-lint` if you have v2+ installed. It's optional, and
+part of neither `make check` nor CI.
+
+## Project layout
+
+The README's [Development](README.md#development) section has the package layout
+block — start there for *where* things live.
+[`docs/architecture.md`](docs/architecture.md) explains *why*: the SDK-direct
+transport, auth resolution, and the domain-model boundary. The specs and plans
+under `docs/superpowers/` are the running record of how features got built; the
+habit here is to land a `docs:` spec commit before a large feature.
+
+Two entry points you'll most likely want:
+
+- **A new UI section** is thin wiring over the generic `section.Model[T]`. Use
+  `internal/ui/components/pullsection/pullsection.go` as the template, then wire
+  it into `buildSections` in `internal/ui/app.go`.
+- **A new Gitea call** goes in `internal/gitea/<domain>.go` using the typed SDK,
+  mapped into `internal/data` before it reaches the UI.
+
+## House rules that will trip you up
+
+None of these are style preferences, and most have a test or a script behind
+them.
+
+- **Never commit an absolute home-directory path, a macOS per-user temporary
+  path, or a secret-manager item route.** `scripts/check-public-hygiene.sh` (run
+  by `make check`) `git grep`s the whole tree for them and fails the build. This
+  is a public repo and those strings leak a maintainer's machine layout. Use
+  placeholders like `<repo-path>` and `<command that prints the token>` in
+  docs, tests, and comments. It uses `git grep`, so it only sees *tracked* files
+  — `git add` a new file before trusting a green run.
+- **Tests use the standard library `testing` package only.** No testify — it
+  shows up in `go.sum` only, via a dependency's own go.mod, and is imported by
+  zero files here. Gitea-layer tests use `net/http/httptest` fakes; see `fakeGitea` in
+  `internal/gitea/client_test.go`, which always stubs `/api/v1/version` and
+  `/api/v1/user` because the SDK probes both at construction.
+- **Current practice: no `testdata/` directory, no golden files, no
+  `t.Parallel()`.** Fixtures are
+  Go string constants next to the test. The end-to-end harness is hand-rolled in
+  `internal/ui/e2e_mock_test.go` (`newE2EModel`, `drain`) — `teatest` is not used.
+- **The C1 guard.** On the cross-repo `/repos/issues/search` endpoint, an `@me`
+  filter must be emitted as that endpoint's boolean flag (`created=true`,
+  `assigned=true`, `mentioned=true`, `review_requested=true`), never as the
+  per-repo `created_by`/`assigned_by` params, which that endpoint silently
+  ignores. It's documented on `buildSearchParams` in `internal/gitea/search.go`
+  and enforced by `internal/gitea/search_test.go`. Corollary: `config.Validate`
+  rejects a non-`@me` author filter on any section that isn't repo-scoped.
+- **A new Gitea endpoint needs a matching `internal/mockgitea` route**, or
+  `--mock` and every e2e test start 404ing with
+  `mockgitea: no handler for <METHOD> <PATH>`. Two landmines inside a handler:
+  the store mutex is non-reentrant (inside `store.WithLock` use only the
+  unexported `*Locked` accessors — an exported getter self-locks and deadlocks),
+  and picking the right response helper matters.
+  `internal/mockgitea/server.go` documents both.
+- **Two silent-failure traps in `section.Options`:** `Options.Type` must
+  correspond to the type parameter `T`, because it drives app-level fetch
+  routing and a mismatch misroutes results with no error; and `section.New`
+  panics if `Fetch`, `BuildRow` or `Limit` is nil. `T` must satisfy
+  `data.RowData`.
+- **Config changes move three files together:** `internal/config/config.go`,
+  `examples/tea-dash.yml`, and `schema.json`. The schema uses
+  `additionalProperties: false` throughout and `schema_test.go` validates the
+  example against it, so forgetting the schema fails `go test ./...` at the repo
+  root in a way that looks unrelated.
+- **`internal/ui/context` shadows the stdlib `context` package.** House
+  convention is to alias: `stdctx "context"` and `appctx ".../ui/context"`.
+  Components read glyphs and colors from `ctx.Icons` / `ctx.Styles` rather than
+  hardcoding them.
+- **This is Bubble Tea v2.** Imports are `charm.land/bubbletea/v2` and friends,
+  not `github.com/charmbracelet/*`, and `View()` returns a struct — read
+  `.Content`. v1 habits will not compile.
+- **Third-party GitHub Actions are SHA-pinned** with a `# vX.Y.Z` trailing
+  comment; keep that form when bumping one, and move the `github/codeql-action`
+  steps in lockstep.
+
+## Submitting a PR
+
+1. Branch off `main` in your fork.
+2. Keep it focused — one concern per PR. A 400-line PR fixing three unrelated
+   things takes far longer to review than three small ones.
+3. Include a test. A bug fix should come with the regression test that fails
+   without it.
+4. `make check` must pass, and so must `go build ./...`.
+5. Leave **"Allow edits by maintainers"** ticked (it's on by default). That's
+   your checkbox, not something I can enable — with it on I can push a small
+   fix-up instead of sending the PR back over a nit.
+6. Say in the description if the change was AI-assisted (see below).
+
+### Commit messages
+
+The history is [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+feat: interactive label filter for PR and issue lists
+fix(sidebar): keep selected preview tab across re-render (sticky by title)
+```
+
+Types in use: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`, `build`.
+Scopes seen in the history: `ui`, `plan`, `mockgitea`, `deps`, `config`, `prs`,
+`actions`, `security`, `keys`, `cli`, `branches` — plus one-offs. Pick the
+closest one or omit it. Add `!` before the colon for a breaking change.
+
+This is load-bearing rather than decorative: `.goreleaser.yaml`'s changelog
+filters drop `docs:`, `test:`, `ci:` and `chore:` commits, so everything else —
+`feat:`, `fix:`, `refactor:`, `build:` — shows up in the release notes. If a
+prefix isn't quite right I'd rather fix it at merge time than send the PR back
+for it.
+
+### What CI does
+
+Three workflows run on every pull request:
+
+- **ci** — `go mod download`, gofmt, `go vet ./...`, `go build ./...`, and
+  `go test -race ./...` on `ubuntu-latest` with Go `stable`. This is the one
+  that has to be green.
+- **CodeQL** — code scanning; results land in the Security tab.
+- **security** — `govulncheck` (reachability-aware, and it *can* fail your PR)
+  and `gosec` (runs with `-no-fail`, so its findings are advisory SARIF only).
+
+On your first PR from a fork the checks sit at **"Awaiting approval"** until I
+click "Approve workflows to run". That's GitHub's default for first-time
+contributors, not me ignoring you.
+
+### AI-assisted contributions
+
+Fine by me — I use these tools on this repo myself — with three conditions:
+
+1. Say so in the PR description.
+2. You understand the change well enough to explain and defend it. If you can't
+   say what it does and how it interacts with the rest of the app, don't send it.
+3. Review questions are for you, not for a model. If I ask why something works
+   the way it does, I need your answer.
+
+Large generated PRs that arrive out of the blue get closed. That's about review
+time, not about the tool.
+
+### Being decent to each other
+
+This project has a [Code of Conduct](CODE_OF_CONDUCT.md) — be kind, assume good
+faith, and help people who are learning. Harassment isn't tolerated and I'll act
+on it.
+
+## Review expectations
+
+This is a spare-time project, so here's the honest version:
+
+- I'll acknowledge issues and PRs **within about a week** — the same promise
+  [SECURITY.md](SECURITY.md) makes. A full review can take longer.
+- Rough priority: bugs and crashes first, then small features, then refactors.
+  A refactor with no user-visible benefit is a hard sell.
+- **Heard nothing in two weeks? Ping the thread.** That's helpful, not rude — it
+  means I dropped it, not that I'm ignoring you.
+- I may decline a good feature simply because I don't want to maintain it
+  forever. That's not a judgment on your code, and I'll try to say so before you
+  build it rather than after — which is the whole point of the "open an issue
+  first" list above.
+
+Please also be willing to iterate on review comments. A drive-by PR that solves
+your own problem and is then abandoned costs more than it saves — keeping it in
+your fork and linking it from an issue is a perfectly good outcome.
+
+## License
+
+tea-dash is [MIT licensed](LICENSE), and contributions are accepted under that
+same license. By opening a pull request you affirm that you wrote the
+contribution or otherwise have the right to submit it, and that it may be
+provided under the project's MIT license.
+
+That's all of it: no CLA, no copyright assignment, nothing to sign. `git commit -s`
+sign-offs are welcome if your employer wants them, but they are not required here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,8 @@ required. Caveats are listed under
 make check      # gofmt-check + go vet + go test -race ./... + public-hygiene
 ```
 
-CI additionally runs `go mod download` and `go build ./...`, so
-**`make check && go build ./...` gets you close enough to a green `ci` run.** The
-public-hygiene step goes the other way: it is a local gate only — CI does not run
-it today, so please don't skip `make check`.
+CI runs the same four gates plus `go mod download` and `go build ./...`, so
+**a green `make check && go build ./...` locally means a green `ci` run.**
 
 While you work:
 
@@ -214,9 +212,9 @@ for it.
 
 Three workflows run on every pull request:
 
-- **ci** — `go mod download`, gofmt, `go vet ./...`, `go build ./...`, and
-  `go test -race ./...` on `ubuntu-latest` with Go `stable`. This is the one
-  that has to be green.
+- **ci** — `go mod download`, gofmt, `go vet ./...`, `go build ./...`,
+  `go test -race ./...`, and the public-hygiene script, on `ubuntu-latest` with
+  Go `stable`. This is the one that has to be green.
 - **CodeQL** — code scanning; results land in the Security tab.
 - **security** — `govulncheck` (reachability-aware, and it *can* fail your PR)
   and `gosec` (runs with `-no-fail`, so its findings are advisory SARIF only).

--- a/README.md
+++ b/README.md
@@ -475,8 +475,8 @@ and delete.
 
 ## Security
 
-Every PR and a weekly schedule run CodeQL, govulncheck, gosec, and OpenSSF
-Scorecard (see the badge above for the public report). Release archives carry
+Every PR runs CodeQL, govulncheck, and gosec; OpenSSF Scorecard runs on pushes
+to `main` and weekly (see the badge above for the public report). Release archives carry
 GitHub build provenance attestations. Vulnerability reports go through
 [GitHub Private Vulnerability Reporting](SECURITY.md) — see
 [`SECURITY.md`](SECURITY.md) for the policy and how to verify a release.
@@ -484,7 +484,7 @@ GitHub build provenance attestations. Vulnerability reports go through
 ## Development
 
 ```sh
-make check   # gofmt-check + go vet + tests (race)
+make check   # gofmt-check + go vet + tests (race) + public-hygiene
 make run     # go run .
 make build   # build ./bin/tea-dash
 make lint    # golangci-lint (optional; requires golangci-lint v2)
@@ -518,6 +518,24 @@ Go with the **Bubble Tea v2** Charm stack — `charm.land/bubbletea/v2` +
 [`gh-dash`](https://github.com/dlvhdr/gh-dash) and Gitea's own `tea` CLI are
 built on. Planned, to stay aligned with gh-dash: `cobra`+`fang` (CLI) and
 `koanf`+`validator` (config).
+
+## Contributing
+
+Contributions are welcome — this is a spare-time project, and bug reports, small
+fixes, and documentation improvements are the most useful things you can send.
+Start with [`CONTRIBUTING.md`](CONTRIBUTING.md); if you're looking for somewhere
+to jump in, see the
+[`good first issue`](https://github.com/gbarany/tea-dash/labels/good%20first%20issue)
+and [`help wanted`](https://github.com/gbarany/tea-dash/labels/help%20wanted)
+issues. You need no Gitea server, token, or `tea` login to hack on it —
+`tea-dash --mock` runs the whole TUI against an in-process fake. Participation is
+covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Typos, docs, and an obvious bug fix with a test can go straight to a pull
+request. For anything that changes the shape of the app — a new key binding, a
+new config field, a new view or section — please
+[open an issue](https://github.com/gbarany/tea-dash/issues/new) first, so we can
+agree on the design before you spend an evening on it.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,9 @@ Every pull request and a weekly schedule run:
 - **CodeQL** (code scanning, results in the Security tab)
 - **govulncheck** (Go vulnerability database, reachability-aware)
 - **gosec** (Go SAST, SARIF results in the Security tab)
+
+On pushes to `main` and weekly:
+
 - **OpenSSF Scorecard** (repository security practices; public report via
   the README badge)
 


### PR DESCRIPTION
Signals explicitly that pull requests are welcome, and adds the official GitHub
affordances that make that signal real rather than a sentence in the README.

GitHub recognises a specific set of "community health" files and surfaces them in
the UI — the Community Standards checklist, the auto-generated `/contribute`
page, the links shown when someone opens an issue or PR, and the issue chooser.
This PR fills in the ones the repo was missing.

### Added

- **`CONTRIBUTING.md`** — opens by saying PRs are welcome, then earns its length:
  when to open an issue first vs. just send the PR, development setup, and the
  house rules that actually trip people up (the public-hygiene script, the C1
  guard on `/repos/issues/search`, needing a matching `internal/mockgitea` route,
  the two silent-failure traps in `section.Options`, and Bubble Tea v2 vs v1).
  No CLA, no DCO — just an inline MIT attestation.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1. Enforcement routes to the
  same private channel `SECURITY.md` already uses, with GitHub's abuse form as
  the escape hatch if a concern involves the maintainer.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — deliberately short; a long template
  suppresses contributions.
- **`.github/ISSUE_TEMPLATE/`** — issue *forms* (bug report, feature request,
  chooser config). The bug form asks whether the bug reproduces under `--mock`,
  which is the highest-signal triage question this project has: if it does, it is
  fixable without access to the reporter's server.
- A README **Contributing** section linking all of the above.

### Fixed along the way

Writing the guide surfaced three places where the repo's own docs were wrong:

- **`make check` has four steps, not three** — it also runs `public-hygiene`.
  `README.md` and `CLAUDE.md` both described three.
- **OpenSSF Scorecard does not run on pull requests.** `scorecard.yml` triggers
  on pushes to `main` and a weekly cron; `README.md` and `SECURITY.md` both
  claimed it ran per-PR.
- **`.gitignore`'s bare `config.yml` rule matches at any depth**, so it silently
  swallowed `.github/ISSUE_TEMPLATE/config.yml` — the issue chooser would have
  shipped broken. Negated for that one path; a stray token-bearing `config.yml`
  at the repo root is still ignored (verified both ways).

### Verification

`make check` passes with every new file **tracked** — which matters, because
`check-public-hygiene.sh` uses `git grep` and therefore only sees staged files.
All three issue-form YAMLs parse and validate against GitHub's issue-forms
schema: valid item types, unique ids, and both referenced labels (`bug`,
`enhancement`) exist in the repo, so neither is silently dropped.

### CI

`ci.yml` now runs `make public-hygiene` as a step of the required `build-test`
check. Until now that gate was local-only, so a fork PR could land a home path or
a secret-manager route without CI noticing — the one gap whose failure is a
public leak. It passes on the current tree, so nothing changes for existing
contributors; it only starts catching the thing it exists to catch.

https://claude.ai/code/session_019a7G7p5hWZwP1j5LKJs99M
